### PR TITLE
removes npm dependency by using mermaid ink service | removes referen…

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,7 +1,3 @@
-# Step 1: Ensure that NPM is installed on your system. Then install mermaid-js.
-npm --version
-sudo npm install -g @mermaid-js/mermaid-cli
-
-# Step 2: Ensure that Python 3.9+ is installed on your system. You can check this by using:
+# Step 1: Ensure that Python 3.9+ is installed on your system. You can check this by using:
 python --version
 python setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,6 @@ RUN apt update &&\
     apt install -y git chromium fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 --no-install-recommends &&\
     apt clean && rm -rf /var/lib/apt/lists/*
 
-# Install Mermaid CLI globally
-ENV CHROME_BIN="/usr/bin/chromium" \
-    PUPPETEER_CONFIG="/app/metagpt/config/puppeteer-config.json"\
-    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
-RUN npm install -g @mermaid-js/mermaid-cli &&\
-    npm cache clean --force
-
 # Install Python dependencies and install MetaGPT
 COPY . /app/metagpt
 WORKDIR /app/metagpt

--- a/README.md
+++ b/README.md
@@ -45,36 +45,16 @@ It costs approximately **$0.2** (in GPT-4 API fees) to generate one example with
 ### Traditional Installation
 
 ```bash
-# Step 1: Ensure that NPM is installed on your system. Then install mermaid-js.
-npm --version
-sudo npm install -g @mermaid-js/mermaid-cli
-
-# Step 2: Ensure that Python 3.9+ is installed on your system. You can check this by using:
+# Step 1: Ensure that Python 3.9+ is installed on your system. You can check this by using:
 python --version
 
-# Step 3: Clone the repository to your local machine, and install it.
+# Step 2: Clone the repository to your local machine, and install it.
 git clone https://github.com/geekan/metagpt
 cd metagpt
 python setup.py install
 ```
 
 **Note:**
-
-- If already have Chrome, Chromium, or MS Edge installed, you can skip downloading Chromium by setting the environment variable
-`PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` to `true`.
-
-- Some people are [having issues](https://github.com/mermaidjs/mermaid.cli/issues/15) installing this tool globally. Installing it locally is an alternative solution,
-
-    ```bash
-    npm install @mermaid-js/mermaid-cli
-    ```
-
-- don't forget to the configuration for mmdc in config.yml
-
-    ```yml
-    PUPPETEER_CONFIG: "./config/puppeteer-config.json"
-    MMDC: "./node_modules/.bin/mmdc"
-    ```
 
 - if `python setup.py install` fails with error `[Errno 13] Permission denied: '/usr/local/lib/python3.11/dist-packages/test-easy-install-13129.write-test'`, try instead running `python setup.py install --user`
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -63,12 +63,6 @@ SD_T2I_API: "/sdapi/v1/txt2img"
 #### for Execution
 #LONG_TERM_MEMORY: false
 
-#### for Mermaid CLI
-## If you installed mmdc (Mermaid CLI) only for metagpt then enable the following configuration.
-#PUPPETEER_CONFIG: "./config/puppeteer-config.json"
-#MMDC: "./node_modules/.bin/mmdc"
-
-
 ### for calc_usage
 # CALC_USAGE: false
 

--- a/docs/FAQ-EN.md
+++ b/docs/FAQ-EN.md
@@ -173,9 +173,3 @@ MetaGPT Community - The position of Chief Evangelist rotates on a monthly basis.
 
     1.  On the day Llama2 was released, some of the community members began experiments and found that output can be generated based on MetaGPT's structure. However, Llama2's context is too short to generate a complete project. Before regularly using Llama2, it's necessary to expand the context window to at least 8k. If anyone has good recommendations for expansion models or methods, please leave a comment.
 
-1.  `mermaid-cli getElementsByTagName SyntaxError: Unexpected token '.'`
-
-    1.  Upgrade node to version 14.x or above:
-
-        1.  `npm install -g n`
-        1.  `n stable` to install the stable version of node（v18.x）

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -40,14 +40,10 @@
 ### 传统安装
 
 ```bash
-# 第 1 步：确保您的系统上安装了 NPM。并使用npm安装mermaid-js
-npm --version
-sudo npm install -g @mermaid-js/mermaid-cli
-
-# 第 2 步：确保您的系统上安装了 Python 3.9+。您可以使用以下命令进行检查：
+# 第 1 步：确保您的系统上安装了 Python 3.9+。您可以使用以下命令进行检查：
 python --version
 
-# 第 3 步：克隆仓库到您的本地机器，并进行安装。
+# 第 2 步：克隆仓库到您的本地机器，并进行安装。
 git clone https://github.com/geekan/metagpt
 cd metagpt
 python setup.py install

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -40,36 +40,14 @@
 ### 伝統的なインストール
 
 ```bash
-# ステップ 1: NPM がシステムにインストールされていることを確認してください。次に mermaid-js をインストールします。
-npm --version
-sudo npm install -g @mermaid-js/mermaid-cli
-
-# ステップ 2: Python 3.9+ がシステムにインストールされていることを確認してください。これを確認するには:
+# ステップ 1: Python 3.9+ がシステムにインストールされていることを確認してください。これを確認するには:
 python --version
 
-# ステップ 3: リポジトリをローカルマシンにクローンし、インストールする。
+# ステップ 2: リポジトリをローカルマシンにクローンし、インストールする。
 git clone https://github.com/geekan/metagpt
 cd metagpt
 python setup.py install
 ```
-
-**注:**
-
-- すでに Chrome、Chromium、MS Edge がインストールされている場合は、環境変数 `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` を `true` に設定することで、
-Chromium のダウンロードをスキップすることができます。
-
-- このツールをグローバルにインストールする[問題を抱えている](https://github.com/mermaidjs/mermaid.cli/issues/15)人もいます。ローカルにインストールするのが代替の解決策です、
-
-    ```bash
-    npm install @mermaid-js/mermaid-cli
-    ```
-
-- config.yml に mmdc のコンフィギュレーションを記述するのを忘れないこと
-
-    ```yml
-    PUPPETEER_CONFIG: "./config/puppeteer-config.json"
-    MMDC: "./node_modules/.bin/mmdc"
-    ```
 
 ### Docker によるインストール
 

--- a/metagpt/utils/common.py
+++ b/metagpt/utils/common.py
@@ -15,16 +15,6 @@ from typing import List, Tuple
 from metagpt.logs import logger
 
 
-def check_cmd_exists(command) -> int:
-    """ 检查命令是否存在
-    :param command: 待检查的命令
-    :return: 如果命令存在，返回0，如果不存在，返回非0
-    """
-    check_command = 'command -v ' + command + ' >/dev/null 2>&1 || { echo >&2 "no mermaid"; exit 1; }'
-    result = os.system(check_command)
-    return result
-
-
 class OutputParser:
 
     @classmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ pydantic==1.10.8
 pytest==7.2.2
 python_docx==0.8.11
 PyYAML==6.0
+requests==2.31.0
 # sentence_transformers==2.2.2
 setuptools==65.6.3
 tenacity==8.2.2

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,9 @@
 """wutils: handy tools
 """
-import subprocess
 from codecs import open
 from os import path
 
-from setuptools import Command, find_packages, setup
-
-
-class InstallMermaidCLI(Command):
-    """A custom command to run `npm install -g @mermaid-js/mermaid-cli` via a subprocess."""
-
-    description = "install mermaid-cli"
-    user_options = []
-
-    def run(self):
-        try:
-            subprocess.check_call(["npm", "install", "-g", "@mermaid-js/mermaid-cli"])
-        except subprocess.CalledProcessError as e:
-            print(f"Error occurred: {e.output}")
-
+from setuptools import find_packages, setup
 
 here = path.abspath(path.dirname(__file__))
 
@@ -47,8 +32,5 @@ setup(
         "selenium": ["selenium>4", "webdriver_manager", "beautifulsoup4"],
         "search-google": ["google-api-python-client==2.94.0"],
         "search-ddg": ["duckduckgo-search==3.8.5"],
-    },
-    cmdclass={
-        "install_mermaid": InstallMermaidCLI,
     },
 )


### PR DESCRIPTION
# Remove the dependency on npm

This issue is document as [issue 167](https://github.com/geekan/MetaGPT/issues/167)

## Changes 

- removes the dependency on npm by using the mermaid ink service
- removes references to the npm version mermaid and the related issues that is causes

### Description of changes

This changes the way that mermaid.py works. Instead of doing checks to see if the npm command exists for mermaid, it makes a call to the mermaid ink service. This service takes a base64 encoded string as the mermaid code and can return either an svg or png depending on the path.

## Testing

A simple test to see if this new approach works is to run the mermaid.py file and see if the mermaid charts are created in the tmp folder in the project root. 

## Warning

This does remove the pdf file output type.

I don't see this as an issue but someone else might.