### PR TITLE
[CHORE] Research Role allow override sys prompt

### DIFF
--- a/metagpt/roles/researcher.py
+++ b/metagpt/roles/researcher.py
@@ -46,7 +46,7 @@ class Researcher(Role):
         else:
             topic = msg.content
 
-        research_system_text = get_research_system_text(topic, self.language)
+        research_system_text = self.research_system_text(topic)
         if isinstance(todo, CollectLinks):
             links = await todo.run(topic, 4, 4)
             ret = Message("", Report(topic=topic, links=links), role=self.profile, cause_by=type(todo))
@@ -64,6 +64,17 @@ class Researcher(Role):
         self._rc.memory.add(ret)
         return ret
 
+    def research_system_text(self, topic) -> str:
+        """ BACKWARD compatible
+        This allows sub-class able to define its own system prompt based on topic.
+        return the previous implementation to have backward compatible
+        Args:
+            topic:
+            language:
+
+        Returns: str
+        """
+        return get_research_system_text(topic, self.language)
     async def react(self) -> Message:
         msg = await super().react()
         report = msg.instruct_content

--- a/metagpt/roles/researcher.py
+++ b/metagpt/roles/researcher.py
@@ -75,6 +75,7 @@ class Researcher(Role):
         Returns: str
         """
         return get_research_system_text(topic, self.language)
+
     async def react(self) -> Message:
         msg = await super().react()
         report = msg.instruct_content

--- a/metagpt/roles/researcher.py
+++ b/metagpt/roles/researcher.py
@@ -4,7 +4,7 @@ import asyncio
 
 from pydantic import BaseModel
 
-from metagpt.actions import CollectLinks, ConductResearch, WebBrowseAndSummarize
+from metagpt.actions import Action, CollectLinks, ConductResearch, WebBrowseAndSummarize
 from metagpt.actions.research import get_research_system_text
 from metagpt.const import RESEARCH_PATH
 from metagpt.logs import logger
@@ -46,7 +46,7 @@ class Researcher(Role):
         else:
             topic = msg.content
 
-        research_system_text = self.research_system_text(topic)
+        research_system_text = self.research_system_text(topic, todo)
         if isinstance(todo, CollectLinks):
             links = await todo.run(topic, 4, 4)
             ret = Message("", Report(topic=topic, links=links), role=self.profile, cause_by=type(todo))
@@ -64,7 +64,7 @@ class Researcher(Role):
         self._rc.memory.add(ret)
         return ret
 
-    def research_system_text(self, topic) -> str:
+    def research_system_text(self, topic, current_task: Action) -> str:
         """ BACKWARD compatible
         This allows sub-class able to define its own system prompt based on topic.
         return the previous implementation to have backward compatible


### PR DESCRIPTION
# Overview
I think each action serve one particular role always has a chance to override its system prompt.

For instance: CollectLinks doesn't need heavy prompt, but ConductResearch is able to inherit something from parent role