### PR TITLE
Feat:+Openai like api

### DIFF
--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -24,6 +24,7 @@ class LLMType(Enum):
     METAGPT = "metagpt"
     AZURE = "azure"
     OLLAMA = "ollama"
+    OPENAI_LIKE = "openai_like"
 
     def __missing__(self, key):
         return self.OPENAI

--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -39,8 +39,7 @@ class LLMConfig(YamlModel):
     """
 
     api_key: str
-    #api_type: LLMType = LLMType.OPENAI
-    api_type: Optional[LLMType] = LLMType.OPENAI
+    api_type: LLMType = LLMType.OPENAI
     base_url: str = "https://api.openai.com/v1"
     api_version: Optional[str] = None
 

--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -6,7 +6,7 @@
 @File    : llm_config.py
 """
 from enum import Enum
-from typing import Optional
+from typing import Optional,List
 
 from pydantic import field_validator
 
@@ -25,6 +25,7 @@ class LLMType(Enum):
     AZURE = "azure"
     OLLAMA = "ollama"
     OPENAI_LIKE = "openai_like"
+    MOONSHOT = "moonshot"
 
     def __missing__(self, key):
         return self.OPENAI
@@ -38,7 +39,8 @@ class LLMConfig(YamlModel):
     """
 
     api_key: str
-    api_type: LLMType = LLMType.OPENAI
+    #api_type: LLMType = LLMType.OPENAI
+    api_type: Optional[LLMType] = LLMType.OPENAI
     base_url: str = "https://api.openai.com/v1"
     api_version: Optional[str] = None
 

--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -6,7 +6,7 @@
 @File    : llm_config.py
 """
 from enum import Enum
-from typing import Optional,List
+from typing import Optional
 
 from pydantic import field_validator
 

--- a/metagpt/provider/__init__.py
+++ b/metagpt/provider/__init__.py
@@ -16,6 +16,7 @@ from metagpt.provider.azure_openai_api import AzureOpenAILLM
 from metagpt.provider.metagpt_api import MetaGPTLLM
 from metagpt.provider.human_provider import HumanProvider
 from metagpt.provider.spark_api import SparkLLM
