### PR TITLE
In some cases when trying to create tests, metagpt crashes.

### DIFF
--- a/metagpt/roles/qa_engineer.py
+++ b/metagpt/roles/qa_engineer.py
@@ -63,6 +63,8 @@ class QaEngineer(Role):
             if not filename or "test" in filename:
                 continue
             code_doc = await src_file_repo.get(filename)
+            if not code_doc:
+                continue
             test_doc = await tests_file_repo.get("test_" + code_doc.filename)
             if not test_doc:
                 test_doc = Document(


### PR DESCRIPTION
Adding some more safeguards to handle the case where code_doc is None.

```

| ERROR    | metagpt.utils.common:wrapper:492 - Exception occurs, start to serialize the project, exp:
Traceback (most recent call last):
  File "/home/arnaud/dev/GenAI/MetaGPT/metagpt/utils/common.py", line 501, in wrapper
    return await func(self, *args, **kwargs)
  File "/home/arnaud/dev/GenAI/MetaGPT/metagpt/roles/role.py", line 485, in run
    rsp = await self.react()
AttributeError: 'NoneType' object has no attribute 'filename'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/arnaud/dev/GenAI/MetaGPT/metagpt/utils/common.py", line 487, in wrapper
    result = await func(self, *args, **kwargs)
  File "/home/arnaud/dev/GenAI/MetaGPT/metagpt/team.py", line 134, in run
    await self.env.run()
Exception: Traceback (most recent call last):
  File "/home/arnaud/dev/GenAI/MetaGPT/metagpt/utils/common.py", line 501, in wrapper
    return await func(self, *args, **kwargs)
  File "/home/arnaud/dev/GenAI/MetaGPT/metagpt/roles/role.py", line 485, in run
    rsp = await self.react()
  File "/home/arnaud/dev/GenAI/MetaGPT/metagpt/roles/role.py", line 453, in react
    rsp = await self._react()
  File "/home/arnaud/dev/GenAI/MetaGPT/metagpt/roles/role.py", line 432, in _react
    rsp = await self._act()  # 这个rsp是否需要publish_message？
  File "/home/arnaud/dev/GenAI/MetaGPT/metagpt/roles/qa_engineer.py", line 168, in _act
    await self._write_test(msg)
  File "/home/arnaud/dev/GenAI/MetaGPT/metagpt/roles/qa_engineer.py", line 66, in _write_test
    test_doc = await tests_file_repo.get("test_" + code_doc.filename)
AttributeError: 'NoneType' object has no attribute 'filename'
```