### PR TITLE
Basic code for serialization/deserialization and test cases

### DIFF
--- a/metagpt/actions/action.py
+++ b/metagpt/actions/action.py
@@ -7,8 +7,9 @@
 """
 import re
 from abc import ABC
-from typing import Optional
+from typing import Optional, Any
 
+from pydantic import BaseModel, Field
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from metagpt.actions.action_output import ActionOutput
@@ -18,45 +19,45 @@ from metagpt.utils.common import OutputParser
 from metagpt.utils.custom_decoder import CustomDecoder
 
 
-class Action(ABC):
-    def __init__(self, name: str = "", context=None, llm: LLM = None):
-        self.name: str = name
-        if llm is None:
-            llm = LLM()
-        self.llm = llm
-        self.context = context
-        self.prefix = ""
-        self.profile = ""
-        self.desc = ""
-        self.content = ""
-        self.instruct_content = None
-
+class Action(BaseModel):
+    name: str = ""
+    llm: LLM = Field(default_factory=LLM)
+    context = ""
+    prefix = ""
+    profile = ""
+    desc = ""
+    content: Optional[str] = None
+    instruct_content: Optional[str] = None
+    
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+    
     def set_prefix(self, prefix, profile):
         """Set prefix for later usage"""
         self.prefix = prefix
         self.profile = profile
-
+    
     def __str__(self):
         return self.__class__.__name__
-
+    
     def __repr__(self):
         return self.__str__()
-
+    
     async def _aask(self, prompt: str, system_msgs: Optional[list[str]] = None) -> str:
         """Append default prefix"""
         if not system_msgs:
             system_msgs = []
         system_msgs.append(self.prefix)
         return await self.llm.aask(prompt, system_msgs)
-
+    
     @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
     async def _aask_v1(
-        self,
-        prompt: str,
-        output_class_name: str,
-        output_data_mapping: dict,
-        system_msgs: Optional[list[str]] = None,
-        format="markdown",  # compatible to original format
+            self,
+            prompt: str,
+            output_class_name: str,
+            output_data_mapping: dict,
+            system_msgs: Optional[list[str]] = None,
+            format="markdown",  # compatible to original format
     ) -> ActionOutput:
         """Append default prefix"""
         if not system_msgs:
@@ -65,25 +66,25 @@ class Action(ABC):
         content = await self.llm.aask(prompt, system_msgs)
         logger.debug(content)
         output_class = ActionOutput.create_model_class(output_class_name, output_data_mapping)
-
+        
         if format == "json":
             pattern = r"\[CONTENT\](\s*\{.*?\}\s*)\[/CONTENT\]"
             matches = re.findall(pattern, content, re.DOTALL)
-
+            
             for match in matches:
                 if match:
                     content = match
                     break
-
+            
             parsed_data = CustomDecoder(strict=False).decode(content)
-
+        
         else:  # using markdown parser
             parsed_data = OutputParser.parse_data_with_mapping(content, output_data_mapping)
-
+        
         logger.debug(parsed_data)
         instruct_content = output_class(**parsed_data)
         return ActionOutput(content, instruct_content)
-
+    
     async def run(self, *args, **kwargs):
         """Run action"""
         raise NotImplementedError("The run method should be implemented in a subclass.")

--- a/metagpt/actions/write_code.py
+++ b/metagpt/actions/write_code.py
@@ -5,13 +5,18 @@
 @Author  : alexanderwu
 @File    : write_code.py
 """
+from typing import List, Optional, Any
+
+from pydantic import Field
+from tenacity import retry, stop_after_attempt, wait_fixed
+
 from metagpt.actions import WriteDesign
 from metagpt.actions.action import Action
+from metagpt.llm import LLM
 from metagpt.const import WORKSPACE_ROOT
 from metagpt.logs import logger
 from metagpt.schema import Message
 from metagpt.utils.common import CodeParser
-from tenacity import retry, stop_after_attempt, wait_fixed
 
 PROMPT_TEMPLATE = """
 NOTICE
@@ -43,9 +48,10 @@ ATTENTION: Use '##' to SPLIT SECTIONS, not '#'. Output format carefully referenc
 
 
 class WriteCode(Action):
-    def __init__(self, name="WriteCode", context: list[Message] = None, llm=None):
-        super().__init__(name, context, llm)
-
+    name: str = "WriteCode"
+    context: Optional[str] = None
+    llm: LLM = Field(default_factory=LLM)
+    
     def _is_invalid(self, filename):
         return any(i in filename for i in ["mp3", "wav"])
 
@@ -79,4 +85,3 @@ class WriteCode(Action):
         # code_rsp = await self._aask_v1(prompt, "code_rsp", OUTPUT_MAPPING)
         # self._save(context, filename, code)
         return code
-    

--- a/metagpt/actions/write_code_review.py
+++ b/metagpt/actions/write_code_review.py
@@ -5,12 +5,15 @@
 @Author  : alexanderwu
 @File    : write_code_review.py
 """
