### PR TITLE
Feature：add turns to live for Message in Memory. 给Memory中的message添加存活轮数机制

### DIFF
--- a/metagpt/memory/memory.py
+++ b/metagpt/memory/memory.py
@@ -129,3 +129,19 @@ class Memory(BaseModel):
                 continue
             rsp += self.index[action]
         return rsp
+
+    def update_storage_by_ttl(self):
+        """update storage by turns-to-live of message."""
+        # find message to delete in storage
+        to_delete_msgs = []
+        for i, msg in enumerate(self.storage):
+            if msg.ttl > -1 and len(self.storage) - i > msg.ttl:
+                to_delete_msgs.append(msg)
+
+        # delete message in storage
+        for msg in to_delete_msgs:
+            self.delete(msg)
+
+    def get_by_ttl(self, k=0):
+        self.update_storage_by_ttl()
+        return self.storage[-k:]

--- a/metagpt/schema.py
+++ b/metagpt/schema.py
@@ -109,7 +109,7 @@ class Message(BaseModel):
     cause_by: str = ""
     sent_from: str = ""
     send_to: Set = Field(default_factory={MESSAGE_ROUTE_TO_ALL})
-    ttl: int = -1       # dialogue turns-to-live, default value -1, means keep it forever.
+    ttl: int = -1  # dialogue turns-to-live, default value -1, means keep it forever.
 
     def __init__(self, **kwargs):
         ic = kwargs.get("instruct_content", None)

--- a/metagpt/schema.py
+++ b/metagpt/schema.py
@@ -109,6 +109,7 @@ class Message(BaseModel):
     cause_by: str = ""
     sent_from: str = ""
     send_to: Set = Field(default_factory={MESSAGE_ROUTE_TO_ALL})
+    ttl: int = -1       # dialogue turns-to-live, default value -1, means keep it forever.
 
     def __init__(self, **kwargs):
         ic = kwargs.get("instruct_content", None)

--- a/tests/metagpt/memory/test_memory_storage.py
+++ b/tests/metagpt/memory/test_memory_storage.py
@@ -11,61 +11,100 @@ from metagpt.actions import UserRequirement, WritePRD
 from metagpt.actions.action_node import ActionNode
 from metagpt.memory.memory_storage import MemoryStorage
 from metagpt.schema import Message
+from metagpt.memory import Memory
 
 
-def test_idea_message():
-    idea = "Write a cli snake game"
-    role_id = "UTUser1(Product Manager)"
-    message = Message(role="User", content=idea, cause_by=UserRequirement)
+# def test_idea_message():
+#     idea = "Write a cli snake game"
+#     role_id = "UTUser1(Product Manager)"
+#     message = Message(role="User", content=idea, cause_by=UserRequirement)
 
-    memory_storage: MemoryStorage = MemoryStorage()
-    messages = memory_storage.recover_memory(role_id)
-    assert len(messages) == 0
+#     memory_storage: MemoryStorage = MemoryStorage()
+#     messages = memory_storage.recover_memory(role_id)
+#     assert len(messages) == 0
 
-    memory_storage.add(message)
-    assert memory_storage.is_initialized is True
+#     memory_storage.add(message)
+#     assert memory_storage.is_initialized is True
 
-    sim_idea = "Write a game of cli snake"
-    sim_message = Message(role="User", content=sim_idea, cause_by=UserRequirement)
-    new_messages = memory_storage.search(sim_message)
-    assert len(new_messages) == 0  # similar, return []
+#     sim_idea = "Write a game of cli snake"
+#     sim_message = Message(role="User", content=sim_idea, cause_by=UserRequirement)
+#     new_messages = memory_storage.search(sim_message)
+#     assert len(new_messages) == 0  # similar, return []
 
-    new_idea = "Write a 2048 web game"
-    new_message = Message(role="User", content=new_idea, cause_by=UserRequirement)
-    new_messages = memory_storage.search(new_message)
-    assert new_messages[0].content == message.content
+#     new_idea = "Write a 2048 web game"
+#     new_message = Message(role="User", content=new_idea, cause_by=UserRequirement)
+#     new_messages = memory_storage.search(new_message)
+#     assert new_messages[0].content == message.content
 
