### PR TITLE
Fix test generation

### DIFF
--- a/metagpt/actions/run_code.py
+++ b/metagpt/actions/run_code.py
@@ -16,6 +16,7 @@
             class.
 """
 import subprocess
+from pathlib import Path
 from typing import Tuple
 
 from pydantic import Field
@@ -152,11 +153,23 @@ class RunCode(Action):
         return subprocess.run(cmd, check=check, cwd=cwd, env=env)
 
     @staticmethod
-    def _install_dependencies(working_directory, env):
+    def _install_requirements(working_directory, env):
+        file_path = Path(working_directory) / "requirements.txt"
+        if not file_path.exists():
+            return
+        if file_path.stat().st_size == 0:
+            return
         install_command = ["python", "-m", "pip", "install", "-r", "requirements.txt"]
         logger.info(" ".join(install_command))
         RunCode._install_via_subprocess(install_command, check=True, cwd=working_directory, env=env)
 
+    @staticmethod
+    def _install_pytest(working_directory, env):
         install_pytest_command = ["python", "-m", "pip", "install", "pytest"]
         logger.info(" ".join(install_pytest_command))
         RunCode._install_via_subprocess(install_pytest_command, check=True, cwd=working_directory, env=env)
+
+    @staticmethod
+    def _install_dependencies(working_directory, env):
+        RunCode._install_requirements(working_directory, env)
+        RunCode._install_pytest(working_directory, env)

--- a/metagpt/roles/qa_engineer.py
+++ b/metagpt/roles/qa_engineer.py
@@ -65,6 +65,8 @@ class QaEngineer(Role):
             code_doc = await src_file_repo.get(filename)
             if not code_doc:
                 continue
+            if not code_doc.filename.endswith(".py"):
+                continue
             test_doc = await tests_file_repo.get("test_" + code_doc.filename)
             if not test_doc:
                 test_doc = Document(


### PR DESCRIPTION
* Stop generating unit tests for non-python code files (e.g. ReadMe.md)
* Stop trying to install dependencies when there are none