### PR TITLE
feat: add caching and benchmark

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,4 +42,4 @@ pytest-mock==3.11.1
 open-interpreter==0.1.4; python_version>"3.9"
 ta==0.10.2
 semantic-kernel==0.3.10.dev0
-
+parea-ai

--- a/startup.py
+++ b/startup.py
@@ -3,6 +3,7 @@
 import asyncio
 
 import fire
+from parea import init, RedisCache
 
 from metagpt.roles import (
     Architect,
@@ -12,6 +13,12 @@ from metagpt.roles import (
     QaEngineer,
 )
 from metagpt.software_company import SoftwareCompany
+
+
+# set this to True to use caching of LLM calls and being able to benchmark function across many inputs in parallel
+IS_DEV = True
+if IS_DEV:
+    init(cache=RedisCache())
 
 
 async def startup(


### PR DESCRIPTION
Hey, I opened a PR which allows you to quickly iterate on your app locally.

Adding the `init` statement will automatically use a local redis cache for any of your LLM requests (more [here](https://github.com/parea-ai/parea-sdk-py#debugging-chains--agents)). With that you won't need to wait for the slow & expensive API requests if you make any changes to your code/prompts and want to make sure everything works as expected.

This will also enable you to test MetaGPT across many inputs at the same time via:

```bash
parea benchmark --func startup:startup --csv_path benchmark-inputs.csv
```

The benchmark will create a CSV file with all the traces for you to debug.

I ran the benchmark with this CSV file:
```csv
idea
"Write a chess game in cli"
"Write a cli snake game"
```