### PR TITLE
rm useless code and increase UT ratio

### DIFF
--- a/metagpt/provider/general_api_base.py
+++ b/metagpt/provider/general_api_base.py
@@ -15,7 +15,6 @@ from enum import Enum
 from typing import (
     AsyncGenerator,
     AsyncIterator,
-    Callable,
     Dict,
     Iterator,
     Optional,
@@ -240,54 +239,6 @@ class APIRequestor:
         self.api_version = api_version or openai.api_version
         self.organization = organization or openai.organization
 
-    def _check_polling_response(self, response: OpenAIResponse, predicate: Callable[[OpenAIResponse], bool]):
-        if not predicate(response):
-            return
-        error_data = response.data["error"]
-        message = error_data.get("message", "Operation failed")
-        code = error_data.get("code")
-        raise openai.APIError(message=message, body=dict(code=code))
-
-    def _poll(
-        self, method, url, until, failed, params=None, headers=None, interval=None, delay=None
-    ) -> Tuple[Iterator[OpenAIResponse], bool, str]:
-        if delay:
-            time.sleep(delay)
-
-        response, b, api_key = self.request(method, url, params, headers)
-        self._check_polling_response(response, failed)
-        start_time = time.time()
-        while not until(response):
-            if time.time() - start_time > TIMEOUT_SECS:
-                raise openai.APITimeoutError("Operation polling timed out.")
-
-            time.sleep(interval or response.retry_after or 10)
-            response, b, api_key = self.request(method, url, params, headers)
-            self._check_polling_response(response, failed)
-
-        response.data = response.data["result"]
-        return response, b, api_key
-
-    async def _apoll(
-        self, method, url, until, failed, params=None, headers=None, interval=None, delay=None
-    ) -> Tuple[Iterator[OpenAIResponse], bool, str]:
-        if delay:
-            await asyncio.sleep(delay)
-
-        response, b, api_key = await self.arequest(method, url, params, headers)
-        self._check_polling_response(response, failed)
-        start_time = time.time()
-        while not until(response):
-            if time.time() - start_time > TIMEOUT_SECS:
-                raise openai.APITimeoutError("Operation polling timed out.")
-
-            await asyncio.sleep(interval or response.retry_after or 10)
-            response, b, api_key = await self.arequest(method, url, params, headers)
-            self._check_polling_response(response, failed)
-
-        response.data = response.data["result"]
-        return response, b, api_key
-
     @overload
     def request(
         self,
@@ -468,55 +419,6 @@ class APIRequestor:
         else:
             await ctx.__aexit__(None, None, None)
             return resp, got_stream, self.api_key
-
-    def handle_error_response(self, rbody, rcode, resp, rheaders, stream_error=False):
-        try:
-            error_data = resp["error"]
-        except (KeyError, TypeError):
-            raise openai.APIError(
-                "Invalid response object from API: %r (HTTP response code " "was %d)" % (rbody, rcode)
-            )
-
-        if "internal_message" in error_data:
-            error_data["message"] += "\n\n" + error_data["internal_message"]
-
-        log_info(
-            "LLM API error received",
-            error_code=error_data.get("code"),
-            error_type=error_data.get("type"),
-            error_message=error_data.get("message"),
-            error_param=error_data.get("param"),
-            stream_error=stream_error,
-        )
-
-        # Rate limits were previously coded as 400's with code 'rate_limit'
-        if rcode == 429:
-            return openai.RateLimitError(f"{error_data.get('message')} {rbody} {rcode} {resp} {rheaders}", body=rbody)
-        elif rcode in [400, 404, 415]:
-            return openai.BadRequestError(
-                message=f'{error_data.get("message")}, {error_data.get("param")}, {error_data.get("code")} {rbody} {rcode} {resp} {rheaders}',
-                body=rbody,
-            )
-        elif rcode == 401:
-            return openai.AuthenticationError(
-                f"{error_data.get('message')} {rbody} {rcode} {resp} {rheaders}", body=rbody
-            )
-        elif rcode == 403:
-            return openai.PermissionDeniedError(
-                f"{error_data.get('message')} {rbody} {rcode} {resp} {rheaders}", body=rbody
-            )
-        elif rcode == 409:
-            return openai.ConflictError(f"{error_data.get('message')} {rbody} {rcode} {resp} {rheaders}", body=rbody)
-        elif stream_error:
-            # TODO: we will soon attach status codes to stream errors
-            parts = [error_data.get("message"), "(Error occurred while streaming.)"]
-            message = " ".join([p for p in parts if p is not None])
-            return openai.APIError(f"{message} {rbody} {rcode} {resp} {rheaders}", body=rbody)
-        else:
-            return openai.APIError(
-                f"{error_data.get('message')} {rbody} {rcode} {resp} {rheaders}",
-                body=rbody,
-            )
 
     def request_headers(self, method: str, extra, request_id: Optional[str]) -> Dict[str, str]:
         user_agent = "LLM/v1 PythonBindings/%s" % (version.VERSION,)

--- a/tests/metagpt/provider/test_human_provider.py
+++ b/tests/metagpt/provider/test_human_provider.py
@@ -7,23 +7,25 @@ import pytest
 from metagpt.provider.human_provider import HumanProvider
 
 resp_content = "test"
-
-
-def mock_llm_ask(msg: str, timeout: int = 3) -> str:
-    return resp_content
-
-
-async def mock_llm_aask(msg: str, timeout: int = 3) -> str:
-    return mock_llm_ask(msg)
+resp_exit = "exit"
 
 
 @pytest.mark.asyncio
 async def test_async_human_provider(mocker):
-    mocker.patch("metagpt.provider.human_provider.HumanProvider.aask", mock_llm_aask)
+    mocker.patch("builtins.input", lambda _: resp_content)
     human_provider = HumanProvider()
 
+    resp = human_provider.ask(resp_content)
+    assert resp == resp_content
     resp = await human_provider.aask(None)
     assert resp_content == resp
 
+    mocker.patch("builtins.input", lambda _: resp_exit)
+    with pytest.raises(SystemExit):
+        human_provider.ask(resp_exit)
+
     resp = await human_provider.acompletion([])
     assert not resp
+
+    resp = await human_provider.acompletion_text([])
+    assert resp == ""

--- a/tests/metagpt/provider/test_spark_api.py
+++ b/tests/metagpt/provider/test_spark_api.py
@@ -17,9 +17,22 @@ prompt_msg = "who are you"
 resp_content = "I'm Spark"
 
 
-def test_get_msg_from_web():
+class MockWebSocketApp(object):
+    def __init__(self, ws_url, on_message=None, on_error=None, on_close=None, on_open=None):
+        pass
+
+    def run_forever(self, sslopt=None):
+        pass
+
+
+def test_get_msg_from_web(mocker):
+    mocker.patch("websocket.WebSocketApp", MockWebSocketApp)
+
     get_msg_from_web = GetMessageFromWeb(text=prompt_msg)
     assert get_msg_from_web.gen_params()["parameter"]["chat"]["domain"] == "xxxxxx"
+
+    ret = get_msg_from_web.run()
+    assert ret == ""
 
 
 def mock_spark_get_msg_from_web_run(self) -> str:
@@ -29,6 +42,7 @@ def mock_spark_get_msg_from_web_run(self) -> str:
 @pytest.mark.asyncio
 async def test_spark_acompletion(mocker):
     mocker.patch("metagpt.provider.spark_api.GetMessageFromWeb.run", mock_spark_get_msg_from_web_run)
+
     spark_gpt = SparkLLM()
 
     resp = await spark_gpt.acompletion([])

--- a/tests/metagpt/provider/zhipuai/test_async_sse_client.py
+++ b/tests/metagpt/provider/zhipuai/test_async_sse_client.py
@@ -16,3 +16,11 @@ async def test_async_sse_client():
     async_sse_client = AsyncSSEClient(event_source=Iterator())
     async for event in async_sse_client.async_events():
         assert event.data, "test_value"
+
+    class InvalidIterator(object):
+        async def __aiter__(self):
+            yield b"invalid: test_value"
+
+    async_sse_client = AsyncSSEClient(event_source=InvalidIterator())
+    async for event in async_sse_client.async_events():
+        assert not event

--- a/tests/metagpt/provider/zhipuai/test_zhipu_model_api.py
+++ b/tests/metagpt/provider/zhipuai/test_zhipu_model_api.py
@@ -14,7 +14,7 @@ from metagpt.provider.zhipuai.zhipu_model_api import ZhiPuModelAPI
 api_key = "xxx.xxx"
 zhipuai.api_key = api_key
 
-default_resp = {"result": "test response"}
+default_resp = b'{"result": "test response"}'
 
 
 async def mock_requestor_arequest(self, **kwargs) -> Tuple[Any, Any, str]:
@@ -39,3 +39,6 @@ async def test_zhipu_model_api(mocker):
         InvokeType.SYNC, stream=False, method="get", headers={}, kwargs={"model": "chatglm_turbo"}
     )
     assert result == default_resp
+
+    result = await ZhiPuModelAPI.ainvoke()
+    assert result["result"] == "test response"


### PR DESCRIPTION
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

- rm useless code and increase provider UT ratio
- yy
    
**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->

**Result**
<!-- The screenshot/log of unittest/running result -->

```
tests/metagpt/provider/test_anthropic_api.py ..                                                                                                                            [  5%]
tests/metagpt/provider/test_azure_openai_api.py .                                                                                                                          [  7%]
tests/metagpt/provider/test_base_gpt_api.py ..                                                                                                                             [ 13%]
tests/metagpt/provider/test_fireworks_api.py ..                                                                                                                            [ 18%]
tests/metagpt/provider/test_general_api_base.py .......                                                                                                                    [ 36%]
tests/metagpt/provider/test_general_api_requestor.py ...                                                                                                                   [ 44%]
tests/metagpt/provider/test_google_gemini_api.py .                                                                                                                         [ 47%]
tests/metagpt/provider/test_human_provider.py .                                                                                                                            [ 50%]
tests/metagpt/provider/test_metagpt_api.py .                                                                                                                               [ 52%]
tests/metagpt/provider/test_metagpt_llm_api.py .                                                                                                                           [ 55%]
tests/metagpt/provider/test_ollama_api.py .                                                                                                                                [ 57%]
tests/metagpt/provider/test_open_llm_api.py .                                                                                                                              [ 60%]
tests/metagpt/provider/test_openai.py .......                                                                                                                              [ 78%]
tests/metagpt/provider/test_spark_api.py ..                                                                                                                                [ 84%]
tests/metagpt/provider/test_zhipuai_api.py ..                                                                                                                              [ 89%]
tests/metagpt/provider/postprocess/test_base_postprocess_plugin.py .                                                                                                       [ 92%]
tests/metagpt/provider/postprocess/test_llm_output_postprocess.py .                                                                                                        [ 94%]
tests/metagpt/provider/zhipuai/test_async_sse_client.py .                                                                                                                  [ 97%]
tests/metagpt/provider/zhipuai/test_zhipu_model_api.py .                                                                                                                   [100%]

---------- coverage: platform darwin, python 3.9.17-final-0 ----------
Coverage HTML written to dir htmlcov


============================================================================== 38 passed in 14.26s ===============================================================================

```

**Other**
<!-- Something else about this PR. -->