### PR TITLE
Update role.py : Role.set_actions()

### DIFF
--- a/metagpt/roles/role.py
+++ b/metagpt/roles/role.py
@@ -281,7 +281,7 @@ class Role(SerializationMixin, ContextMixin, BaseModel):
                 i = action
             self._init_action(i)
             self.actions.append(i)
-            self.states.append(f"{len(self.actions)}. {action}")
+            self.states.append(f"{len(self.actions) - 1}. {action}")
 
     def _set_react_mode(self, react_mode: str, max_react_loop: int = 1, auto_run: bool = True, use_tools: bool = False):
         """Set strategy of the Role reacting to observed Message. Variation lies in how


### PR DESCRIPTION
由于提示词里要求llm选择的状态码是 0 到 状态数-1，所以我想这里往states里添加动作对应状态时，也应当从0开始。
Due to the requirement in the prompt word that llm selects a status code from 0 to the number of states -1, I believe that when adding action corresponding states to states, it should also start from 0.