+from typing import List, Optional, Any
+from pydantic import Field
+from tenacity import retry, stop_after_attempt, wait_fixed
 
+from metagpt.llm import LLM
 from metagpt.actions.action import Action
 from metagpt.logs import logger
 from metagpt.schema import Message
 from metagpt.utils.common import CodeParser
-from tenacity import retry, stop_after_attempt, wait_fixed
 
 PROMPT_TEMPLATE = """
 NOTICE
@@ -62,9 +65,10 @@ FORMAT_EXAMPLE = """
 
 
 class WriteCodeReview(Action):
-    def __init__(self, name="WriteCodeReview", context: list[Message] = None, llm=None):
-        super().__init__(name, context, llm)
-
+    name: str = "WriteCodeReview"
+    context: Optional[str] = None
+    llm: LLM = Field(default_factory=LLM)
+    
     @retry(stop=stop_after_attempt(2), wait=wait_fixed(1))
     async def write_code(self, prompt):
         code_rsp = await self._aask(prompt)
@@ -79,4 +83,3 @@ class WriteCodeReview(Action):
         # code_rsp = await self._aask_v1(prompt, "code_rsp", OUTPUT_MAPPING)
         # self._save(context, filename, code)
         return code
-    

--- a/metagpt/environment.py
+++ b/metagpt/environment.py
@@ -29,11 +29,12 @@ class Environment(BaseModel):
         arbitrary_types_allowed = True
 
     def add_role(self, role: Role):
-        """增加一个在当前环境的角色
+        """增加一个在当前环境的角色, 默认为profile/role_profile
            Add a role in the current environment
         """
         role.set_env(self)
-        self.roles[role.profile] = role
+        # use alias
+        self.roles[role.role_profile] = role
 
     def add_roles(self, roles: Iterable[Role]):
         """增加一批在当前环境的角色

--- a/metagpt/roles/architect.py
+++ b/metagpt/roles/architect.py
@@ -5,10 +5,11 @@
 @Author  : alexanderwu
 @File    : architect.py
 """
+from pydantic import Field
 
 from metagpt.actions import WritePRD
 from metagpt.actions.design_api import WriteDesign
-from metagpt.roles import Role
+from metagpt.roles.role import Role
 
 
 class Architect(Role):
@@ -21,17 +22,16 @@ class Architect(Role):
         goal (str): Primary goal or responsibility of the architect.
         constraints (str): Constraints or guidelines for the architect.
     """
+    name: str = "Bob"
+    role_profile: str = Field(default="Architect" , alias='profile')
+    goal: str = "Design a concise, usable, complete python system"
+    constraints: str = "Try to specify good open source tools as much as possible"
 
     def __init__(
-        self,
-        name: str = "Bob",
-        profile: str = "Architect",
-        goal: str = "Design a concise, usable, complete python system",
-        constraints: str = "Try to specify good open source tools as much as possible",
+            self,
+            **kwargs
     ) -> None:
-        """Initializes the Architect with given attributes."""
-        super().__init__(name, profile, goal, constraints)
-
+        super().__init__(**kwargs)
         # Initialize actions specific to the Architect role
         self._init_actions([WriteDesign])
 

--- a/metagpt/roles/product_manager.py
+++ b/metagpt/roles/product_manager.py
@@ -5,37 +5,33 @@
 @Author  : alexanderwu
 @File    : product_manager.py
 """
+from pydantic import Field
+
 from metagpt.actions import BossRequirement, WritePRD
-from metagpt.roles import Role
+from metagpt.roles.role import Role
 
 
 class ProductManager(Role):
     """
-    Represents a Product Manager role responsible for product development and management.
+    Initializes the ProductManager role with given attributes.
 
-    Attributes:
+    Args:
         name (str): Name of the product manager.
-        profile (str): Role profile, default is 'Product Manager'.
+        profile (str): Role profile.
         goal (str): Goal of the product manager.
         constraints (str): Constraints or limitations for the product manager.
     """
-
+    name: str = "Alice"
+    role_profile: str = Field(default="Product Manager", alias='profile')
+    goal: str = "Efficiently create a successful product"
+    constraints: str = ""
+    """
+    Represents a Product Manager role responsible for product development and management.
+    """
     def __init__(
-        self,
-        name: str = "Alice",
-        profile: str = "Product Manager",
-        goal: str = "Efficiently create a successful product",
-        constraints: str = "",
+            self,
+            **kwargs
     ) -> None:
-        """
-        Initializes the ProductManager role with given attributes.
-
-        Args:
-            name (str): Name of the product manager.
-            profile (str): Role profile.
-            goal (str): Goal of the product manager.
-            constraints (str): Constraints or limitations for the product manager.
-        """
-        super().__init__(name, profile, goal, constraints)
+        super().__init__(**kwargs)
         self._init_actions([WritePRD])
         self._watch([BossRequirement])

--- a/metagpt/roles/project_manager.py
+++ b/metagpt/roles/project_manager.py
@@ -5,9 +5,11 @@
 @Author  : alexanderwu
 @File    : project_manager.py
 """
