### PR TITLE
Refactor get_choice_delta_text for safer dict access while using ZHIPU API

### DIFF
--- a/metagpt/provider/base_llm.py
+++ b/metagpt/provider/base_llm.py
@@ -91,7 +91,7 @@ class BaseLLM(ABC):
 
     def get_choice_delta_text(self, rsp: dict) -> str:
         """Required to provide the first text of stream choice"""
-        return rsp.get("choices")[0]["delta"]["content"]
+        return rsp.get("choices", [{}])[0].get("delta", {}).get("content", "")
 
     def get_choice_function(self, rsp: dict) -> dict:
         """Required to provide the first function of choice


### PR DESCRIPTION
**Features**
Refactor get_choice_delta_text for safer dict access while using ZHIPU API.

**Influence**
To address a KeyError encountered when using the ZHIPU API to execute the command metagpt "Write an ssh interact cli by python" --run_tests=true, here are the relevant logs.

```shell
2024-01-28 00:21:17.405 | INFO     | metagpt.utils.file_repository:save:66 - update dependency: /Users/chengyunquan/Projects/MetaGPT/workspace/python_ssh_cli/python_ssh_cli/ssh_connection.py:{'docs/tasks/20240128001937.json', 'docs/system_design/20240128001937.json'}
2024-01-28 00:21:17.410 | INFO     | metagpt.actions.write_code:run:156 - Writing session_manager.py..
2024-01-28 00:21:48.362 | WARNING  | metagpt.utils.common:wrapper:510 - There is a exception in role's execution, in order to resume, we delete the newest role communication message in the role's memory.
2024-01-28 00:21:48.370 | ERROR    | metagpt.utils.common:wrapper:492 - Exception occurs, start to serialize the project, exp:
Traceback (most recent call last):
  File "/Users/chengyunquan/miniconda3/envs/metagpt/lib/python3.9/site-packages/tenacity/_asyncio.py", line 50, in __call__
    result = await fn(*args, **kwargs)
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/actions/write_code.py", line 100, in write_code
    code_rsp = await self._aask(prompt)
KeyError: 'delta'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/utils/common.py", line 501, in wrapper
    return await func(self, *args, **kwargs)
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/roles/role.py", line 485, in run
    rsp = await self.react()
tenacity.RetryError: RetryError[<Future at 0x14e6adcd0 state=finished raised KeyError>]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/utils/common.py", line 487, in wrapper
    result = await func(self, *args, **kwargs)
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/team.py", line 134, in run
    await self.env.run()
Exception: Traceback (most recent call last):
  File "/Users/chengyunquan/miniconda3/envs/metagpt/lib/python3.9/site-packages/tenacity/_asyncio.py", line 50, in __call__
    result = await fn(*args, **kwargs)
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/actions/write_code.py", line 100, in write_code
    code_rsp = await self._aask(prompt)
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/actions/action.py", line 67, in _aask
    return await self.llm.aask(prompt, system_msgs)
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/provider/base_llm.py", line 52, in aask
    rsp = await self.acompletion_text(message, stream=stream, timeout=timeout)
  File "/Users/chengyunquan/miniconda3/envs/metagpt/lib/python3.9/site-packages/tenacity/_asyncio.py", line 88, in async_wrapped
    return await fn(*args, **kwargs)
  File "/Users/chengyunquan/miniconda3/envs/metagpt/lib/python3.9/site-packages/tenacity/_asyncio.py", line 47, in __call__
    do = self.iter(retry_state=retry_state)
  File "/Users/chengyunquan/miniconda3/envs/metagpt/lib/python3.9/site-packages/tenacity/__init__.py", line 314, in iter
    return fut.result()
  File "/Users/chengyunquan/miniconda3/envs/metagpt/lib/python3.9/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/Users/chengyunquan/miniconda3/envs/metagpt/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/Users/chengyunquan/miniconda3/envs/metagpt/lib/python3.9/site-packages/tenacity/_asyncio.py", line 50, in __call__
    result = await fn(*args, **kwargs)
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/provider/zhipuai_api.py", line 112, in acompletion_text
    return await self._achat_completion_stream(messages)
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/provider/zhipuai_api.py", line 92, in _achat_completion_stream
    content = self.get_choice_delta_text(chunk)
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/provider/base_llm.py", line 94, in get_choice_delta_text
    return rsp.get("choices")[0]["delta"]["content"]
KeyError: 'delta'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/utils/common.py", line 501, in wrapper
    return await func(self, *args, **kwargs)
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/roles/role.py", line 485, in run
    rsp = await self.react()
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/roles/role.py", line 453, in react
    rsp = await self._react()
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/roles/role.py", line 432, in _react
    rsp = await self._act()  # 这个rsp是否需要publish_message？
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/roles/engineer.py", line 157, in _act
    return await self._act_write_code()
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/roles/engineer.py", line 164, in _act_write_code
    changed_files = await self._act_sp_with_cr(review=self.use_code_review)
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/roles/engineer.py", line 120, in _act_sp_with_cr
    coding_context = await todo.run()
  File "/Users/chengyunquan/Projects/MetaGPT/metagpt/actions/write_code.py", line 157, in run
    code = await self.write_code(prompt)
  File "/Users/chengyunquan/miniconda3/envs/metagpt/lib/python3.9/site-packages/tenacity/_asyncio.py", line 88, in async_wrapped
    return await fn(*args, **kwargs)
  File "/Users/chengyunquan/miniconda3/envs/metagpt/lib/python3.9/site-packages/tenacity/_asyncio.py", line 47, in __call__
    do = self.iter(retry_state=retry_state)
  File "/Users/chengyunquan/miniconda3/envs/metagpt/lib/python3.9/site-packages/tenacity/__init__.py", line 326, in iter
    raise retry_exc from fut.exception()
tenacity.RetryError: RetryError[<Future at 0x14e6adcd0 state=finished raised KeyError>]
```
