### PR TITLE
Support installing mmdc locally and skipping downloading Chromium

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ cd metagpt
 python setup.py install
 ```
 
+**Note:**
+
+- If already have Chrome, Chromium, or MS Edge installed, you can skip downloading Chromium by setting the environment variable
+`PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` to `true`.
+
+- Some people are [having issues](https://github.com/mermaidjs/mermaid.cli/issues/15) installing this tool globally. Installing it locally is an alternative solution,
+
+    ```bash
+    npm install @mermaid-js/mermaid-cli
+    ```
+
+- don't forget to the configuration for mmdc in config.yml
+
+    ```yml
+    PUPPETEER_CONFIG: "./puppeteer-config.json"
+    MMDC: "./node_modules/.bin/mmdc"
+    ```
+
 ### Installation by Docker
 
 ```bash

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -55,3 +55,9 @@ SD_T2I_API: "/sdapi/v1/txt2img"
 
 #### for Execution
 #LONG_TERM_MEMORY: false
+
+#### for Mermaid CLI
+# adds support for installing mmdc (Mermaid CLI) locally on the user's machine.
+# PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install @mermaid-js/mermaid-cli
+#PUPPETEER_CONFIG: "./puppeteer-config.json"
+#MMDC: "./node_modules/.bin/mmdc"

--- a/metagpt/config.py
+++ b/metagpt/config.py
@@ -77,6 +77,8 @@ class Config(metaclass=Singleton):
             logger.warning("LONG_TERM_MEMORY is True")
         self.max_budget = self._get("MAX_BUDGET", 10.0)
         self.total_cost = 0.0
+        self.puppeteer_config = self._get("PUPPETEER_CONFIG","")
+        self.mmdc = self._get("MMDC","mmdc")
 
     def _init_with_config_files_and_env(self, configs: dict, yaml_file):
         """从config/key.yaml / config/config.yaml / env三处按优先级递减加载"""

--- a/metagpt/utils/mermaid.py
+++ b/metagpt/utils/mermaid.py
@@ -8,12 +8,14 @@
 import os
 import subprocess
 from pathlib import Path
-
+from metagpt.config import CONFIG
 from metagpt.const import PROJECT_ROOT
 from metagpt.logs import logger
 from metagpt.utils.common import check_cmd_exists
 
 IS_DOCKER = os.environ.get('AM_I_IN_A_DOCKER_CONTAINER', 'false').lower()
+
+
 
 
 def mermaid_to_file(mermaid_code, output_file_without_suffix, width=2048, height=2048) -> int:
@@ -42,7 +44,11 @@ def mermaid_to_file(mermaid_code, output_file_without_suffix, width=2048, height
             subprocess.run(['mmdc', '-p', '/app/metagpt/puppeteer-config.json', '-i',
                            str(tmp), '-o', output_file, '-w', str(width), '-H', str(height)])
         else:
-            subprocess.run(['mmdc', '-i', str(tmp), '-o',
+            if CONFIG.puppeteer_config:
+                subprocess.run([CONFIG.mmdc,'-p',CONFIG.puppeteer_config, '-i', str(tmp), '-o',
+                           output_file, '-w', str(width), '-H', str(height)])
+            else:
+                subprocess.run( [CONFIG.mmdc, '-i', str(tmp), '-o',
                            output_file, '-w', str(width), '-H', str(height)])
     return 0
 


### PR DESCRIPTION

## Skip Downloading Chromium
If you already have Chrome, Chromium, or MS Edge installed, you can skip downloading Chromium by setting the environment variable:

- For Linux or macOS:
```bash
export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
```

- For Windows:
```bash
set PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
```

## Adds Support for Installing mmdc (Mermaid CLI) Locally
To add support for installing mmdc (Mermaid CLI) locally on the user's machine.

> Some people are [having issues](https://github.com/mermaidjs/mermaid.cli/issues/15) installing this tool globally. Installing it locally is an alternative solution:

```bash
npm install @mermaid-js/mermaid-cli
```

## Configuration for MMDC in config.yml

Add the following configuration in your `config.yml` file to specify the locations of Puppeteer and MMDC:

```yml
PUPPETEER_CONFIG: "./puppeteer-config.json"
MMDC: "./node_modules/.bin/mmdc"
```