+from pydantic import Field
+
 from metagpt.actions import WriteTasks
 from metagpt.actions.design_api import WriteDesign
-from metagpt.roles import Role
+from metagpt.roles.role import Role
 
 
 class ProjectManager(Role):
@@ -20,23 +22,16 @@ class ProjectManager(Role):
         goal (str): Goal of the project manager.
         constraints (str): Constraints or limitations for the project manager.
     """
+    name: str = "Eve"
+    role_profile: str = Field(default="Project Manager", alias='profile')
+    
+    goal: str = "Improve team efficiency and deliver with quality and quantity"
+    constraints: str = ""
 
     def __init__(
-        self,
-        name: str = "Eve",
-        profile: str = "Project Manager",
-        goal: str = "Improve team efficiency and deliver with quality and quantity",
-        constraints: str = "",
+            self,
+            **kwargs
     ) -> None:
-        """
-        Initializes the ProjectManager role with given attributes.
-
-        Args:
-            name (str): Name of the project manager.
-            profile (str): Role profile.
-            goal (str): Goal of the project manager.
-            constraints (str): Constraints or limitations for the project manager.
-        """
-        super().__init__(name, profile, goal, constraints)
+        super().__init__(**kwargs)
         self._init_actions([WriteTasks])
         self._watch([WriteDesign])

--- a/metagpt/roles/role.py
+++ b/metagpt/roles/role.py
@@ -5,17 +5,26 @@
 @Author  : alexanderwu
 @File    : role.py
 """
+
 from __future__ import annotations
 
-from typing import Iterable, Type, Union
-from enum import Enum
-
+import sys
+from types import SimpleNamespace
+from typing import (
+    Dict,
+    Optional,
+    Union,
+    Iterable,
+    Type
+)
+import re
 from pydantic import BaseModel, Field
+from importlib import import_module
 
 # from metagpt.environment import Environment
 from metagpt.config import CONFIG
 from metagpt.actions import Action, ActionOutput
-from metagpt.llm import LLM, HumanProvider
+from metagpt.llm import LLM
 from metagpt.logs import logger
 from metagpt.memory import Memory, LongTermMemory
 from metagpt.schema import Message
@@ -28,14 +37,12 @@ Please note that only the text between the first and second "===" is information
 {history}
 ===
 
-Your previous stage: {previous_state}
-
-Now choose one of the following stages you need to go to in the next step:
+You can now choose one of the following stages to decide the stage you need to go in the next step:
 {states}
 
 Just answer a number between 0-{n_states}, choose the most suitable stage according to the understanding of the conversation.
 Please note that the answer only needs a number, no need to add any other text.
