### PR TITLE
fix parse code

### DIFF
--- a/metagpt/actions/design_api.py
+++ b/metagpt/actions/design_api.py
@@ -207,5 +207,11 @@ class WriteDesign(Action):
         prompt = prompt_template.format(context=context, format_example=format_example)
         # system_design = await self._aask(prompt)
         system_design = await self._aask_v1(prompt, "system_design", OUTPUT_MAPPING, format=format)
+        # fix Python package name, we can't system_design.instruct_content.python_package_name = "xxx" since "Python package name" contain space, have to use setattr
+        setattr(
+            system_design.instruct_content,
+            "Python package name",
+            system_design.instruct_content.dict()["Python package name"].strip().strip("'").strip('"'),
+        )
         await self._save(context, system_design)
         return system_design

--- a/metagpt/utils/common.py
+++ b/metagpt/utils/common.py
@@ -180,7 +180,7 @@ class OutputParser:
 
         if start_index != -1 and end_index != -1:
             # Extract the structure part
-            structure_text = text[start_index:end_index + 1]
+            structure_text = text[start_index : end_index + 1]
 
             try:
                 # Attempt to convert the text to a Python data type using ast.literal_eval
@@ -237,7 +237,7 @@ class CodeParser:
             logger.error(f"{pattern} not match following text:")
             logger.error(text)
             # raise Exception
-            return ""
+            return text  # just assume original text is code
         return code
 
     @classmethod


### PR DESCRIPTION
1.Python package name would still return "snake_game",
so just modifies it directly in WriteDesign
```
# fix Python package name, we can't system_design.instruct_content.python_package_name = "xxx" since "Python package name" contain space, have to use setattr
        setattr(
            system_design.instruct_content,
            "Python package name",
            system_design.instruct_content.dict()["Python package name"].strip().strip("'").strip('"'),
        )
```
2.CodeParser.parse_code just return original text when can't parse, assuming llm sends us the whole text as code, instead of return ""
```
logger.error(f"{pattern} not match following text:")
logger.error(text)
# raise Exception
return text  # just assume original text is code
```
for  WriteCode/WriteCodeReview/WriteTest/DebugError action the error semantics is the same as original, 
for parse_str/parse_file_list,  it will error out both under can't parse condition.
so the error semantics is the same.

3.probably in OutputParser's parse_code, could also change raise Exception into return text?
```
    def parse_code(cls, text: str, lang: str = "") -> str:
        pattern = rf"```{lang}.*?\s+(.*?)```"
        match = re.search(pattern, text, re.DOTALL)
        if match:
            code = match.group(1)
        else:
            raise Exception
        return code
```
because the usage of it, the semantics is the same when can't parse, just use original content
```
        for block, content in block_dict.items():
            # 尝试去除code标记
            try:
                content = cls.parse_code(text=content)
            except Exception:
                pass

            # 尝试解析list
            try:
                content = cls.parse_file_list(text=content)
            except Exception:
                pass
            parsed_data[block] = content
        return parsed_data
```

