### PR TITLE
Set WindowsProactorEventLoopPolicy after importing sk_function

### DIFF
--- a/metagpt/_compat.py
+++ b/metagpt/_compat.py
@@ -3,13 +3,18 @@ import sys
 import warnings
 
 if sys.implementation.name == "cpython" and platform.system() == "Windows" and sys.version_info[:2] == (3, 9):
-    # https://github.com/python/cpython/pull/92842
-
+    import asyncio
     from asyncio.proactor_events import _ProactorBasePipeTransport
 
+    from semantic_kernel.orchestration import sk_function as _  # noqa: F401
+
+    # https://github.com/python/cpython/pull/92842
     def pacth_del(self, _warn=warnings.warn):
         if self._sock is not None:
             _warn(f"unclosed transport {self!r}", ResourceWarning, source=self)
             self._sock.close()
 
     _ProactorBasePipeTransport.__del__ = pacth_del
+
+    # caused by https://github.com/microsoft/semantic-kernel/pull/1416
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())


### PR DESCRIPTION
Fixed a "raise NotImplementedError" issue on Windows when calling loop.subprocess_exec due to the semantic_kernel.orchestration.sk_function. (fix https://github.com/geekan/MetaGPT/issues/346)