-If you think you have completed your goal and don't need to go to any of the stages, return -1.
+If there is no conversation record, choose 0.
 Do not answer anything else, and do not add any other information in your answer.
 """
 
@@ -49,27 +56,18 @@ ROLE_TEMPLATE = """Your response should be based on the previous conversation hi
 {name}: {result}
 """
 
-class RoleReactMode(str, Enum):
-    REACT = "react"
-    BY_ORDER = "by_order"
-    PLAN_AND_ACT = "plan_and_act"
-
-    @classmethod
-    def values(cls):
-        return [item.value for item in cls]
 
 class RoleSetting(BaseModel):
     """Role Settings"""
-    name: str
-    profile: str
-    goal: str
-    constraints: str
-    desc: str
-    is_human: bool
-
+    name: str = ""
+    profile: str = ""
+    goal: str = ""
+    constraints: str = ""
+    desc: str = ""
+    
     def __str__(self):
         return f"{self.name}({self.profile})"
-
+    
     def __repr__(self):
         return self.__str__()
 
@@ -79,109 +77,128 @@ class RoleContext(BaseModel):
     env: 'Environment' = Field(default=None)
     memory: Memory = Field(default_factory=Memory)
     long_term_memory: LongTermMemory = Field(default_factory=LongTermMemory)
-    state: int = Field(default=-1) # -1 indicates initial or termination state where todo is None
+    state: int = Field(default=0)
     todo: Action = Field(default=None)
     watch: set[Type[Action]] = Field(default_factory=set)
     news: list[Type[Message]] = Field(default=[])
-    react_mode: RoleReactMode = RoleReactMode.REACT # see `Role._set_react_mode` for definitions of the following two attributes
-    max_react_loop: int = 1
-
+    
     class Config:
         arbitrary_types_allowed = True
-
+    
     def check(self, role_id: str):
         if hasattr(CONFIG, "long_term_memory") and CONFIG.long_term_memory:
             self.long_term_memory.recover_memory(role_id, self)
             self.memory = self.long_term_memory  # use memory to act as long_term_memory for unify operation
-
+    
     @property
     def important_memory(self) -> list[Message]:
         """Get the information corresponding to the watched actions"""
         return self.memory.get_by_actions(self.watch)
-
+    
     @property
     def history(self) -> list[Message]:
         return self.memory.get()
 
 
-class Role:
+class Role(BaseModel):
     """Role/Agent"""
-
-    def __init__(self, name="", profile="", goal="", constraints="", desc="", is_human=False):
-        self._llm = LLM() if not is_human else HumanProvider()
-        self._setting = RoleSetting(name=name, profile=profile, goal=goal,
-                                    constraints=constraints, desc=desc, is_human=is_human)
-        self._states = []
-        self._actions = []
-        self._role_id = str(self._setting)
-        self._rc = RoleContext()
-
+    name: str = ""
+    profile: str = ""
+    goal: str = ""
+    constraints: str = ""
+    desc: str = ""
+    _setting: RoleSetting = Field(default_factory=RoleSetting, alias="_setting")
+    _setting = RoleSetting(name=name, profile=profile, goal=goal, constraints=constraints)
+    _role_id: str = ""
+    _states: list = Field(default=[])
+    _actions: list = Field(default=[])
+    _actions_type: list = Field(default=[])
+    _rc: RoleContext = RoleContext()
+    
+    _private_attributes = {
+        '_setting': _setting,
+        '_role_id': _role_id,
+        '_states': [],
+        '_actions': [],
+        '_actions_type': []  # 用于记录和序列化
+    }
+    
+    class Config:
+        arbitrary_types_allowed = True
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # 关于私有变量的初始化  https://github.com/pydantic/pydantic/issues/655
+        for key in self._private_attributes.keys():
+            if key in kwargs:
+                object.__setattr__(self, key, kwargs[key])
+                if key =="_setting":
+                    _setting = RoleSetting(**kwargs[key])
+                    object.__setattr__(self, '_setting', _setting)
+                elif key == "_rc":
+                    _rc = RoleContext
+                    object.__setattr__(self, '_rc', _rc)
+            else:
+                object.__setattr__(self, key, self._private_attributes[key])
+    
     def _reset(self):
-        self._states = []
-        self._actions = []
+        object.__setattr__(self, '_states', [])
+        object.__setattr__(self, '_actions', [])
+    
 
+    
+    @staticmethod
+    def _process_class(class_str, module_name):
+        cleaned_string = re.sub(r"[<>']", "", class_str).replace("class ", "")
+        package_name = "metagpt"
+        file_name = cleaned_string.replace(package_name, "").replace("." + module_name, "")
+        print(file_name)
+        # print("\n", sys.modules)
+        module_file = import_module(file_name, package=package_name)
+        module = getattr(module_file, module_name)
+        return module
+    
     def _init_actions(self, actions):
         self._reset()
         for idx, action in enumerate(actions):
             if not isinstance(action, Action):
-                i = action("", llm=self._llm)
+                ## 默认初始化
+                i = action()
             else:
-                if self._setting.is_human and not isinstance(action.llm, HumanProvider):
-                    logger.warning(f"is_human attribute does not take effect,"
-                        f"as Role's {str(action)} was initialized using LLM, try passing in Action classes instead of initialized instances")
                 i = action
             i.set_prefix(self._get_prefix(), self.profile)
             self._actions.append(i)
             self._states.append(f"{idx}. {action}")
-
-    def _set_react_mode(self, react_mode: str, max_react_loop: int = 1):
-        """Set strategy of the Role reacting to observed Message. Variation lies in how
-        this Role elects action to perform during the _think stage, especially if it is capable of multiple Actions.
-
-        Args:
-            react_mode (str): Mode for choosing action during the _think stage, can be one of:
-                        "react": standard think-act loop in the ReAct paper, alternating thinking and acting to solve the task, i.e. _think -> _act -> _think -> _act -> ...
-                                 Use llm to select actions in _think dynamically;
-                        "by_order": switch action each time by order defined in _init_actions, i.e. _act (Action1) -> _act (Action2) -> ...;
-                        "plan_and_act": first plan, then execute an action sequence, i.e. _think (of a plan) -> _act -> _act -> ...
-                                        Use llm to come up with the plan dynamically.
-                        Defaults to "react".
-            max_react_loop (int): Maximum react cycles to execute, used to prevent the agent from reacting forever.
-                                  Take effect only when react_mode is react, in which we use llm to choose actions, including termination.
-                                  Defaults to 1, i.e. _think -> _act (-> return result and end)
-        """
-        assert react_mode in RoleReactMode.values(), f"react_mode must be one of {RoleReactMode.values()}"
-        self._rc.react_mode = react_mode
-        if react_mode == RoleReactMode.REACT:
-            self._rc.max_react_loop = max_react_loop
-
+            action_title = action.schema()["title"]
+            self._actions_type.append(action_title)
+    
     def _watch(self, actions: Iterable[Type[Action]]):
         """Listen to the corresponding behaviors"""
         self._rc.watch.update(actions)
         # check RoleContext after adding watch actions
         self._rc.check(self._role_id)
-
-    def _set_state(self, state: int):
+    
+    def _set_state(self, state):
         """Update the current state."""
         self._rc.state = state
         logger.debug(self._actions)
-        self._rc.todo = self._actions[self._rc.state] if state >= 0 else None
-
+        self._rc.todo = self._actions[self._rc.state]
+    
     def set_env(self, env: 'Environment'):
         """Set the environment in which the role works. The role can talk to the environment and can also receive messages by observing."""
         self._rc.env = env
-
+    
     @property
     def profile(self):
         """Get the role description (position)"""
         return self._setting.profile
-
+    
     def _get_prefix(self):
         """Get the role prefix"""
         if self._setting.desc:
             return self._setting.desc
         return PREFIX_TEMPLATE.format(**self._setting.dict())
-
+    
     async def _think(self) -> None:
         """Think about what to do and decide on the next action"""
         if len(self._actions) == 1:
@@ -190,104 +207,60 @@ class Role:
             return
         prompt = self._get_prefix()
         prompt += STATE_TEMPLATE.format(history=self._rc.history, states="\n".join(self._states),
-                                        n_states=len(self._states) - 1, previous_state=self._rc.state)
-        # print(prompt)
+                                        n_states=len(self._states) - 1)
         next_state = await self._llm.aask(prompt)
         logger.debug(f"{prompt=}")
-        if (not next_state.isdigit() and next_state != "-1") \
-            or int(next_state) not in range(-1, len(self._states)):
-            logger.warning(f'Invalid answer of state, {next_state=}, will be set to -1')
-            next_state = -1
-        else:
-            next_state = int(next_state)
-            if next_state == -1:
-                logger.info(f"End actions with {next_state=}")
-        self._set_state(next_state)
-
+        if not next_state.isdigit() or int(next_state) not in range(len(self._states)):
+            logger.warning(f'Invalid answer of state, {next_state=}')
+            next_state = "0"
+        self._set_state(int(next_state))
+    
     async def _act(self) -> Message:
-        # prompt = self.get_prefix()
-        # prompt += ROLE_TEMPLATE.format(name=self.profile, state=self.states[self.state], result=response,
-        #                                history=self.history)
-
         logger.info(f"{self._setting}: ready to {self._rc.todo}")
         response = await self._rc.todo.run(self._rc.important_memory)
         # logger.info(response)
         if isinstance(response, ActionOutput):
             msg = Message(content=response.content, instruct_content=response.instruct_content,
-                        role=self.profile, cause_by=type(self._rc.todo))
+                          role=self.profile, cause_by=type(self._rc.todo))
         else:
             msg = Message(content=response, role=self.profile, cause_by=type(self._rc.todo))
         self._rc.memory.add(msg)
         # logger.debug(f"{response}")
-
+        
         return msg
-
+    
     async def _observe(self) -> int:
         """Observe from the environment, obtain important information, and add it to memory"""
         if not self._rc.env:
             return 0
         env_msgs = self._rc.env.memory.get()
-
+        
         observed = self._rc.env.memory.get_by_actions(self._rc.watch)
         
-        self._rc.news = self._rc.memory.find_news(observed)  # find news (previously unseen messages) from observed messages
-
+        self._rc.news = self._rc.memory.find_news(
+            observed)  # find news (previously unseen messages) from observed messages
+        
         for i in env_msgs:
             self.recv(i)
-
+        
         news_text = [f"{i.role}: {i.content[:20]}..." for i in self._rc.news]
         if news_text:
             logger.debug(f'{self._setting} observed: {news_text}')
         return len(self._rc.news)
-
+    
     def _publish_message(self, msg):
         """If the role belongs to env, then the role's messages will be broadcast to env"""
         if not self._rc.env:
             # If env does not exist, do not publish the message
             return
         self._rc.env.publish_message(msg)
