### PR TITLE
add ActionNode review/revise

### DIFF
--- a/metagpt/actions/action_node.py
+++ b/metagpt/actions/action_node.py
@@ -553,7 +553,8 @@ class ActionNode:
 
         include_keys = list(review_comments.keys())
 
-        # generate revise content
+        # generate revise content, two-steps
+        # step1, find the needed revise keys from review comments to makeup prompt template
         nodes_output = self._makeup_nodes_output_with_comment(review_comments)
         keys = self.keys()
         exclude_keys = list(set(keys).difference(include_keys))
@@ -567,6 +568,7 @@ class ActionNode:
             constraint=FORMAT_CONSTRAINT,
         )
 
+        # step2, use `_aask_v1` to get revise structure result
         output_mapping = self.get_mapping(mode="auto", exclude=exclude_keys)
         output_class_name = f"{self.key}_AN_REVISE"
         content, scontent = await self._aask_v1(

--- a/metagpt/actions/action_node.py
+++ b/metagpt/actions/action_node.py
@@ -9,7 +9,8 @@ NOTE: You should use typing.List instead of list to do type annotation. Because 
   we can use typing to extract the type of the node, but we cannot use built-in list to extract.
 """
 import json
-from typing import Any, Dict, List, Optional, Tuple, Type
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from pydantic import BaseModel, create_model, model_validator
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -19,6 +20,18 @@ from metagpt.llm import BaseLLM
 from metagpt.logs import logger
 from metagpt.provider.postprocess.llm_output_postprocess import llm_output_postprocess
 from metagpt.utils.common import OutputParser, general_after_log
+from metagpt.utils.human_interaction import HumanInteraction
+
+
+class ReviewMode(Enum):
+    HUMAN = "human"
+    AUTO = "auto"
+
+
+class ReviseMode(Enum):
+    HUMAN = "human"
+    AUTO = "auto"
+
 
 TAG = "CONTENT"
 
@@ -43,6 +56,58 @@ SIMPLE_TEMPLATE = """
 
 ## action
 Follow instructions of nodes, generate output and make sure it follows the format example.
+"""
+
+REVIEW_TEMPLATE = """
+## context
+Compare the keys of nodes_output and the corresponding requirements one by one. If a key that does not match the requirement is found, provide the comment content on how to modify it. No output is required for matching keys.
+
+### nodes_output
+{nodes_output}
+
+-----
+
+## format example
+[{tag}]
+{{
+    "key1": "comment1",
+    "key2": "comment2",
+    "keyn": "commentn"
+}}
+[/{tag}]
+
+## nodes: "<node>: <type>  # <instruction>"
+- key1: <class \'str\'> # the first key name of mismatch key
+- key2: <class \'str\'> # the second key name of mismatch key
+- keyn: <class \'str\'> # the last key name of mismatch key
+
+## constraint
+{constraint}
+
+## action
+generate output and make sure it follows the format example.
+"""
+
+REVISE_TEMPLATE = """
+## context
+change the nodes_output key's value to meet its comment and no need to add extra comment.
+
+### nodes_output
+{nodes_output}
+
+-----
+
+## format example
+{example}
+
+## nodes: "<node>: <type>  # <instruction>"
+{instruction}
+
+## constraint
+{constraint}
+
+## action
+generate output and make sure it follows the format example.
 """
 
 
@@ -105,6 +170,9 @@ class ActionNode:
         """增加子ActionNode"""
         self.children[node.key] = node
 
+    def get_child(self, key: str) -> Union["ActionNode", None]:
+        return self.children.get(key, None)
+
     def add_children(self, nodes: List["ActionNode"]):
         """批量增加子ActionNode"""
         for node in nodes:
@@ -152,6 +220,11 @@ class ActionNode:
         new_class = create_model(class_name, __validators__=validators, **mapping)
         return new_class
 
+    def create_class(self, mode: str = "auto", class_name: str = None, exclude=None):
+        class_name = class_name if class_name else f"{self.key}_AN"
+        mapping = self.get_mapping(mode=mode, exclude=exclude)
+        return self.create_model_class(class_name, mapping)
+
     def create_children_class(self, exclude=None):
         """使用object内有的字段直接生成model_class"""
         class_name = f"{self.key}_AN"
@@ -185,6 +258,25 @@ class ActionNode:
             node_dict.update(child_node.to_dict(format_func))
 
         return node_dict
+
+    def update_instruct_content(self, incre_data: dict[str, Any]):
+        assert self.instruct_content
+        origin_sc_dict = self.instruct_content.model_dump()
+        origin_sc_dict.update(incre_data)
+        output_class = self.create_class()
+        self.instruct_content = output_class(**origin_sc_dict)
+
+    def keys(self, mode: str = "auto") -> list:
+        if mode == "children" or (mode == "auto" and self.children):
+            keys = []
+        else:
+            keys = [self.key]
+        if mode == "root":
+            return keys
+
+        for _, child_node in self.children.items():
+            keys.append(child_node.key)
+        return keys
 
     def compile_to(self, i: Dict, schema, kv_sep) -> str:
         if schema == "json":
@@ -343,7 +435,170 @@ class ActionNode:
                 if exclude and i.key in exclude:
                     continue
                 child = await i.simple_fill(schema=schema, mode=mode, timeout=timeout, exclude=exclude)
-                tmp.update(child.instruct_content.dict())
+                tmp.update(child.instruct_content.model_dump())
             cls = self.create_children_class()
             self.instruct_content = cls(**tmp)
             return self
+
+    async def human_review(self) -> dict[str, str]:
+        review_comments = HumanInteraction().interact_with_instruct_content(
+            instruct_content=self.instruct_content, interact_type="review"
+        )
+
+        return review_comments
+
+    def _makeup_nodes_output_with_req(self) -> dict[str, str]:
+        instruct_content_dict = self.instruct_content.model_dump()
+        nodes_output = {}
+        for key, value in instruct_content_dict.items():
+            child = self.get_child(key)
+            nodes_output[key] = {"value": value, "requirement": child.instruction if child else self.instruction}
+        return nodes_output
+
+    async def auto_review(self, template: str = REVIEW_TEMPLATE) -> dict[str, str]:
+        """use key's output value and its instruction to review the modification comment"""
+        nodes_output = self._makeup_nodes_output_with_req()
+        """nodes_output format:
+        {
+            "key": {"value": "output value", "requirement": "key instruction"}
+        }
+        """
+        if not nodes_output:
+            return dict()
+
+        prompt = template.format(
+            nodes_output=json.dumps(nodes_output, ensure_ascii=False, indent=4), tag=TAG, constraint=FORMAT_CONSTRAINT
+        )
+
+        content = await self.llm.aask(prompt)
+        # Extract the dict of mismatch key and its comment. Due to the mismatch keys are unknown, here use the keys
+        # of ActionNode to judge if exist in `content` and then follow the `data_mapping` method to create model class.
+        keys = self.keys()
+        include_keys = []
+        for key in keys:
+            if f'"{key}":' in content:
+                include_keys.append(key)
+        if not include_keys:
+            return dict()
+
+        exclude_keys = list(set(keys).difference(include_keys))
+        output_class_name = f"{self.key}_AN_REVIEW"
+        output_class = self.create_class(class_name=output_class_name, exclude=exclude_keys)
+        parsed_data = llm_output_postprocess(
+            output=content, schema=output_class.model_json_schema(), req_key=f"[/{TAG}]"
+        )
+        instruct_content = output_class(**parsed_data)
+        return instruct_content.model_dump()
+
+    async def simple_review(self, review_mode: ReviewMode = ReviewMode.AUTO):
+        # generate review comments
+        if review_mode == ReviewMode.HUMAN:
+            review_comments = await self.human_review()
+        else:
+            review_comments = await self.auto_review()
+
+        if not review_comments:
+            logger.warning("There are no review comments")
+        return review_comments
+
+    async def review(self, strgy: str = "simple", review_mode: ReviewMode = ReviewMode.AUTO):
+        """only give the review comment of each exist and mismatch key
+
+        :param strgy: simple/complex
+         - simple: run only once
+         - complex: run each node
+        """
+        if not hasattr(self, "llm"):
+            raise RuntimeError("use `review` after `fill`")
+        assert review_mode in ReviewMode
+        assert self.instruct_content, 'review only support with `schema != "raw"`'
+
+        if strgy == "simple":
+            review_comments = await self.simple_review(review_mode)
+        elif strgy == "complex":
+            # review each child node one-by-one
+            review_comments = {}
+            for _, child in self.children.items():
+                child_review_comment = await child.simple_review(review_mode)
+                review_comments.update(child_review_comment)
+
+        return review_comments
+
+    async def human_revise(self) -> dict[str, str]:
+        review_contents = HumanInteraction().interact_with_instruct_content(
+            instruct_content=self.instruct_content, mapping=self.get_mapping(mode="auto"), interact_type="revise"
+        )
+        # re-fill the ActionNode
+        self.update_instruct_content(review_contents)
+        return review_contents
+
+    def _makeup_nodes_output_with_comment(self, review_comments: dict[str, str]) -> dict[str, str]:
+        instruct_content_dict = self.instruct_content.model_dump()
+        nodes_output = {}
+        for key, value in instruct_content_dict.items():
+            if key in review_comments:
+                nodes_output[key] = {"value": value, "comment": review_comments[key]}
+        return nodes_output
+
+    async def auto_revise(self, template: str = REVISE_TEMPLATE) -> dict[str, str]:
+        """revise the value of incorrect keys"""
+        # generate review comments
+        review_comments: dict = await self.auto_review()
+        include_keys = list(review_comments.keys())
+
+        # generate revise content
+        nodes_output = self._makeup_nodes_output_with_comment(review_comments)
+        keys = self.keys()
+        exclude_keys = list(set(keys).difference(include_keys))
+        example = self.compile_example(schema="json", mode="auto", tag=TAG, exclude=exclude_keys)
+        instruction = self.compile_instruction(schema="markdown", mode="auto", exclude=exclude_keys)
+
+        prompt = template.format(
+            nodes_output=json.dumps(nodes_output, ensure_ascii=False, indent=4),
+            example=example,
+            instruction=instruction,
+            constraint=FORMAT_CONSTRAINT,
+        )
+
+        output_mapping = self.get_mapping(mode="auto", exclude=exclude_keys)
+        output_class_name = f"{self.key}_AN_REVISE"
+        content, scontent = await self._aask_v1(
+            prompt=prompt, output_class_name=output_class_name, output_data_mapping=output_mapping, schema="json"
+        )
+
+        # re-fill the ActionNode
+        sc_dict = scontent.model_dump()
+        self.update_instruct_content(sc_dict)
+        return sc_dict
+
+    async def simple_revise(self, revise_mode: ReviseMode = ReviseMode.AUTO) -> dict[str, str]:
+        if revise_mode == ReviseMode.HUMAN:
+            revise_contents = await self.human_revise()
+        else:
+            revise_contents = await self.auto_revise()
+
+        return revise_contents
+
+    async def revise(self, strgy: str = "simple", revise_mode: ReviseMode = ReviseMode.AUTO) -> dict[str, str]:
+        """revise the content of ActionNode and update the instruct_content
+
+        :param strgy: simple/complex
+         - simple: run only once
+         - complex: run each node
+        """
+        if not hasattr(self, "llm"):
+            raise RuntimeError("use `revise` after `fill`")
+        assert revise_mode in ReviseMode
+        assert self.instruct_content, 'revise only support with `schema != "raw"`'
+
+        if strgy == "simple":
+            revise_contents = await self.simple_revise(revise_mode)
+        elif strgy == "complex":
+            # revise each child node one-by-one
+            revise_contents = {}
+            for _, child in self.children.items():
+                child_revise_content = await child.simple_revise(revise_mode)
+                revise_contents.update(child_revise_content)
+            self.update_instruct_content(revise_contents)
+
+        return revise_contents

--- a/metagpt/actions/action_node.py
+++ b/metagpt/actions/action_node.py
@@ -29,8 +29,9 @@ class ReviewMode(Enum):
 
 
 class ReviseMode(Enum):
-    HUMAN = "human"
-    AUTO = "auto"
+    HUMAN = "human"  # human revise
+    HUMAN_REVIEW = "human_review"  # human-review and auto-revise
+    AUTO = "auto"  # auto-review and auto-revise
 
 
 TAG = "CONTENT"
@@ -540,10 +541,16 @@ class ActionNode:
                 nodes_output[key] = {"value": value, "comment": review_comments[key]}
         return nodes_output
 
-    async def auto_revise(self, template: str = REVISE_TEMPLATE) -> dict[str, str]:
+    async def auto_revise(
+        self, revise_mode: ReviseMode = ReviseMode.AUTO, template: str = REVISE_TEMPLATE
+    ) -> dict[str, str]:
         """revise the value of incorrect keys"""
         # generate review comments
-        review_comments: dict = await self.auto_review()
+        if revise_mode == ReviseMode.AUTO:
+            review_comments: dict = await self.auto_review()
+        elif revise_mode == ReviseMode.HUMAN_REVIEW:
+            review_comments: dict = await self.human_review()
+
         include_keys = list(review_comments.keys())
 
         # generate revise content
@@ -575,7 +582,7 @@ class ActionNode:
         if revise_mode == ReviseMode.HUMAN:
             revise_contents = await self.human_revise()
         else:
-            revise_contents = await self.auto_revise()
+            revise_contents = await self.auto_revise(revise_mode)
 
         return revise_contents
 

--- a/metagpt/utils/human_interaction.py
+++ b/metagpt/utils/human_interaction.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# @Desc   : human interaction to get required type text
+
+import json
+from typing import Any, Tuple, Type
+
+from pydantic import BaseModel
+
+from metagpt.logs import logger
+from metagpt.utils.common import import_class
+
+
+class HumanInteraction(object):
+    stop_list = ("q", "quit", "exit")
+
+    def multilines_input(self, prompt: str = "Enter: ") -> str:
+        logger.warning("Enter your content, use Ctrl-D or Ctrl-Z ( windows ) to save it.")
+        logger.info(f"{prompt}\n")
+        lines = []
+        while True:
+            try:
+                line = input()
+                lines.append(line)
+            except EOFError:
+                break
+        return "".join(lines)
+
+    def check_input_type(self, input_str: str, req_type: Type) -> Tuple[bool, Any]:
+        check_ret = True
+        if req_type == str:
+            # required_type = str, just return True
+            return check_ret, input_str
+        try:
+            input_str = input_str.strip()
+            data = json.loads(input_str)
+        except Exception:
+            return False, None
+
+        actionnode_class = import_class("ActionNode", "metagpt.actions.action_node")  # avoid circular import
+        tmp_key = "tmp"
+        tmp_cls = actionnode_class.create_model_class(class_name=tmp_key.upper(), mapping={tmp_key: (req_type, ...)})
+        try:
+            _ = tmp_cls(**{tmp_key: data})
+        except Exception:
+            check_ret = False
+        return check_ret, data
+
+    def input_until_valid(self, prompt: str, req_type: Type) -> Any:
+        # check the input with req_type until it's ok
+        while True:
+            input_content = self.multilines_input(prompt)
+            check_ret, structure_content = self.check_input_type(input_content, req_type)
+            if check_ret:
+                break
+            else:
+                logger.error(f"Input content can't meet required_type: {req_type}, please Re-Enter.")
+        return structure_content
+
+    def input_num_until_valid(self, num_max: int) -> int:
+        while True:
+            input_num = input("Enter the num of the interaction key: ")
+            input_num = input_num.strip()
+            if input_num in self.stop_list:
+                return input_num
+            try:
+                input_num = int(input_num)
+                if 0 <= input_num < num_max:
+                    return input_num
+            except Exception:
+                pass
+
+    def interact_with_instruct_content(
+        self, instruct_content: BaseModel, mapping: dict = dict(), interact_type: str = "review"
+    ) -> dict[str, Any]:
+        assert interact_type in ["review", "revise"]
+        assert instruct_content
+        instruct_content_dict = instruct_content.model_dump()
+        num_fields_map = dict(zip(range(0, len(instruct_content_dict)), instruct_content_dict.keys()))
+        logger.info(
+            f"\n{interact_type.upper()} interaction\n"
+            f"Interaction data: {num_fields_map}\n"
+            f"Enter the num to interact with corresponding field or `q`/`quit`/`exit` to stop interaction.\n"
+            f"Enter the field content until it meet field required type.\n"
+        )
+
+        interact_contents = {}
+        while True:
+            input_num = self.input_num_until_valid(len(instruct_content_dict))
+            if input_num in self.stop_list:
+                logger.warning("Stop human interaction")
+                break
+
+            field = num_fields_map.get(input_num)
+            logger.info(f"You choose to interact with field: {field}, and do a `{interact_type}` operation.")
+
+            if interact_type == "review":
+                prompt = "Enter your review comment: "
+                req_type = str
+            else:
+                prompt = "Enter your revise content: "
+                req_type = mapping.get(field)[0]  # revise need input content match the required_type
+
+            field_content = self.input_until_valid(prompt=prompt, req_type=req_type)
+            interact_contents[field] = field_content
+
+        return interact_contents

--- a/tests/metagpt/utils/test_human_interaction.py
+++ b/tests/metagpt/utils/test_human_interaction.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# @Desc   : unittest of human_interaction
+
+import pytest
+
+from pydantic import BaseModel
+
+from metagpt.utils.human_interaction import HumanInteraction
+
+
+class InstructContent(BaseModel):
+    test_field1: str = ""
+    test_field2: list[str] = []
+
+
+data_mapping = {
+    "test_field1": (str, ...),
+    "test_field2": (list[str], ...)
+}
+
+human_interaction = HumanInteraction()
+
+
+def test_input_num(mocker):
+    mocker.patch("builtins.input", lambda _: "quit")
+
+    interact_contents = human_interaction.interact_with_instruct_content(InstructContent(), data_mapping)
+    assert len(interact_contents) == 0
+
+    mocker.patch("builtins.input", lambda _: "1")
+    input_num = human_interaction.input_num_until_valid(2)
+    assert input_num == 1
+
+
+def test_check_input_type():
+    ret, _ = human_interaction.check_input_type(input_str="test string",
+                                                req_type=str)
+    assert ret
+
+    ret, _ = human_interaction.check_input_type(input_str='["test string"]',
+                                                req_type=list[str])
+    assert ret
+
+    ret, _ = human_interaction.check_input_type(input_str='{"key", "value"}',
+                                                req_type=list[str])
+    assert not ret
+
+
+global_index = 0
+
+
+def mock_input(*args, **kwargs):
+    """there are multi input call, return it by global_index"""
+    arr = ["1", '["test"]', "ignore", "quit"]
+    global global_index
+    global_index += 1
+    if global_index == 3:
+        raise EOFError()
+    val = arr[global_index-1]
+    return val
+
+
+def test_human_interact_valid_content(mocker):
+    mocker.patch("builtins.input", mock_input)
+    input_contents = HumanInteraction().interact_with_instruct_content(InstructContent(), data_mapping, "review")
+    assert len(input_contents) == 1
+    assert input_contents["test_field2"] == '["test"]'
+
+    global global_index
+    global_index = 0
+    input_contents = HumanInteraction().interact_with_instruct_content(InstructContent(), data_mapping, "revise")
+    assert len(input_contents) == 1
+    assert input_contents["test_field2"] == ["test"]

--- a/tests/metagpt/utils/test_human_interaction.py
+++ b/tests/metagpt/utils/test_human_interaction.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 # @Desc   : unittest of human_interaction
 
-import pytest
-
 from pydantic import BaseModel
 
 from metagpt.utils.human_interaction import HumanInteraction
@@ -14,10 +12,7 @@ class InstructContent(BaseModel):
     test_field2: list[str] = []
 
 
-data_mapping = {
-    "test_field1": (str, ...),
-    "test_field2": (list[str], ...)
-}
+data_mapping = {"test_field1": (str, ...), "test_field2": (list[str], ...)}
 
 human_interaction = HumanInteraction()
 
@@ -34,16 +29,13 @@ def test_input_num(mocker):
 
 
 def test_check_input_type():
-    ret, _ = human_interaction.check_input_type(input_str="test string",
-                                                req_type=str)
+    ret, _ = human_interaction.check_input_type(input_str="test string", req_type=str)
     assert ret
 
-    ret, _ = human_interaction.check_input_type(input_str='["test string"]',
-                                                req_type=list[str])
+    ret, _ = human_interaction.check_input_type(input_str='["test string"]', req_type=list[str])
     assert ret
 
-    ret, _ = human_interaction.check_input_type(input_str='{"key", "value"}',
-                                                req_type=list[str])
+    ret, _ = human_interaction.check_input_type(input_str='{"key", "value"}', req_type=list[str])
     assert not ret
 
 
@@ -57,7 +49,7 @@ def mock_input(*args, **kwargs):
     global_index += 1
     if global_index == 3:
         raise EOFError()
-    val = arr[global_index-1]
+    val = arr[global_index - 1]
     return val
 
 


### PR DESCRIPTION
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

for raw requirement, search `ActionNode提供Review、Revise` in feishu.

- add ActionNode review/revise in sinple/complex strategy and human/auto mode
- add its unittest
    
**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->

**Result**
<!-- The screenshot/log of unittest/running result -->

```
(metagpt_v2) MacBook-Pro:MetaGPT xxxx$ pytest -s tests/metagpt/utils/test_human_interaction.py
.

=============================================================================== 3 passed in 0.69s ================================================================================
```

```
(metagpt_v2) MacBook-Pro:MetaGPT xxx$ pytest -s tests/metagpt/actions/test_action_node.py

=================================================================== 11 passed, 8 warnings in 91.44s (0:01:31) ==================================================================
```

[revise_review_gpt_raw_prompt_output.log](https://github.com/geekan/MetaGPT/files/13857653/revise_review_gpt_raw_prompt_output.log)


**Other**
<!-- Something else about this PR. -->