### PR TITLE
Fix prompt logic when defining to who the message should be sent.

### DIFF
--- a/metagpt/actions/run_code.py
+++ b/metagpt/actions/run_code.py
@@ -42,8 +42,8 @@ Determine the ONE file to rewrite in order to fix the error, for example, xyz.py
 Determine if all of the code works fine, if so write PASS, else FAIL,
 WRITE ONLY ONE WORD, PASS OR FAIL, IN THIS SECTION
 ## Send To:
-Please write Engineer if the errors are due to problematic development codes, and QaEngineer to problematic test codes, and NoOne if there are no errors,
-WRITE ONLY ONE WORD, Engineer OR QaEngineer OR NoOne, IN THIS SECTION.
+Please write NoOne if there are no errors, Engineer if the errors are due to problematic development codes, else QaEngineer,
+WRITE ONLY ONE WORD, NoOne OR Engineer OR QaEngineer, IN THIS SECTION.
 ---
 You should fill in necessary instruction, status, send to, and finally return all content between the --- segment line.
 """


### PR DESCRIPTION
With the previous logic, it was possible to reach an undefined state where it was not meant to be sent to Engineer, QaEngineer, or NoOne.