-
+    
     async def _react(self) -> Message:
-        """Think first, then act, until the Role _think it is time to stop and requires no more todo.
-        This is the standard think-act loop in the ReAct paper, which alternates thinking and acting in task solving, i.e. _think -> _act -> _think -> _act -> ... 
-        Use llm to select actions in _think dynamically
-        """
-        actions_taken = 0
-        rsp = Message("No actions taken yet") # will be overwritten after Role _act
-        while actions_taken < self._rc.max_react_loop:
-            # think
-            await self._think()
-            if self._rc.todo is None:
-                break
-            # act
-            logger.debug(f"{self._setting}: {self._rc.state=}, will do {self._rc.todo}")
-            rsp = await self._act()
-            actions_taken += 1
-        return rsp # return output from the last action
-
-    async def _act_by_order(self) -> Message:
-        """switch action each time by order defined in _init_actions, i.e. _act (Action1) -> _act (Action2) -> ..."""
-        for i in range(len(self._states)):
-            self._set_state(i)
-            rsp = await self._act()
-        return rsp # return output from the last action
-
-    async def _plan_and_act(self) -> Message:
-        """first plan, then execute an action sequence, i.e. _think (of a plan) -> _act -> _act -> ... Use llm to come up with the plan dynamically."""
-        # TODO: to be implemented
-        return Message("")
-
-    async def react(self) -> Message:
-        """Entry to one of three strategies by which Role reacts to the observed Message"""
-        if self._rc.react_mode == RoleReactMode.REACT:
-            rsp = await self._react()
-        elif self._rc.react_mode == RoleReactMode.BY_ORDER:
-            rsp = await self._act_by_order()
-        elif self._rc.react_mode == RoleReactMode.PLAN_AND_ACT:
-            rsp = await self._plan_and_act()
-        self._set_state(state=-1) # current reaction is complete, reset state to -1 and todo back to None
-        return rsp
-
+        """Think first, then act"""
+        await self._think()
+        logger.debug(f"{self._setting}: {self._rc.state=}, will do {self._rc.todo}")
+        return await self._act()
+    
     def recv(self, message: Message) -> None:
         """add message to history."""
         # self._history += f"\n{message}"
