### PR TITLE
fix:`ModuleNotFoundError`: No module named 'bs4'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ tqdm==4.64.0
 # playwright
 # selenium>4
 # webdriver_manager<3.9
+BeautifulSoup4
 anthropic==0.3.6
 typing-inspect==0.8.0
 typing_extensions==4.5.0


### PR DESCRIPTION
`ModuleNotFoundError`: No module named 'bs4' fixed for locally build docker container