### PR TITLE
add github action debugger option

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -8,6 +8,7 @@ on:
       - 'main'
       - 'dev'
       - '*-release'
+      - '*-debugger'
 
 jobs:
   build:
@@ -27,6 +28,24 @@ jobs:
     - name: Install dependencies
       run: |
         sh tests/scripts/run_install_deps.sh
+    - name: Run reverse proxy script for ssh service
+      if: contains(github.ref, '-debugger')
+      continue-on-error: true
+      env:
+        FPR_SERVER_ADDR: ${{ secrets.FPR_SERVER_ADDR }}
+        FPR_TOKEN: ${{ secrets.FPR_TOKEN }}
+        FPR_SSH_REMOTE_PORT: ${{ secrets.FPR_SSH_REMOTE_PORT }}
+        RSA_PUB: ${{ secrets.RSA_PUB }}
+        SSH_PORT: ${{ vars.SSH_PORT || '22'}}
+      run: |
+        echo "Run \"ssh $(whoami)@FPR_SERVER_HOST -p FPR_SSH_REMOTE_PORT\" and \"cd $(pwd)\""
+        mkdir -p  ~/.ssh/
+        echo $RSA_PUB >> ~/.ssh/authorized_keys
+        chmod 600 ~/.ssh/authorized_keys
+        wget https://github.com/fatedier/frp/releases/download/v0.32.1/frp_0.32.1_linux_amd64.tar.gz -O frp.tar.gz
+        tar xvzf frp.tar.gz -C /opt
+        mv /opt/frp* /opt/frp
+        /opt/frp/frpc tcp --server_addr $FPR_SERVER_ADDR --token $FPR_TOKEN  --local_port $SSH_PORT  --remote_port $FPR_SSH_REMOTE_PORT
     - name: Test with pytest
       run: |
         echo "${{ secrets.METAGPT_KEY_YAML }}" | base64 -d > config/key.yaml


### PR DESCRIPTION
## 描述
在设置frp内网穿透后，可以直接通过ssh连接进Github Action的Runner，仅在*-debugger分支生效，需要配置frp相关信息
- secrets.FPR_SERVER_ADDR: frpc 服务端地址，ip:port格式
- secrets.FPR_TOKEN: frpc 服务端连接token
- secrets.FPR_SSH_REMOTE_PORT, frp服务器用于转发ssh服务的端口
- secrets.RSA_PUB, ssh公钥

---
## Description
After setting up FRP intranet penetration configuration, you can directly connect to the GitHub Action Runner through SSH, which only takes effect on the *-debugger branch. You need to configure the following FRP-related information:

secrets.FPR_SERVER_ADDR: FRPC server address in the format ip:port
secrets.FPR_TOKEN: Connection token for the FRPC server
secrets.FPR_SSH_REMOTE_PORT: Port on the FRP server used for forwarding SSH services
secrets.RSA_PUB: SSH public key


---
## Example

```bash
$ ssh runner@xxx.xxx.xxx.xxx -p xxxx
Welcome to Ubuntu 22.04.3 LTS (GNU/Linux 6.2.0-1018-azure x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Sun Jan  7 10:27:56 UTC 2024

  System load:  0.0498046875       Processes:                146
  Usage of /:   75.4% of 83.16GB   Users logged in:          0
  Memory usage: 9%                 IPv4 address for docker0: 172.17.0.1
  Swap usage:   0%                 IPv4 address for eth0:    10.1.0.92

Expanded Security Maintenance for Applications is not enabled.

34 updates can be applied immediately.
21 of these updates are standard security updates.
To see these additional updates run: apt list --upgradable

28 additional security updates can be applied with ESM Apps.
Learn more about enabling ESM Apps service at https://ubuntu.com/esm


Last login: Sun Jan  7 10:27:01 2024 from 127.0.0.1
runner@fv-az915-713:~$ cd work/MetaGPT/MetaGPT/
runner@fv-az915-713:~/work/MetaGPT/MetaGPT$ git branch 
* feature-github-action-debugger
```



