### PR TITLE
Updates requirements.txt and adds quickfix to use pydantic v2

### DIFF
--- a/metagpt/actions/action_output.py
+++ b/metagpt/actions/action_output.py
@@ -8,7 +8,7 @@
 
 from typing import Dict, Type
 
-from pydantic import BaseModel, create_model, root_validator, validator
+from pydantic.v1 import BaseModel, create_model, root_validator, validator
 
 
 class ActionOutput:

--- a/metagpt/actions/research.py
+++ b/metagpt/actions/research.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 from typing import Callable
 
-from pydantic import parse_obj_as
+from pydantic.v1 import parse_obj_as
 
 from metagpt.actions import Action
 from metagpt.config import CONFIG

--- a/metagpt/actions/search_and_summarize.py
+++ b/metagpt/actions/search_and_summarize.py
@@ -107,7 +107,7 @@ class SearchAndSummarize(Action):
 
         try:
             self.search_engine = SearchEngine(self.engine, run_func=search_func)
-        except pydantic.ValidationError:
+        except pydantic.v1.ValidationError:
             self.search_engine = None
 
         self.result = ""

--- a/metagpt/environment.py
+++ b/metagpt/environment.py
@@ -8,7 +8,7 @@
 import asyncio
 from typing import Iterable
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from metagpt.memory import Memory
 from metagpt.roles import Role

--- a/metagpt/roles/researcher.py
+++ b/metagpt/roles/researcher.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from metagpt.actions import CollectLinks, ConductResearch, WebBrowseAndSummarize
 from metagpt.actions.research import get_research_system_text

--- a/metagpt/roles/role.py
+++ b/metagpt/roles/role.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Iterable, Type
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 # from metagpt.environment import Environment
 from metagpt.config import CONFIG

--- a/metagpt/schema.py
+++ b/metagpt/schema.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Type, TypedDict
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from metagpt.logs import logger
 

--- a/metagpt/software_company.py
+++ b/metagpt/software_company.py
@@ -5,7 +5,7 @@
 @Author  : alexanderwu
 @File    : software_company.py
 """
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from metagpt.actions import BossRequirement
 from metagpt.config import CONFIG

--- a/metagpt/tools/search_engine_googleapi.py
+++ b/metagpt/tools/search_engine_googleapi.py
@@ -9,7 +9,7 @@ from typing import Optional
 from urllib.parse import urlparse
 
 import httplib2
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 from metagpt.config import CONFIG
 from metagpt.logs import logger

--- a/metagpt/tools/search_engine_serpapi.py
+++ b/metagpt/tools/search_engine_serpapi.py
@@ -8,7 +8,7 @@
 from typing import Any, Dict, Optional, Tuple
 
 import aiohttp
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 from metagpt.config import CONFIG
 

--- a/metagpt/tools/search_engine_serper.py
+++ b/metagpt/tools/search_engine_serper.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict, Optional, Tuple
 
 import aiohttp
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 from metagpt.config import CONFIG
 

--- a/metagpt/tools/ut_writer.py
+++ b/metagpt/tools/ut_writer.py
@@ -60,7 +60,7 @@ def test_node_tags(project_key, nodes, operations, expected_msg):
 # 3. If comments are needed, use Chinese.
 
 # If you understand, please wait for me to give the interface definition and just answer "Understood" to save tokens.
-
+'''
 ACT_PROMPT_PREFIX = '''Refer to the test types: such as missing request parameters, field boundary verification, incorrect field type.
 Please output 10 test cases within one `@pytest.mark.parametrize` scope.
 ```text
@@ -94,7 +94,7 @@ Name	Type	Required	Default Value	Remarks
 code	integer	Yes		
 message	string	Yes		
 data	object	Yes		
-
+'''
 
 
 class UTGenerator:

--- a/metagpt/utils/parse_html.py
+++ b/metagpt/utils/parse_html.py
@@ -5,7 +5,7 @@ from typing import Generator, Optional
 from urllib.parse import urljoin, urlparse
 
 from bs4 import BeautifulSoup
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class WebPage(BaseModel):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ fire==0.4.0
 # godot==0.1.1
 # google_api_python_client==2.93.0
 lancedb==0.1.16
-langchain==0.0.231
+langchain==0.0.285
 loguru==0.6.0
 meilisearch==0.21.0
 numpy==1.24.3
@@ -18,7 +18,7 @@ openai==0.27.8
 openpyxl
 beautifulsoup4==4.12.2
 pandas==2.0.3
-pydantic==1.10.8
+pydantic==2.3.0
 #pygame==2.1.3
 #pymilvus==2.2.8
 pytest==7.2.2
@@ -33,8 +33,8 @@ tqdm==4.64.0
 # playwright
 # selenium>4
 # webdriver_manager<3.9
-anthropic==0.3.6
+anthropic==0.3.11
 typing-inspect==0.8.0
-typing_extensions==4.5.0
+typing_extensions==4.6.1
 libcst==1.0.1
 qdrant-client==1.4.0


### PR DESCRIPTION
#301 To support applications using Pydantic v2, have upgraded using a quick fix method (still using v1 internally using pydantic)
* Have Upgraded necessary dependency like Langchain, Antrophic to latest versions which support Pydantic 2.
* Have fixed the syntax error in `metagpt/tools/ut_writer.py` cause by unclosed triple quotes.
* Chromadb doesn't support pedantic v2 as of now, so it will crash until they upgrade.
* Have tested by running the startup command, building docker container and running pytest test doesn't seem to cause any additional failures in the test.