### PR TITLE
feat: option to skip hiring an engineer  with implement=False

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,20 @@ python setup.py install
 **Note:**
 
 - If already have Chrome, Chromium, or MS Edge installed, you can skip downloading Chromium by setting the environment variable
-`PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` to `true`.
+  `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` to `true`.
 
 - Some people are [having issues](https://github.com/mermaidjs/mermaid.cli/issues/15) installing this tool globally. Installing it locally is an alternative solution,
 
-    ```bash
-    npm install @mermaid-js/mermaid-cli
-    ```
+  ```bash
+  npm install @mermaid-js/mermaid-cli
+  ```
 
 - don't forget to the configuration for mmdc in config.yml
 
-    ```yml
-    PUPPETEER_CONFIG: "./config/puppeteer-config.json"
-    MMDC: "./node_modules/.bin/mmdc"
-    ```
+  ```yml
+  PUPPETEER_CONFIG: "./config/puppeteer-config.json"
+  MMDC: "./node_modules/.bin/mmdc"
+  ```
 
 - if `python setup.py install` fails with error `[Errno 13] Permission denied: '/usr/local/lib/python3.11/dist-packages/test-easy-install-13129.write-test'`, try instead running `python setup.py install --user`
 
@@ -139,18 +139,24 @@ cp config/config.yaml config/key.yaml
 ## Tutorial: Initiating a startup
 
 ```shell
+# Run the script
 python startup.py "Write a cli snake game"
-# Use code review will cost more money, but will opt for better code quality.
-python startup.py "Write a cli snake game" --code_review True 
+# Do not hire an engineer to implement the project
+python startup.py "Write a cli snake game" --implement False
+# Hire an engineer and perform code reviews
+python startup.py "Write a cli snake game" --code_review True
 ```
 
 After running the script, you can find your new project in the `workspace/` directory.
-### Preference of Platform or Tool 
+
+### Preference of Platform or Tool
 
 You can tell which platform or tool you want to use when stating your requirements.
+
 ```shell
 python startup.py "Write a cli snake game based on pygame"
 ```
+
 ### Usage
 
 ```
@@ -199,16 +205,18 @@ async def startup(idea: str, investment: float = 3.0, n_round: int = 5):
 You can check `examples` for more details on single role (with knowledge base) and LLM only examples.
 
 ## QuickStart
-It is difficult to install and configure the local environment for some users. The following tutorials will allow you to quickly experience the charm of MetaGPT.  
+
+It is difficult to install and configure the local environment for some users. The following tutorials will allow you to quickly experience the charm of MetaGPT.
 
 - [MetaGPT quickstart](https://deepwisdom.feishu.cn/wiki/CyY9wdJc4iNqArku3Lncl4v8n2b)
 
 ## Citation
 
 For now, cite the [Arxiv paper](https://arxiv.org/abs/2308.00352):
+
 ```bibtex
 @misc{hong2023metagpt,
-      title={MetaGPT: Meta Programming for Multi-Agent Collaborative Framework}, 
+      title={MetaGPT: Meta Programming for Multi-Agent Collaborative Framework},
       author={Sirui Hong and Xiawu Zheng and Jonathan Chen and Yuheng Cheng and Jinlin Wang and Ceyao Zhang and Zili Wang and Steven Ka Shing Yau and Zijuan Lin and Liyang Zhou and Chenyu Ran and Lingfeng Xiao and Chenglin Wu},
       year={2023},
       eprint={2308.00352},
@@ -231,6 +239,7 @@ We will respond to all questions within 2-3 business days.
 https://github.com/geekan/MetaGPT/assets/2707039/5e8c1062-8c35-440f-bb20-2b0320f8d27d
 
 ## Join us
+
 📢 Join Our Discord Channel!
 https://discord.gg/4WdszVjv
 

--- a/startup.py
+++ b/startup.py
@@ -4,38 +4,64 @@ import asyncio
 import platform
 import fire
 
-from metagpt.roles import Architect, Engineer, ProductManager, ProjectManager, QaEngineer
+from metagpt.roles import Architect, Engineer, ProductManager
+from metagpt.roles import ProjectManager, QaEngineer
 from metagpt.software_company import SoftwareCompany
 
 
-async def startup(idea: str, investment: float = 3.0, n_round: int = 5,
-                  code_review: bool = False, run_tests: bool = False):
+async def startup(
+    idea: str,
+    investment: float = 3.0,
+    n_round: int = 5,
+    code_review: bool = False,
+    run_tests: bool = False,
+    implement: bool = True
+):
     """Run a startup. Be a boss."""
     company = SoftwareCompany()
-    company.hire([ProductManager(),
-                  Architect(),
-                  ProjectManager(),
-                  Engineer(n_borg=5, use_code_review=code_review)])
+    company.hire([
+        ProductManager(),
+        Architect(),
+        ProjectManager(),
+    ])
+
+    # if implement or code_review
+    if implement or code_review:
+        # developing features: implement the idea
+        company.hire([Engineer(n_borg=5, use_code_review=code_review)])
+
     if run_tests:
-        # developing features: run tests on the spot and identify bugs (bug fixing capability comes soon!)
+        # developing features: run tests on the spot and identify bugs
+        # (bug fixing capability comes soon!)
         company.hire([QaEngineer()])
+
     company.invest(investment)
     company.start_project(idea)
     await company.run(n_round=n_round)
 
 
-def main(idea: str, investment: float = 3.0, n_round: int = 5, code_review: bool = False, run_tests: bool = False):
+def main(
+    idea: str,
+    investment: float = 3.0,
+    n_round: int = 5,
+    code_review: bool = False,
+    run_tests: bool = False,
+    implement: bool = False
+):
     """
-    We are a software startup comprised of AI. By investing in us, you are empowering a future filled with limitless possibilities.
+    We are a software startup comprised of AI. By investing in us,
+    you are empowering a future filled with limitless possibilities.
     :param idea: Your innovative idea, such as "Creating a snake game."
-    :param investment: As an investor, you have the opportunity to contribute a certain dollar amount to this AI company.
+    :param investment: As an investor, you have the opportunity to contribute
+    a certain dollar amount to this AI company.
     :param n_round:
     :param code_review: Whether to use code review.
     :return:
     """
     if platform.system() == "Windows":
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    asyncio.run(startup(idea, investment, n_round, code_review, run_tests))
+    asyncio.run(startup(idea, investment, n_round,
+                code_review, run_tests, implement))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR provides additional customizations on what steps to perform with `setup.py`.

- NEW: Do not hire an engineer to write code `--implement False` (default True)
- Hire an engineer and perform code review `--code_review True` (will also hire an engineer)

Additionally, there are some subjective readability improvements to the README. Glad to remove those from the diff if needed. 