### PR TITLE
fixbug: compatible with windows path

### DIFF
--- a/metagpt/actions/design_api.py
+++ b/metagpt/actions/design_api.py
@@ -46,7 +46,7 @@ class WriteDesign(Action):
     )
 
     async def run(self, with_messages: Message, schema: str = None):
-        # Use `git status` to identify which PRD documents have been modified in the `docs/prds` directory.
+        # Use `git status` to identify which PRD documents have been modified in the `docs/prd` directory.
         changed_prds = self.repo.docs.prd.changed_files
         # Use `git status` to identify which design documents in the `docs/system_designs` directory have undergone
         # changes.

--- a/metagpt/actions/prepare_documents.py
+++ b/metagpt/actions/prepare_documents.py
@@ -48,5 +48,5 @@ class PrepareDocuments(Action):
         # Write the newly added requirements from the main parameter idea to `docs/requirement.txt`.
         doc = await self.repo.docs.save(filename=REQUIREMENT_FILENAME, content=with_messages[0].content)
         # Send a Message notification to the WritePRD action, instructing it to process requirements using
-        # `docs/requirement.txt` and `docs/prds/`.
+        # `docs/requirement.txt` and `docs/prd/`.
         return ActionOutput(content=doc.content, instruct_content=doc)

--- a/metagpt/roles/engineer.py
+++ b/metagpt/roles/engineer.py
@@ -178,7 +178,7 @@ class Engineer(Role):
             is_pass, reason = await self._is_pass(summary)
             if not is_pass:
                 todo.i_context.reason = reason
-                tasks.append(todo.i_context.dict())
+                tasks.append(todo.i_context.model_dump())
 
                 await self.project_repo.docs.code_summary.save(
                     filename=Path(todo.i_context.design_filename).name,

--- a/metagpt/utils/file_repository.py
+++ b/metagpt/utils/file_repository.py
@@ -101,21 +101,28 @@ class FileRepository:
         path_name = self.workdir / filename
         if not path_name.exists():
             return None
+        if not path_name.is_file():
+            return None
         doc.content = await aread(path_name)
         return doc
 
-    async def get_all(self) -> List[Document]:
+    async def get_all(self, filter_ignored=True) -> List[Document]:
         """Get the content of all files in the repository.
 
         :return: List of Document instances representing files.
         """
         docs = []
-        for root, dirs, files in os.walk(str(self.workdir)):
-            for file in files:
-                file_path = Path(root) / file
-                relative_path = file_path.relative_to(self.workdir)
-                doc = await self.get(relative_path)
+        if filter_ignored:
+            for f in self.all_files:
+                doc = await self.get(f)
                 docs.append(doc)
+        else:
+            for root, dirs, files in os.walk(str(self.workdir)):
+                for file in files:
+                    file_path = Path(root) / file
+                    relative_path = file_path.relative_to(self.workdir)
+                    doc = await self.get(relative_path)
+                    docs.append(doc)
         return docs
 
     @property


### PR DESCRIPTION
**Features**
- Windows use `\` as path delimiter, while Unix use `/` as path delimiter. This causes issues with `dependencies.json` not working consistently across different platforms.
- Standardize the path delimiter for `.dependencies.json` to `/`
- Add the `filter_ignored` parameter to `FileRepository.get_all()` to enable the functioning of `.gitignore` filters.