@@ -295,18 +268,14 @@ class Role:
         if message in self._rc.memory.get():
             return
         self._rc.memory.add(message)
-
+    
     async def handle(self, message: Message) -> Message:
         """Receive information and reply with actions"""
         # logger.debug(f"{self.name=}, {self.profile=}, {message.role=}")
         self.recv(message)
-
+        
         return await self._react()
-
-    def get_memories(self, k=0) -> list[Message]:
-        """A wrapper to return the most recent k memories of this role, return all when k=0"""
-        return self._rc.memory.get(k=k)
-
+    
     async def run(self, message=None):
         """Observe, and think and act based on the results of the observation"""
         if message:
@@ -320,8 +289,8 @@ class Role:
             # If there is no new information, suspend and wait
             logger.debug(f"{self._setting}: no news. waiting.")
             return
-
-        rsp = await self.react()
+        
+        rsp = await self._react()
         # Publish the reply to the environment, waiting for the next subscriber to process
         self._publish_message(rsp)
         return rsp

--- a/tests/metagpt/serialize_deserialize/__init__.py
+++ b/tests/metagpt/serialize_deserialize/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# @Date    : 11/22/2023 11:48 AM
+# @Author  : stellahong (stellahong@fuzhi.ai)
+# @Desc    :

--- a/tests/metagpt/serialize_deserialize/test_actions.py
+++ b/tests/metagpt/serialize_deserialize/test_actions.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# @Date    : 11/22/2023 11:48 AM
+# @Author  : stellahong (stellahong@fuzhi.ai)
+# @Desc    :
+import pytest
+
+from metagpt.actions import Action
+from metagpt.llm import LLM
+
+def test_action_serialize():
+    action = Action()
+    ser_action_dict = action.dict()
+    assert "name" in ser_action_dict
+    assert "llm" in ser_action_dict
+
+@pytest.mark.asyncio
+async def test_action_deserialize():
+    action = Action()
+    serialized_data = action.dict()
+    
+    new_action = Action(**serialized_data)
+    assert new_action.name == ""
+    assert new_action.llm == LLM()
+    assert len(await new_action._aask("who are you")) > 0

--- a/tests/metagpt/serialize_deserialize/test_architect_deserialize.py
+++ b/tests/metagpt/serialize_deserialize/test_architect_deserialize.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# @Date    : 11/26/2023 2:04 PM
+# @Author  : stellahong (stellahong@fuzhi.ai)
+# @Desc    :
+import pytest
+
+from metagpt.roles.architect import Architect
+from metagpt.actions.action import Action
+
+def test_architect_serialize():
+    role = Architect()
+    ser_role_dict = role.dict(by_alias=True)
+    assert "name" in ser_role_dict
+    assert "_states" in ser_role_dict
+    assert "_actions" in ser_role_dict
+
+@pytest.mark.asyncio
+async def test_architect_deserialize():
+    role = Architect()
+    ser_role_dict = role.dict(by_alias=True)
+    new_role = Architect(**ser_role_dict)
+    # new_role = Architect.deserialize(ser_role_dict)
+    assert new_role.name == "Bob"
+    assert len(new_role._actions) == 1
+    assert isinstance(new_role._actions[0], Action)
+    await new_role._actions[0].run(context="write a cli snake game")

--- a/tests/metagpt/serialize_deserialize/test_product_manager.py
+++ b/tests/metagpt/serialize_deserialize/test_product_manager.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# @Date    : 11/26/2023 2:07 PM
+# @Author  : stellahong (stellahong@fuzhi.ai)
+# @Desc    :
+import pytest
+
+from metagpt.roles.product_manager import ProductManager
+from metagpt.actions.action import Action
+from metagpt.schema import Message
+
+@pytest.mark.asyncio
+async def test_product_manager_deserialize():
+    role = ProductManager()
+    ser_role_dict = role.dict(by_alias=True)
+    new_role = ProductManager(**ser_role_dict)
+    # new_role = ProductManager().deserialize(ser_role_dict)
+    
+    assert new_role.name == "Alice"
+    assert len(new_role._actions) == 1
+    assert isinstance(new_role._actions[0], Action)
+    await new_role._actions[0].run([Message(content="write a cli snake game")])

