### PR TITLE
Add support for Llama 2, Palm, Anthropic, Cohere Models - using litellm

### DIFF
--- a/metagpt/provider/litellm.py
+++ b/metagpt/provider/litellm.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+@Time    : 2023/08/04 10:00
+@Author  : ishaan-jaff
+@File    : openai.py
+"""
+from metagpt.provider.base_gpt_api import BaseGPTAPI
+from metagpt.provider.openai_api import CostManager, RateLimiter
+from metagpt.config import CONFIG
+
+class liteLLM(BaseGPTAPI, RateLimiter):
+    def __init__(self):
+        self.__init_openai(CONFIG)
+        self.model = CONFIG.model # litellm model
+        self._cost_manager = CostManager()
+        RateLimiter.__init__(self, rpm=self.rpm)
+
+    def _chat_completion(self, messages: list[dict], model: str) -> dict:
+        rsp = self.llm.ChatCompletion.create(**self._cons_kwargs(messages))
+        self._update_costs(rsp)
+        return rsp
+
+"""
+https://github.com/BerriAI/litellm/
+
+usage for litellm
+from litellm import completion
+
+## set ENV variables
+# ENV variables can be set in .env file, too. Example in .env.example
+os.environ["OPENAI_API_KEY"] = "openai key"
+os.environ["COHERE_API_KEY"] = "cohere key"
+
+messages = [{ "content": "Hello, how are you?","role": "user"}]
+
+model_name = "replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1"
+
+# llama2 call
+response = completion(model_name, messages)
+
+# openai call
+response = completion(model="gpt-3.5-turbo", messages=messages)
+
+# cohere call
+response = completion("command-nightly", messages)
+
+# azure openai call
+response = completion("chatgpt-test", messages, azure=True)
+
+# openrouter call
+response = completion("google/palm-2-codechat-bison", messages)
+
+
+"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ fire==0.4.0
 # godot==0.1.1
 # google_api_python_client==2.93.0
 langchain==0.0.231
+litellm==0.1.226
 loguru==0.6.0
 meilisearch==0.21.0
 numpy==1.24.3


### PR DESCRIPTION
Addressing https://github.com/geekan/MetaGPT/issues/97 

I'm the maintainer of litellm https://github.com/BerriAI/litellm - a simple & light package to call OpenAI, Azure, Cohere, Anthropic, Replicate API Endpoints

This PR adds support for models from all the above mentioned providers (by creating a class `liteLLM`)

Here's a sample of how it's used:

```
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```