-    memory_storage.clean()
-    assert memory_storage.is_initialized is False
+#     memory_storage.clean()
+#     assert memory_storage.is_initialized is False
 
 
-def test_actionout_message():
-    out_mapping = {"field1": (str, ...), "field2": (List[str], ...)}
-    out_data = {"field1": "field1 value", "field2": ["field2 value1", "field2 value2"]}
-    ic_obj = ActionNode.create_model_class("prd", out_mapping)
+# def test_actionout_message():
+#     out_mapping = {"field1": (str, ...), "field2": (List[str], ...)}
+#     out_data = {"field1": "field1 value", "field2": ["field2 value1", "field2 value2"]}
+#     ic_obj = ActionNode.create_model_class("prd", out_mapping)
 
-    role_id = "UTUser2(Architect)"
-    content = "The user has requested the creation of a command-line interface (CLI) snake game"
-    message = Message(
-        content=content, instruct_content=ic_obj(**out_data), role="user", cause_by=WritePRD
-    )  # WritePRD as test action
+#     role_id = "UTUser2(Architect)"
+#     content = "The user has requested the creation of a command-line interface (CLI) snake game"
+#     message = Message(
+#         content=content, instruct_content=ic_obj(**out_data), role="user", cause_by=WritePRD
+#     )  # WritePRD as test action
 
-    memory_storage: MemoryStorage = MemoryStorage()
-    messages = memory_storage.recover_memory(role_id)
-    assert len(messages) == 0
+#     memory_storage: MemoryStorage = MemoryStorage()
+#     messages = memory_storage.recover_memory(role_id)
+#     assert len(messages) == 0
 
-    memory_storage.add(message)
-    assert memory_storage.is_initialized is True
+#     memory_storage.add(message)
+#     assert memory_storage.is_initialized is True
 
-    sim_conent = "The request is command-line interface (CLI) snake game"
-    sim_message = Message(content=sim_conent, instruct_content=ic_obj(**out_data), role="user", cause_by=WritePRD)
-    new_messages = memory_storage.search(sim_message)
-    assert len(new_messages) == 0  # similar, return []
+#     sim_conent = "The request is command-line interface (CLI) snake game"
+#     sim_message = Message(content=sim_conent, instruct_content=ic_obj(**out_data), role="user", cause_by=WritePRD)
+#     new_messages = memory_storage.search(sim_message)
+#     assert len(new_messages) == 0  # similar, return []
 
-    new_conent = "Incorporate basic features of a snake game such as scoring and increasing difficulty"
-    new_message = Message(content=new_conent, instruct_content=ic_obj(**out_data), role="user", cause_by=WritePRD)
-    new_messages = memory_storage.search(new_message)
-    assert new_messages[0].content == message.content
+#     new_conent = "Incorporate basic features of a snake game such as scoring and increasing difficulty"
+#     new_message = Message(content=new_conent, instruct_content=ic_obj(**out_data), role="user", cause_by=WritePRD)
+#     new_messages = memory_storage.search(new_message)
+#     assert new_messages[0].content == message.content
 
