### PR TITLE
fix ltm serialize_message

### DIFF
--- a/metagpt/utils/serialize.py
+++ b/metagpt/utils/serialize.py
@@ -4,7 +4,7 @@
 
 import copy
 import pickle
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 from metagpt.actions.action_output import ActionOutput
 from metagpt.schema import Message
@@ -38,7 +38,7 @@ def actionoutout_schema_to_mapping(schema: Dict) -> Dict:
             mapping[field] = (List[str], ...)
         elif property["type"] == "array" and property["items"]["type"] == "array":
             # here only consider the `Tuple[str, str]` situation
-            mapping[field] = (List[Tuple[str, str]], ...)
+            mapping[field] = (List[List[str]], ...)
     return mapping
 
 

--- a/metagpt/utils/serialize.py
+++ b/metagpt/utils/serialize.py
@@ -37,7 +37,7 @@ def actionoutout_schema_to_mapping(schema: Dict) -> Dict:
         elif property["type"] == "array" and property["items"]["type"] == "string":
             mapping[field] = (List[str], ...)
         elif property["type"] == "array" and property["items"]["type"] == "array":
-            # here only consider the `Tuple[str, str]` situation
+            # here only consider the `List[List[str]]` situation
             mapping[field] = (List[List[str]], ...)
     return mapping
 


### PR DESCRIPTION
since the format has been changed to support json,
json doesn't have tuple in it.
have to use List[List[str]] instead of List[Tupe[str,str]],

while reading LongTermMemory, found out 
that code in actionoutout_schema_to_mapping still uses  List[Tupe[str,str]],
fix that