### PR TITLE
return store when calling faiss_store write

### DIFF
--- a/metagpt/document_store/faiss_store.py
+++ b/metagpt/document_store/faiss_store.py
@@ -67,6 +67,7 @@ class FaissStore(LocalStore):
 
         self.store = self._write(docs, metadatas)
         self.persist()
+        return self.store
 
     def add(self, texts: list[str], *args, **kwargs) -> list[str]:
         """FIXME: 目前add之后没有更新store"""


### PR DESCRIPTION
Fix: An error of 'NoneType' object has no attribute 'similarity_search' occurred,  when executing faiss_store.py