### PR TITLE
replaced wait_fixed with wait_exponential

### DIFF
--- a/metagpt/actions/action.py
+++ b/metagpt/actions/action.py
@@ -9,7 +9,7 @@ import re
 from abc import ABC
 from typing import Optional
 
-from tenacity import retry, stop_after_attempt, wait_fixed
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 from metagpt.actions.action_output import ActionOutput
 from metagpt.llm import LLM
@@ -49,7 +49,7 @@ class Action(ABC):
         system_msgs.append(self.prefix)
         return await self.llm.aask(prompt, system_msgs)
 
-    @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+    @retry(stop=stop_after_attempt(4), wait=wait_exponential(10,60,3))
     async def _aask_v1(
         self,
         prompt: str,

--- a/metagpt/actions/write_code.py
+++ b/metagpt/actions/write_code.py
@@ -11,7 +11,7 @@ from metagpt.const import WORKSPACE_ROOT
 from metagpt.logs import logger
 from metagpt.schema import Message
 from metagpt.utils.common import CodeParser
-from tenacity import retry, stop_after_attempt, wait_fixed
+from tenacity import retry, stop_after_attempt, wait_exponential, wait_exponential
 
 PROMPT_TEMPLATE = """
 NOTICE
@@ -66,7 +66,7 @@ class WriteCode(Action):
         code_path.write_text(code)
         logger.info(f"Saving Code to {code_path}")
 
-    @retry(stop=stop_after_attempt(2), wait=wait_fixed(1))
+    @retry(stop=stop_after_attempt(4), wait=wait_exponential(10,60,3))
     async def write_code(self, prompt):
         code_rsp = await self._aask(prompt)
         code = CodeParser.parse_code(block="", text=code_rsp)

--- a/metagpt/actions/write_code_review.py
+++ b/metagpt/actions/write_code_review.py
@@ -10,7 +10,7 @@ from metagpt.actions.action import Action
 from metagpt.logs import logger
 from metagpt.schema import Message
 from metagpt.utils.common import CodeParser
-from tenacity import retry, stop_after_attempt, wait_fixed
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 PROMPT_TEMPLATE = """
 NOTICE
@@ -65,7 +65,7 @@ class WriteCodeReview(Action):
     def __init__(self, name="WriteCodeReview", context: list[Message] = None, llm=None):
         super().__init__(name, context, llm)
 
-    @retry(stop=stop_after_attempt(2), wait=wait_fixed(1))
+    @retry(stop=stop_after_attempt(4), wait=wait_exponential(10,60,3))
     async def write_code(self, prompt):
         code_rsp = await self._aask(prompt)
         code = CodeParser.parse_code(block="", text=code_rsp)

--- a/metagpt/provider/openai_api.py
+++ b/metagpt/provider/openai_api.py
@@ -15,7 +15,7 @@ from tenacity import (
     retry,
     retry_if_exception_type,
     stop_after_attempt,
-    wait_fixed,
+    wait_exponential,
 )
 
 from metagpt.config import CONFIG
@@ -226,8 +226,8 @@ class OpenAIGPTAPI(BaseGPTAPI, RateLimiter):
         return await self._achat_completion(messages)
 
     @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_fixed(1),
+        stop=stop_after_attempt(4),
+        wait=wait_exponential(10,60,3),
         after=after_log(logger, logger.level("WARNING").name),
         retry=retry_if_exception_type(APIConnectionError),
         retry_error_callback=log_and_reraise,


### PR DESCRIPTION
Fixed MetaGPT crashing due to `openai.error.RateLimitError`.

The best way to handle API rate limits is by using an exponential backoff retry strategy. This is done by simply replacing tenacity's `wait_fixed` with `wait_exponential`, and to be extra sure, increasing the number of attempts by one.

Related open issues:

https://github.com/geekan/MetaGPT/issues/253
https://github.com/geekan/MetaGPT/issues/255
https://github.com/geekan/MetaGPT/issues/477

