### PR TITLE
Fix litellm function calling error

### DIFF
--- a/metagpt/tools/code_interpreter.py
+++ b/metagpt/tools/code_interpreter.py
@@ -41,7 +41,7 @@ class OpenCodeInterpreter(object):
         interpreter.auto_run = auto_run
         interpreter.model = CONFIG.openai_api_model or "gpt-3.5-turbo"
         interpreter.api_key = CONFIG.openai_api_key
-        interpreter.api_base = CONFIG.openai_api_base
+        # interpreter.api_base = CONFIG.openai_api_base
         self.interpreter = interpreter
 
     def chat(self, query: str, reset: bool = True):

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,4 +42,4 @@ pytest-mock==3.11.1
 open-interpreter==0.1.4; python_version>"3.9"
 ta==0.10.2
 semantic-kernel==0.3.10.dev0
-
+wrapt==1.15.0


### PR DESCRIPTION
Fix litellm function calling error and add wrapt in requirements.txt

# changed
- Comment out the statement line 44 in metagpt/tools/code_interpreter.py: interpreter.api_base = CONFIG.openai_api_base 
- add wrapt in requirements.txt