### PR TITLE
[Bugfix] Set openai proxy for class ZhiPuAPTAPI

### DIFF
--- a/metagpt/provider/zhipuai_api.py
+++ b/metagpt/provider/zhipuai_api.py
@@ -50,6 +50,8 @@ class ZhiPuAIGPTAPI(BaseGPTAPI):
         assert config.zhipuai_api_key
         zhipuai.api_key = config.zhipuai_api_key
         openai.api_key = zhipuai.api_key  # due to use openai sdk, set the api_key but it will't be used.
+        if config.openai_proxy:
+            openai.proxy = config.openai_proxy
 
     def _const_kwargs(self, messages: list[dict]) -> dict:
         kwargs = {"model": self.model, "prompt": messages, "temperature": 0.3}

--- a/tests/metagpt/provider/test_zhipuai_api.py
+++ b/tests/metagpt/provider/test_zhipuai_api.py
@@ -35,3 +35,10 @@ async def test_zhipuai_acompletion(mocker):
 
     assert resp["code"] == 200
     assert "chatglm-turbo" in resp["data"]["choices"][0]["content"]
+
+def test_zhipuai_proxy(mocker):
+    import openai
+    from metagpt.config import CONFIG
+    CONFIG.openai_proxy = 'http://127.0.0.1:8080'
+    _ = ZhiPuAIGPTAPI()
+    assert openai.proxy == CONFIG.openai_proxy


### PR DESCRIPTION
When using ZHIPUAI as the large model provider, it is not possible to access ZHIPUAI in an HTTP proxy environment, and the following error will be reported: openai.error.APIConnectionError: Error communicating with OpenAI

So we need set proxy for class ZhiPuAPTAPI.


**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->
https://github.com/geekan/MetaGPT/issues/629

**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->

**Result**
 ```
@springasa ➜ /workspaces/MetaGPT (bug-fix-proxy) $ pytest -vs tests/metagpt/provider/test_zhipuai_api.py 
2023-12-25 15:48:50.340 | INFO     | metagpt.const:get_metagpt_package_root:32 - Package root set to /workspaces/MetaGPT
============================================================ test session starts =============================================================
platform linux -- Python 3.11.4, pytest-7.3.1, pluggy-1.0.0 -- /usr/local/py-utils/venvs/pytest/bin/python
cachedir: .pytest_cache
rootdir: /workspaces/MetaGPT
plugins: mock-3.11.1, anyio-3.7.1, asyncio-0.23.2
asyncio: mode=Mode.STRICT
collected 3 items                                                                                                                            

tests/metagpt/provider/test_zhipuai_api.py::test_zhipuai_completion PASSED
tests/metagpt/provider/test_zhipuai_api.py::test_zhipuai_acompletion PASSED
tests/metagpt/provider/test_zhipuai_api.py::test_zhipuai_proxy PASSED
 ```
**Other**
<!-- Something else about this PR. -->
