### PR TITLE
Retry if OpenAI rate limit is hit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ anthropic==0.3.6
 typing-inspect==0.8.0
 typing_extensions==4.5.0
 libcst==1.0.1
+bs4>=0.0.1


### PR DESCRIPTION
Issues #205 and #206 for OpenAI rate limit hit.

Added retries (with exponential backoff), for OpenAI API rate limit hit (default org limit: 10000/min). OpenAI recomends to retry in minimum 6ms, so it starts with 6 and then 12, 24, 48 and 96 ms, with 5 retries by default.

It is better to retry on error instead of slowing down all requests, as this slows it down only if the rate limit is hit.