### PR TITLE
bugfix: DEFAULT_PROVIDER config is invalid

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,6 +4,9 @@
 #### Project Path Setting
 # WORKSPACE_PATH: "Path for placing output files"
 
+### Default LLM Provider Setting
+DEFAULT_PROVIDER: openai
+
 #### if OpenAI
 ## The official OPENAI_BASE_URL is https://api.openai.com/v1
 ## If the official OPENAI_BASE_URL is not available, we recommend using the [openai-forward](https://github.com/beidongjiedeguang/openai-forward).
@@ -15,7 +18,6 @@ OPENAI_API_MODEL: "gpt-4-1106-preview"
 MAX_TOKENS: 4096
 RPM: 10
 TIMEOUT: 60 # Timeout for llm invocation
-#DEFAULT_PROVIDER: openai
 
 #### if Spark
 #SPARK_APPID : "YOUR_APPID"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,6 +5,7 @@
 # WORKSPACE_PATH: "Path for placing output files"
 
 ### Default LLM Provider Setting
+## Optional LLM: openai, azure_openai, gemini, spark, zhipuai, fireworks, open_llm, ollama, anthropic, metagpt
 DEFAULT_PROVIDER: openai
 
 #### if OpenAI

--- a/metagpt/config.py
+++ b/metagpt/config.py
@@ -107,15 +107,15 @@ class Config(metaclass=Singleton):
             LLMProviderEnum.OLLAMA: self._is_valid_llm_key(self.OLLAMA_API_BASE),
         }
         provider = None
-        for k, v in mappings.items():
-            if v:
-                provider = k
-                break
+        if self.DEFAULT_PROVIDER:
+            provider = LLMProviderEnum(self.DEFAULT_PROVIDER)
+        else:
+            for k, v in mappings.items():
+                if v:
+                    provider = k
+                    break
         if provider is None:
-            if self.DEFAULT_PROVIDER:
-                provider = LLMProviderEnum(self.DEFAULT_PROVIDER)
-            else:
-                raise NotConfiguredException("You should config a LLM configuration first")
+            raise NotConfiguredException("You should config a LLM configuration first")
 
         if provider is LLMProviderEnum.GEMINI and not require_python_version(req_version=(3, 10)):
             warnings.warn("Use Gemini requires Python >= 3.10")


### PR DESCRIPTION
1. As long as `self._is_valid_llm_key(self.OPENAI_API_KEY) and not self.OPENAI_API_TYPE and self.OPENAI_API_MODEL` is true, LLM will use openai, `DEFAULT_PROVIDER` is invalid.
2. If users want to change to other LLM, they have to comment out `OPENAI_API_KEY` in the config if they have set it before. 