-    memory_storage.clean()
-    assert memory_storage.is_initialized is False
+#     memory_storage.clean()
+#     assert memory_storage.is_initialized is False
+
+
+def test_memory_ttl():
+    working_memory = Memory()
+    msg = Message(content='This msg will be droped on 2th dialogue.', ttl=1)
+    msg2 = Message(content='This msg will be droped after live 2 turn dialogue.', ttl=2)
+    msg3 = Message(content='This msg will never be droped.')
+    msg4 = Message(content='This msg will never be droped too.')
+    # 第1轮对话
+    working_memory.add(msg)
+    assert msg in working_memory.storage
+    working_memory.update_storage_by_ttl()
+    assert msg in working_memory.storage
+    # 第2轮对话
+    working_memory.add(msg2)
+    assert msg in working_memory.storage
+    assert msg2 in working_memory.storage
+    working_memory.update_storage_by_ttl()
+    assert msg not in working_memory.storage
+    assert msg2 in working_memory.storage
+    # 第3轮对话
+    working_memory.add(msg3)
+    assert msg not in working_memory.storage
+    assert msg2 in working_memory.storage
+    assert msg3 in working_memory.storage
+    working_memory.update_storage_by_ttl()
+    assert msg2 in working_memory.storage
+    assert msg3 in working_memory.storage
+    # 第4轮对话
+    working_memory.add(msg4)
+    assert msg not in working_memory.storage
+    assert msg2 in working_memory.storage
+    assert msg3 in working_memory.storage
+    assert msg4 in working_memory.storage
+    working_memory.update_storage_by_ttl()
+    assert msg2 not in working_memory.storage
+    assert msg3 in working_memory.storage
+    assert msg4 in working_memory.storage

--- a/tests/metagpt/memory/test_memory_storage.py
+++ b/tests/metagpt/memory/test_memory_storage.py
@@ -14,62 +14,62 @@ from metagpt.schema import Message
 from metagpt.memory import Memory
 
 
-# def test_idea_message():
-#     idea = "Write a cli snake game"
-#     role_id = "UTUser1(Product Manager)"
-#     message = Message(role="User", content=idea, cause_by=UserRequirement)
+def test_idea_message():
+    idea = "Write a cli snake game"
+    role_id = "UTUser1(Product Manager)"
+    message = Message(role="User", content=idea, cause_by=UserRequirement)
 
-#     memory_storage: MemoryStorage = MemoryStorage()
-#     messages = memory_storage.recover_memory(role_id)
-#     assert len(messages) == 0
+    memory_storage: MemoryStorage = MemoryStorage()
+    messages = memory_storage.recover_memory(role_id)
+    assert len(messages) == 0
 
-#     memory_storage.add(message)
-#     assert memory_storage.is_initialized is True
+    memory_storage.add(message)
+    assert memory_storage.is_initialized is True
 
-#     sim_idea = "Write a game of cli snake"
-#     sim_message = Message(role="User", content=sim_idea, cause_by=UserRequirement)
-#     new_messages = memory_storage.search(sim_message)
-#     assert len(new_messages) == 0  # similar, return []
+    sim_idea = "Write a game of cli snake"
+    sim_message = Message(role="User", content=sim_idea, cause_by=UserRequirement)
+    new_messages = memory_storage.search(sim_message)
+    assert len(new_messages) == 0  # similar, return []
 
-#     new_idea = "Write a 2048 web game"
-#     new_message = Message(role="User", content=new_idea, cause_by=UserRequirement)
-#     new_messages = memory_storage.search(new_message)
-#     assert new_messages[0].content == message.content
+    new_idea = "Write a 2048 web game"
+    new_message = Message(role="User", content=new_idea, cause_by=UserRequirement)
+    new_messages = memory_storage.search(new_message)
+    assert new_messages[0].content == message.content
 
-#     memory_storage.clean()
-#     assert memory_storage.is_initialized is False
+    memory_storage.clean()
+    assert memory_storage.is_initialized is False
 
 
-# def test_actionout_message():
-#     out_mapping = {"field1": (str, ...), "field2": (List[str], ...)}
-#     out_data = {"field1": "field1 value", "field2": ["field2 value1", "field2 value2"]}
-#     ic_obj = ActionNode.create_model_class("prd", out_mapping)
+def test_actionout_message():
+    out_mapping = {"field1": (str, ...), "field2": (List[str], ...)}
+    out_data = {"field1": "field1 value", "field2": ["field2 value1", "field2 value2"]}
+    ic_obj = ActionNode.create_model_class("prd", out_mapping)
 
-#     role_id = "UTUser2(Architect)"
-#     content = "The user has requested the creation of a command-line interface (CLI) snake game"
-#     message = Message(
-#         content=content, instruct_content=ic_obj(**out_data), role="user", cause_by=WritePRD
-#     )  # WritePRD as test action
+    role_id = "UTUser2(Architect)"
+    content = "The user has requested the creation of a command-line interface (CLI) snake game"
+    message = Message(
+        content=content, instruct_content=ic_obj(**out_data), role="user", cause_by=WritePRD
+    )  # WritePRD as test action
 