--- a/tests/metagpt/serialize_deserialize/test_project_manager.py
+++ b/tests/metagpt/serialize_deserialize/test_project_manager.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# @Date    : 11/26/2023 2:06 PM
+# @Author  : stellahong (stellahong@fuzhi.ai)
+# @Desc    :
+import pytest
+
+from metagpt.roles.project_manager import ProjectManager
+from metagpt.actions.action import Action
+
+def test_project_manager_serialize():
+    role = ProjectManager()
+    ser_role_dict = role.dict(by_alias=True)
+    assert "name" in ser_role_dict
+    assert "_states" in ser_role_dict
+    assert "_actions" in ser_role_dict
+
+@pytest.mark.asyncio
+async def test_project_manager_deserialize():
+    role = ProjectManager()
+    ser_role_dict = role.dict(by_alias=True)
+    new_role = ProjectManager(**ser_role_dict)
+    # new_role = ProjectManager().deserialize(ser_role_dict)
+    assert new_role.name == "Eve"
+    assert len(new_role._actions) == 1
+    assert isinstance(new_role._actions[0], Action)
+    await new_role._actions[0].run(context="write a cli snake game")

--- a/tests/metagpt/serialize_deserialize/test_role.py
+++ b/tests/metagpt/serialize_deserialize/test_role.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# @Date    : 11/23/2023 4:49 PM
+# @Author  : stellahong (stellahong@fuzhi.ai)
+# @Desc    :
+import pytest
+
+from metagpt.roles.role import Role
+from metagpt.roles.engineer import Engineer
+
+from metagpt.actions.action import Action
+
+
+def test_role_serialize():
+    role = Role()
+    ser_role_dict = role.dict(by_alias=True)
+    assert "name" in ser_role_dict
+    assert "_states" in ser_role_dict
+    assert "_actions" in ser_role_dict
+
+
+def test_engineer_serialize():
+    role = Engineer()
+    ser_role_dict = role.dict(by_alias=True)
+    assert "name" in ser_role_dict
+    assert "_states" in ser_role_dict
+    assert "_actions" in ser_role_dict
+
+
+@pytest.mark.asyncio
+async def test_engineer_deserialize():
+    role = Engineer(use_code_review=True)
+    ser_role_dict = role.dict(by_alias=True)
+    # new_role = Engineer().deserialize(ser_role_dict)
+    # also can be deserialized in this way:
+    new_role = Engineer(**ser_role_dict)
+    assert new_role.name == "Alex"
+    assert new_role.use_code_review == True
+    assert len(new_role._actions) == 2
+    assert isinstance(new_role._actions[0], Action)
+    assert isinstance(new_role._actions[1], Action)
+    await new_role._actions[0].run(context="write a cli snake game", filename="test_code")

--- a/tests/metagpt/serialize_deserialize/test_team.py
+++ b/tests/metagpt/serialize_deserialize/test_team.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# @Date    : 11/27/2023 10:07 AM
+# @Author  : stellahong (stellahong@fuzhi.ai)
+# @Desc    :
+import pytest
+
+from metagpt.environment import Environment
+from metagpt.schema import Message
+from metagpt.software_company import SoftwareCompany
+from metagpt.roles import ProjectManager, ProductManager, Architect
+
+
+def test_env_serialize():
+    env = Environment()
+    ser_env_dict = env.dict()
+    assert "roles" in ser_env_dict
+    assert "memory" in ser_env_dict
+    assert "memory" in ser_env_dict
+
+
+def test_env_deserialize():
+    env = Environment()
+    env.publish_message(message=Message(content="test env serialize"))
+    ser_env_dict = env.dict()
+    new_env = Environment(**ser_env_dict)
+    assert len(new_env.roles) == 0
+    assert new_env.memory.storage[0].content == "test env serialize"
+    assert len(new_env.history) == 25
+
+
+def test_softwarecompany_deserialize():
+    team = SoftwareCompany()
+    team.hire(
+        [
+            ProductManager(),
+            Architect(),
+            ProjectManager(),
+        ]
+    )
+    assert len(team.environment.get_roles()) == 3
+    ser_team_dict = team.dict()
+    new_team = SoftwareCompany(**ser_team_dict)
+    
+    assert len(new_team.environment.get_roles()) == 3
+    assert new_team.environment.get_role('Product Manager') is not None
+    assert new_team.environment.get_role('Product Manager') is not None
+    assert new_team.environment.get_role('Architect') is not None

