### PR TITLE
fixbug: gitignore error after project renamed

### DIFF
--- a/metagpt/utils/git_repository.py
+++ b/metagpt/utils/git_repository.py
@@ -204,6 +204,7 @@ class GitRepository:
             logger.warning(f"Move {str(self.workdir)} to {str(new_path)} error: {e}")
         logger.info(f"Rename directory {str(self.workdir)} to {str(new_path)}")
         self._repository = Repo(new_path)
+        self._gitignore_rules = parse_gitignore(full_path=str(new_path / ".gitignore"))
 
     def get_files(self, relative_path: Path | str, root_relative_path: Path | str = None, filter_ignored=True) -> List:
         """


### PR DESCRIPTION
fixbug: gitignore error after project renamed

原因：在项目路径变更后，没有重新生成git ignore规则，导致规则匹配还是用的旧的项目路径。

Reason: After changing the project path, the gitignore rules were not regenerated, resulting in the continued use of old project path rules.