-#     memory_storage: MemoryStorage = MemoryStorage()
-#     messages = memory_storage.recover_memory(role_id)
-#     assert len(messages) == 0
+    memory_storage: MemoryStorage = MemoryStorage()
+    messages = memory_storage.recover_memory(role_id)
+    assert len(messages) == 0
 
-#     memory_storage.add(message)
-#     assert memory_storage.is_initialized is True
+    memory_storage.add(message)
+    assert memory_storage.is_initialized is True
 
-#     sim_conent = "The request is command-line interface (CLI) snake game"
-#     sim_message = Message(content=sim_conent, instruct_content=ic_obj(**out_data), role="user", cause_by=WritePRD)
-#     new_messages = memory_storage.search(sim_message)
-#     assert len(new_messages) == 0  # similar, return []
+    sim_conent = "The request is command-line interface (CLI) snake game"
+    sim_message = Message(content=sim_conent, instruct_content=ic_obj(**out_data), role="user", cause_by=WritePRD)
+    new_messages = memory_storage.search(sim_message)
+    assert len(new_messages) == 0  # similar, return []
 
-#     new_conent = "Incorporate basic features of a snake game such as scoring and increasing difficulty"
-#     new_message = Message(content=new_conent, instruct_content=ic_obj(**out_data), role="user", cause_by=WritePRD)
-#     new_messages = memory_storage.search(new_message)
-#     assert new_messages[0].content == message.content
+    new_conent = "Incorporate basic features of a snake game such as scoring and increasing difficulty"
+    new_message = Message(content=new_conent, instruct_content=ic_obj(**out_data), role="user", cause_by=WritePRD)
+    new_messages = memory_storage.search(new_message)
+    assert new_messages[0].content == message.content
 
-#     memory_storage.clean()
-#     assert memory_storage.is_initialized is False
+    memory_storage.clean()
+    assert memory_storage.is_initialized is False
 
 
 def test_memory_ttl():

--- a/tests/metagpt/memory/test_memory_storage.py
+++ b/tests/metagpt/memory/test_memory_storage.py
@@ -9,9 +9,9 @@ from typing import List
 
 from metagpt.actions import UserRequirement, WritePRD
 from metagpt.actions.action_node import ActionNode
+from metagpt.memory import Memory
 from metagpt.memory.memory_storage import MemoryStorage
 from metagpt.schema import Message
-from metagpt.memory import Memory
 
 
 def test_idea_message():
@@ -74,10 +74,10 @@ def test_actionout_message():
 
 def test_memory_ttl():
     working_memory = Memory()
-    msg = Message(content='This msg will be droped on 2th dialogue.', ttl=1)
-    msg2 = Message(content='This msg will be droped after live 2 turn dialogue.', ttl=2)
-    msg3 = Message(content='This msg will never be droped.')
-    msg4 = Message(content='This msg will never be droped too.')
+    msg = Message(content="This msg will be droped on 2th dialogue.", ttl=1)
+    msg2 = Message(content="This msg will be droped after live 2 turn dialogue.", ttl=2)
+    msg3 = Message(content="This msg will never be droped.")
+    msg4 = Message(content="This msg will never be droped too.")
     # 第1轮对话
     working_memory.add(msg)
     assert msg in working_memory.storage


### PR DESCRIPTION
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

- 给Memory中的message添加存活轮数机制（turns-to-live, ttl），表示message接下来可以存活几轮对话。
    
**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->
- 方便按重要性管理Memory里的message，剔除不重要的，需要遗忘的message，例如，对于bug message，如果解决完bug后，将bug message从Memory中移除是有利的，可以减少Memory中的信息冗余，使得Memory中信息熵更小。

**Result**
<!-- The screenshot/log of unittest/running result -->

**Other**
<!-- Something else about this PR. -->