### PR TITLE
set `block on white` style for markdown block.

### DIFF
--- a/metagpt/actions/mi/execute_nb_code.py
+++ b/metagpt/actions/mi/execute_nb_code.py
@@ -215,20 +215,21 @@ def truncate(result: str, keep_len: int = 2000, is_success: bool = True):
 
 
 def remove_escape_and_color_codes(input_str: str):
-    # 使用正则表达式去除转义字符和颜色代码
+    # 使用正则表达式去除jupyter notebook输出结果中的转义字符和颜色代码
+    # Use regular expressions to get rid of escape characters and color codes in jupyter notebook output.
     pattern = re.compile(r"\x1b\[[0-9;]*[mK]")
     result = pattern.sub("", input_str)
     return result
 
 
 def display_markdown(content: str):
-    # 使用正则表达式逐个匹配代码块
+    # Use regular expressions to match blocks of code one by one.
     matches = re.finditer(r"```(.+?)```", content, re.DOTALL)
     start_index = 0
     content_panels = []
-    # 文本背景色和文字颜色设置
+    # Set the text background color and text color.
     style = "black on white"
-    # 逐个打印匹配到的文本和代码
+    # Print the matching text and code one by one.
     for match in matches:
         text_content = content[start_index : match.start()].strip()
         code_content = match.group(0).strip()[3:-3]  # Remove triple backticks
@@ -240,12 +241,12 @@ def display_markdown(content: str):
             content_panels.append(Panel(Markdown(f"```{code_content}"), style=style, box=MINIMAL))
         start_index = match.end()
 
-    # 打印剩余文本（如果有）
+    # Print remaining text (if any).
     remaining_text = content[start_index:].strip()
     if remaining_text:
         content_panels.append(Panel(Markdown(remaining_text), style=style, box=MINIMAL))
 
-    # 在Live模式中显示所有Panel
+    # Display all panels in Live mode.
     with Live(auto_refresh=False, console=Console(), vertical_overflow="visible") as live:
         live.update(Group(*content_panels))
         live.refresh()

--- a/metagpt/actions/mi/execute_nb_code.py
+++ b/metagpt/actions/mi/execute_nb_code.py
@@ -226,22 +226,24 @@ def display_markdown(content: str):
     matches = re.finditer(r"```(.+?)```", content, re.DOTALL)
     start_index = 0
     content_panels = []
+    # 文本背景色和文字颜色设置
+    style = "black on white"
     # 逐个打印匹配到的文本和代码
     for match in matches:
         text_content = content[start_index : match.start()].strip()
         code_content = match.group(0).strip()[3:-3]  # Remove triple backticks
 
         if text_content:
-            content_panels.append(Panel(Markdown(text_content), box=MINIMAL))
+            content_panels.append(Panel(Markdown(text_content), style=style, box=MINIMAL))
 
         if code_content:
-            content_panels.append(Panel(Markdown(f"```{code_content}"), box=MINIMAL))
+            content_panels.append(Panel(Markdown(f"```{code_content}"), style=style, box=MINIMAL))
         start_index = match.end()
 
     # 打印剩余文本（如果有）
     remaining_text = content[start_index:].strip()
     if remaining_text:
-        content_panels.append(Panel(Markdown(remaining_text), box=MINIMAL))
+        content_panels.append(Panel(Markdown(remaining_text), style=style, box=MINIMAL))
 
     # 在Live模式中显示所有Panel
     with Live(auto_refresh=False, console=Console(), vertical_overflow="visible") as live:


### PR DESCRIPTION
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

- 为markdown block设置 `block on white` style ，效果如下：
  - 示例代码为：![image](https://github.com/geekan/MetaGPT/assets/84325228/eb2cac13-914b-40ff-afdd-5d26010377b8)
  - terminal是黑底时：![image](https://github.com/geekan/MetaGPT/assets/84325228/1ac24425-7513-45a8-a2c3-5cbb2bcb83e5)
  - terminal是白底时：![image](https://github.com/geekan/MetaGPT/assets/84325228/9072e101-9388-4eda-967a-975ddb32395a)