+from metagpt.provider.openai_like_api import OpenAILIKE
 
 __all__ = [
     "FireworksLLM",
@@ -28,4 +29,5 @@ __all__ = [
     "OllamaLLM",
     "HumanProvider",
     "SparkLLM",
+    "OpenAILIKE",
 ]

--- a/metagpt/provider/__init__.py
+++ b/metagpt/provider/__init__.py
@@ -16,7 +16,7 @@ from metagpt.provider.azure_openai_api import AzureOpenAILLM
 from metagpt.provider.metagpt_api import MetaGPTLLM
 from metagpt.provider.human_provider import HumanProvider
 from metagpt.provider.spark_api import SparkLLM
-from metagpt.provider.openai_like_api import OpenAILIKE
+from metagpt.provider.openai_like_api import OpenAILIKELLM
 
 __all__ = [
     "FireworksLLM",
@@ -29,5 +29,5 @@ __all__ = [
     "OllamaLLM",
     "HumanProvider",
     "SparkLLM",
-    "OpenAILIKE",
+    "OpenAILIKELLM",
 ]

--- a/metagpt/provider/llm_provider_registry.py
+++ b/metagpt/provider/llm_provider_registry.py
@@ -25,7 +25,7 @@ def register_provider(keys):
     """register provider to registry"""
 
     def decorator(cls):
-        if isinstance(keys,list):
+        if isinstance(keys, list):
             for key in keys:
                 LLM_REGISTRY.register(key, cls)
         else:

--- a/metagpt/provider/llm_provider_registry.py
+++ b/metagpt/provider/llm_provider_registry.py
@@ -21,11 +21,15 @@ class LLMProviderRegistry:
         return self.providers[enum]
 
 
-def register_provider(key):
+def register_provider(keys):
     """register provider to registry"""
 
     def decorator(cls):
-        LLM_REGISTRY.register(key, cls)
+        if isinstance(keys,list):
+            for key in keys:
+                LLM_REGISTRY.register(key, cls)
+        else:
+            LLM_REGISTRY.register(keys, cls)
         return cls
 
     return decorator

--- a/metagpt/provider/openai_like_api.py
+++ b/metagpt/provider/openai_like_api.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# @Desc   : self-host open llm model with openai-compatible interface
+
+from openai.types import CompletionUsage
+from openai.types.chat import  ChatCompletionChunk
+from metagpt.configs.llm_config import LLMConfig, LLMType
+from openai import  AsyncStream
+from metagpt.logs import logger
+from metagpt.provider.llm_provider_registry import register_provider
+from metagpt.provider.openai_api import OpenAILLM
+from metagpt.utils.cost_manager import Costs, TokenCostManager
+
+
+@register_provider(LLMType.OPENAI_LIKE)
+class OpenAILIKE(OpenAILLM):
+    """Used for OPENAI-like payment models, unlike OPEN_LLM with added billing functionality"""
+
+    def __init__(self, config: LLMConfig):
+        super().__init__(config)
+        self._cost_manager = TokenCostManager()
+        self.model = config.model
+
+    def _make_client_kwargs(self) -> dict:
+        kwargs = dict(api_key=self.config.api_key, base_url=self.config.base_url)
+        return kwargs
+
+    def _update_costs(self, usage: CompletionUsage):
+        if self.config.calc_usage and usage:
+            try:
+                # use OpenLLMCostManager not CONFIG.cost_manager
+                self._cost_manager.update_cost(usage.prompt_tokens, usage.completion_tokens, self.model)
+            except Exception as e:
+                logger.error(f"updating costs failed!, exp: {e}")
+
+    def get_costs(self) -> Costs:
+        return self._cost_manager.get_costs()
+
+    async def _achat_completion_stream(self, messages: list[dict], timeout=3) -> str:
+        response: AsyncStream[ChatCompletionChunk] = await self.aclient.chat.completions.create(
+            **self._cons_kwargs(messages), stream=True
+        )
+
+        collected_content = []
+        usage = CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+        # iterate through the stream of events
+        async for chunk in response:
+            if chunk.choices:
+                choice = chunk.choices[0]
+                choice_delta = choice.delta
+                finish_reason = choice.finish_reason if hasattr(choice, "finish_reason") else None
+                if choice_delta.content:
+                    collected_content.append(choice_delta.content)
+                    print(choice_delta.content, end="")
+                if finish_reason:
+                    # fireworks api return usage when finish_reason is not None
+                    usage = CompletionUsage(**choice.usage)
+
+        full_content = "".join(collected_content)
+        self._update_costs(usage)
+        return full_content
+
+    async def acompletion_text(self, messages: list[dict], stream=False, timeout: int = 3) -> str:
+        """when streaming, print each token in place."""
+        if stream:
+            return await self._achat_completion_stream(messages)
+        rsp = await self._achat_completion(messages)
+        return self.get_choice_text(rsp)

--- a/metagpt/provider/openai_like_api.py
+++ b/metagpt/provider/openai_like_api.py
@@ -12,7 +12,7 @@ from metagpt.provider.openai_api import OpenAILLM
 from metagpt.utils.cost_manager import Costs, CostManager
 
 
-@register_provider([LLMType.OPENAI_LIKE,LLMType.MOONSHOT])
+@register_provider([LLMType.OPENAI_LIKE, LLMType.MOONSHOT])
 class OpenAILIKELLM(OpenAILLM):
     """Used for OPENAI-like payment models, unlike OPEN_LLM with added billing functionality"""
 

--- a/metagpt/provider/openai_like_api.py
+++ b/metagpt/provider/openai_like_api.py
@@ -3,9 +3,9 @@
 # @Desc   : self-host open llm model with openai-compatible interface
 
 from openai.types import CompletionUsage
-from openai.types.chat import  ChatCompletionChunk
+from openai.types.chat import ChatCompletionChunk
 from metagpt.configs.llm_config import LLMConfig, LLMType
-from openai import  AsyncStream
+from openai import AsyncStream
 from metagpt.logs import logger,log_llm_stream
 from metagpt.provider.llm_provider_registry import register_provider
 from metagpt.provider.openai_api import OpenAILLM

--- a/metagpt/provider/openai_like_api.py
+++ b/metagpt/provider/openai_like_api.py
@@ -12,8 +12,8 @@ from metagpt.provider.openai_api import OpenAILLM
 from metagpt.utils.cost_manager import Costs, CostManager
 
 
-@register_provider([LLMType.OPENAI_LIKE,LLMType.OPENAI])
-class OpenAILIKE(OpenAILLM):
+@register_provider([LLMType.OPENAI_LIKE,LLMType.MOONSHOT])
+class OpenAILIKELLM(OpenAILLM):
     """Used for OPENAI-like payment models, unlike OPEN_LLM with added billing functionality"""
 
     def __init__(self, config: LLMConfig):

--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -35,9 +35,9 @@ TOKEN_COSTS = {
     "glm-3-turbo": {"prompt": 0.0, "completion": 0.0007},  # 128k version, prompt + completion tokens=0.005￥/k-tokens
     "glm-4": {"prompt": 0.0, "completion": 0.014},  # 128k version, prompt + completion tokens=0.1￥/k-tokens
     "gemini-pro": {"prompt": 0.00025, "completion": 0.0005},
-    "moonshot-v1-8k": {"prompt": 0, "completion": 0.012}, # prompt + completion tokens=0.012￥/k-tokens
-    "moonshot-v1-32k": {"prompt": 0, "completion": 0.024},
-    "moonshot-v1-128k": {"prompt": 0, "completion": 0.06},
+    "moonshot-v1-8k": {"prompt": 0.012, "completion": 0.012}, # prompt + completion tokens=0.012￥/k-tokens
+    "moonshot-v1-32k": {"prompt": 0.024, "completion": 0.024},
+    "moonshot-v1-128k": {"prompt": 0.06, "completion": 0.06},
 }
 
 

--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -35,9 +35,9 @@ TOKEN_COSTS = {
     "glm-3-turbo": {"prompt": 0.0, "completion": 0.0007},  # 128k version, prompt + completion tokens=0.005￥/k-tokens
     "glm-4": {"prompt": 0.0, "completion": 0.014},  # 128k version, prompt + completion tokens=0.1￥/k-tokens
     "gemini-pro": {"prompt": 0.00025, "completion": 0.0005},
-    "moonshot-v1-8k":{"prompt":0,"completion":0.012},
-    "moonshot-v1-32k":{"prompt":0,"completion":0.024},
-    "moonshot-v1-128k":{"prompt":0,"completion":0.06},
+    "moonshot-v1-8k": {"prompt": 0, "completion": 0.012}, # prompt + completion tokens=0.012￥/k-tokens
+    "moonshot-v1-32k": {"prompt": 0, "completion": 0.024},
+    "moonshot-v1-128k": {"prompt": 0, "completion": 0.06},
 }
 
 
@@ -63,9 +63,9 @@ TOKEN_MAX = {
     "text-embedding-ada-002": 8192,
     "chatglm_turbo": 32768,
     "gemini-pro": 32768,
-    "moonshot-v1-8k":8192,
-    "moonshot-v1-32k":32768,
-    "moonshot-v1-128k":128000,
+    "moonshot-v1-8k": 8192,
+    "moonshot-v1-32k": 32768,
+    "moonshot-v1-128k": 128000,
 }
 
 

--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -32,8 +32,8 @@ TOKEN_COSTS = {
     "gpt-4-vision-preview": {"prompt": 0.01, "completion": 0.03},  # TODO add extra image price calculator
     "gpt-4-1106-vision-preview": {"prompt": 0.01, "completion": 0.03},
     "text-embedding-ada-002": {"prompt": 0.0004, "completion": 0.0},
-    "glm-3-turbo": {"prompt": 0.0, "completion": 0.0007},  # 128k version, prompt + completion tokens=0.005￥/k-tokens
-    "glm-4": {"prompt": 0.0, "completion": 0.014},  # 128k version, prompt + completion tokens=0.1￥/k-tokens
+    "glm-3-turbo": {"prompt": 0.0007, "completion": 0.0007},  # 128k version, prompt + completion tokens=0.005￥/k-tokens
+    "glm-4": {"prompt": 0.014, "completion": 0.014},  # 128k version, prompt + completion tokens=0.1￥/k-tokens
     "gemini-pro": {"prompt": 0.00025, "completion": 0.0005},
     "moonshot-v1-8k": {"prompt": 0.012, "completion": 0.012}, # prompt + completion tokens=0.012￥/k-tokens
     "moonshot-v1-32k": {"prompt": 0.024, "completion": 0.024},

--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -35,6 +35,9 @@ TOKEN_COSTS = {
     "glm-3-turbo": {"prompt": 0.0, "completion": 0.0007},  # 128k version, prompt + completion tokens=0.005￥/k-tokens
     "glm-4": {"prompt": 0.0, "completion": 0.014},  # 128k version, prompt + completion tokens=0.1￥/k-tokens
     "gemini-pro": {"prompt": 0.00025, "completion": 0.0005},
+    "moonshot-v1-8k":{"prompt":0,"completion":0.012},
+    "moonshot-v1-32k":{"prompt":0,"completion":0.024},
+    "moonshot-v1-128k":{"prompt":0,"completion":0.06},
 }
 
 
@@ -60,6 +63,9 @@ TOKEN_MAX = {
     "text-embedding-ada-002": 8192,
     "chatglm_turbo": 32768,
     "gemini-pro": 32768,
+    "moonshot-v1-8k":8192,
+    "moonshot-v1-32k":32768,
+    "moonshot-v1-128k":128000,
 }
 
 

--- a/tests/metagpt/provider/mock_llm_config.py
+++ b/tests/metagpt/provider/mock_llm_config.py
@@ -42,3 +42,10 @@ mock_llm_config_zhipu = LLMConfig(
     model="mock_zhipu_model",
     proxy="http://localhost:8080",
 )
+
+mock_llm_config_openailike = LLMConfig(
+    api_type= "openai_like",
+    base_url= "https://api.moonshot.cn/v1",
+    api_key="mock_api_key.moonshot",
+    model="moonshot-v1-8k"
+)

--- a/tests/metagpt/provider/test_openai_like_api.py
+++ b/tests/metagpt/provider/test_openai_like_api.py
@@ -9,7 +9,7 @@ from openai.types.completion_usage import CompletionUsage
 from metagpt.provider.openai_like_api import OpenAILIKELLM
 from tests.metagpt.provider.mock_llm_config import mock_llm_config_openailike
 
-resp_content = ' 1\n2\n3\n4\n5\n6\n7\n8\n9\n10'
+resp_content = " 1\n2\n3\n4\n5\n6\n7\n8\n9\n10"
 default_resp = ChatCompletion(
     id='cmpl-ae9688c1d46b4ed28f6ef53e06152121',
     choices=[
@@ -38,7 +38,7 @@ async def test_openai_like_acompletion():
     resp = await llm.acompletion_text(hello_msg, stream=False)
     assert resp == resp_content
 
-    resp = await llm.acompletion_text(hello_msg,stream=True)
+    resp = await llm.acompletion_text(hello_msg, stream=True)
     assert  resp == resp_content
 
 

--- a/tests/metagpt/provider/test_openai_like_api.py
+++ b/tests/metagpt/provider/test_openai_like_api.py
@@ -6,8 +6,7 @@ from openai.types.chat.chat_completion import (
 import pytest
 
 from openai.types.completion_usage import CompletionUsage
-from metagpt.llm import LLM
-from metagpt.provider.openai_like_api import OpenAILIKE
+from metagpt.provider.openai_like_api import OpenAILIKELLM
 from tests.metagpt.provider.mock_llm_config import mock_llm_config_openailike
 
 resp_content = ' 1\n2\n3\n4\n5\n6\n7\n8\n9\n10'
@@ -31,7 +30,7 @@ hello_msg = [{"role": "user", "content": "count from 1 to 10. split by newline."
 
 @pytest.mark.asyncio
 async def test_openai_like_acompletion():
-    llm = OpenAILIKE(mock_llm_config_openailike)
+    llm = OpenAILIKELLM(mock_llm_config_openailike)
 
     resp = await llm.acompletion(hello_msg)
     assert resp.choices[0].message.content == resp_content

--- a/tests/metagpt/provider/test_openai_like_api.py
+++ b/tests/metagpt/provider/test_openai_like_api.py
@@ -1,0 +1,46 @@
+from openai.types.chat.chat_completion import (
+    ChatCompletion,
+    ChatCompletionMessage,
+    Choice,
+)
+import pytest
+
+from openai.types.completion_usage import CompletionUsage
+from metagpt.llm import LLM
+from metagpt.provider.openai_like_api import OpenAILIKE
+from tests.metagpt.provider.mock_llm_config import mock_llm_config_openailike
+
+resp_content = ' 1\n2\n3\n4\n5\n6\n7\n8\n9\n10'
+default_resp = ChatCompletion(
+    id='cmpl-ae9688c1d46b4ed28f6ef53e06152121',
+    choices=[
+        Choice(
+            finish_reason='stop',
+            index=0,
+            logprobs=None,
+            message=ChatCompletionMessage(content=resp_content, role='assistant', function_call=None, tool_calls=None)
+        )
+    ],
+    created=2777813,
+    model='moonshot-v1-8k',
+    object='chat.completion',
+    system_fingerprint=None,
+    usage=CompletionUsage(completion_tokens=21, prompt_tokens=15, total_tokens=36))
+
+hello_msg = [{"role": "user", "content": "count from 1 to 10. split by newline."}]
+
+@pytest.mark.asyncio
+async def test_openai_like_acompletion():
+    llm = OpenAILIKE(mock_llm_config_openailike)
+
+    resp = await llm.acompletion(hello_msg)
+    assert resp.choices[0].message.content == resp_content
+
+    resp = await llm.acompletion_text(hello_msg, stream=False)
+    assert resp == resp_content
+
+    resp = await llm.acompletion_text(hello_msg,stream=True)
+    assert  resp == resp_content
+
+
+


### PR DESCRIPTION
**Features**
Used for OPENAI-like payment models, unlike OPEN_LLM with added billing functionality
Unlike OPENAI, we can still count tokens in stream mode
The configuration documentation can be found by clicking on the detailed https://github.com/geekan/MetaGPT-docs/pull/85
such as you can rewrite config2.py like this:
```python
llm:
  api_type: "moonshot"
  base_url: "https://api.moonshot.cn/v1"
  api_key: "YOUR_API_KEY"
  model: "moonshot-v1-8k"
```

Unit test result as follow:
```python
(yql-mg) root@v100s-prod-uchb1-2001:/data2/yangqianli/MetaGPT# pytest /data2/yangqianli/MetaGPT/tests/metagpt/provider/test_openai_like_api.py
============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.17, pytest-7.2.2, pluggy-1.2.0
rootdir: /data2/yangqianli/MetaGPT
plugins: asyncio-0.23.5, anyio-3.7.1, mock-3.11.1
asyncio: mode=strict
collected 1 item                                                                                                                                                                                                 

tests/metagpt/provider/test_openai_like_api.py .                                                                                                                                                           [100%]

=============================================================================================== 1 passed in 5.20s ================================================================================================