--- a/tests/metagpt/serialize_deserialize/test_wrire_prd.py
+++ b/tests/metagpt/serialize_deserialize/test_wrire_prd.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# @Date    : 11/22/2023 1:47 PM
+# @Author  : stellahong (stellahong@fuzhi.ai)
+# @Desc    :
+import pytest
+
+from metagpt.actions import WritePRD
+from metagpt.llm import LLM
+from metagpt.schema import Message
+
+
+def test_action_serialize():
+    action = WritePRD()
+    ser_action_dict = action.dict()
+    assert "name" in ser_action_dict
+    assert "llm" in ser_action_dict
+
+
+@pytest.mark.asyncio
+async def test_action_deserialize():
+    action = WritePRD()
+    serialized_data = action.dict()
+    new_action = WritePRD(**serialized_data)
+    # new_action = WritePRD().deserialize(serialized_data)
+    assert new_action.name == ""
+    assert new_action.llm == LLM()
+    assert len(await new_action.run([Message(content="write a cli snake game")]))>0
+   

--- a/tests/metagpt/serialize_deserialize/test_write_code.py
+++ b/tests/metagpt/serialize_deserialize/test_write_code.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# @Date    : 11/23/2023 10:56 AM
+# @Author  : stellahong (stellahong@fuzhi.ai)
+# @Desc    :
+import pytest
+
+from metagpt.actions import WriteCode, WriteCodeReview
+from metagpt.llm import LLM
+
+def test_write_design_serialize():
+    action = WriteCode()
+    ser_action_dict = action.dict()
+    assert ser_action_dict["name"] == "WriteCode"
+    assert "llm" in ser_action_dict
+
+def test_write_task_serialize():
+    action = WriteCodeReview()
+    ser_action_dict = action.dict()
+    assert ser_action_dict["name"] == "WriteCodeReview"
+    assert "llm" in ser_action_dict
+    
+@pytest.mark.asyncio
+async def test_write_code_deserialize():
+    action = WriteCode()
+    serialized_data = action.dict()
+    new_action = WriteCode(**serialized_data)
+    # new_action = WriteCode().deserialize(serialized_data)
+    assert new_action.name == "WriteCode"
+    assert new_action.llm == LLM()
+    await new_action.run(context="write a cli snake game", filename="test_code")
+
+@pytest.mark.asyncio
+async def test_write_code_review_deserialize():
+    action = WriteCodeReview()
+    serialized_data = action.dict()
+    new_action = WriteCodeReview(**serialized_data)
+    # new_action = WriteCodeReview().deserialize(serialized_data)
+    code = await WriteCode().run(context="write a cli snake game", filename="test_code")
+
+    assert new_action.name == "WriteCodeReview"
+    assert new_action.llm == LLM()
+    await new_action.run(context="write a cli snake game", code =code,  filename="test_rewrite_code")

--- a/tests/metagpt/serialize_deserialize/test_write_design.py
+++ b/tests/metagpt/serialize_deserialize/test_write_design.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# @Date    : 11/22/2023 8:19 PM
+# @Author  : stellahong (stellahong@fuzhi.ai)
+# @Desc    :
+import pytest
+
+from metagpt.actions import WriteDesign, WriteTasks
+from metagpt.llm import LLM
+
+def test_write_design_serialize():
+    action = WriteDesign()
+    ser_action_dict = action.dict()
+    assert "name" in ser_action_dict
+    assert "llm" in ser_action_dict
+
+def test_write_task_serialize():
+    action = WriteTasks()
+    ser_action_dict = action.dict()
+    assert "name" in ser_action_dict
+    assert "llm" in ser_action_dict
+
+@pytest.mark.asyncio
+async def test_write_design_deserialize():
+    action = WriteDesign()
+    serialized_data = action.dict()
+    new_action = WriteDesign().deserialize(serialized_data)
+    assert new_action.name == ""
+    assert new_action.llm == LLM()
+    await new_action.run(context="write a cli snake game")
+
+@pytest.mark.asyncio
+async def test_write_task_deserialize():
+    action = WriteTasks()
+    serialized_data = action.dict()
+    new_action = WriteTasks(**serialized_data)
+    # new_action = WriteTasks().deserialize(serialized_data)
+    assert new_action.name == "CreateTasks"
+    assert new_action.llm == LLM()
+    await new_action.run(context="write a cli snake game")


### PR DESCRIPTION
### Summary:
This pull request aims to refactor the existing code based on Pydantic v1.10 to achieve a more straightforward serialization and deserialization process. This includes directly using object.dict() for serialization. All relevant classes should inherit from Pydantic's BaseModel and undergo necessary initialization adjustments. For a better understanding of the refactoring approach, refer to the role/architect.py file or action/write_prd.py.

### Overview of Changes:
1.  Pydantic v1.10.13 (test on Python 3.9)
2.  All relevant classes should inherit from Pydantic's BaseModel and refactor necessary initialization.
3. Utilize object.dict() directly for serialization.
4. Deserialization can be done by directly loading the serialized dict or considering the use of the BaseModel.parse_obj method.

### Testing:
Add relevant test cases during the refactoring process to validate the correctness of the new serialization and deserialization logic. Test cases in ./tests/serialize_deserialize
Currently, have tested on architect/productmanager/projectmanager/engineer, write_prd/write_code/write_code_review/writed_design/write_task, as well as Environment and SoftwareCompany, more test cases need to be added. 