### PR TITLE
Fix: requirements.txt was not written to the disk

### DIFF
--- a/metagpt/actions/project_management.py
+++ b/metagpt/actions/project_management.py
@@ -100,7 +100,7 @@ class WriteTasks(Action):
     @staticmethod
     async def _update_requirements(doc):
         m = json.loads(doc.content)
-        packages = set(m.get("Required Python third-party packages", set()))
+        packages = set(m.get("Required Python packages", set()))
         file_repo = CONFIG.git_repo.new_file_repository()
         requirement_doc = await file_repo.get(filename=PACKAGE_REQUIREMENTS_FILENAME)
         if not requirement_doc:


### PR DESCRIPTION
While the Python packages requirements are correctly detected and saved into the json task file, requirements.txt was always empty. Since it was trying to get packages with the wrong key, packages were always empty when writing in requirements.txt


**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->
    
**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->

**Result**
<!-- The screenshot/log of unittest/running result -->

**Other**
<!-- Something else about this PR. -->