### PR TITLE
Fix action.llm.model in examples/debate_simple

### DIFF
--- a/examples/debate_simple.py
+++ b/examples/debate_simple.py
@@ -8,14 +8,17 @@
 import asyncio
 
 from metagpt.actions import Action
+from metagpt.config2 import Config
 from metagpt.environment import Environment
 from metagpt.roles import Role
 from metagpt.team import Team
 
-action1 = Action(name="AlexSay", instruction="Express your opinion with emotion and don't repeat it")
-action1.llm.model = "gpt-4-1106-preview"
-action2 = Action(name="BobSay", instruction="Express your opinion with emotion and don't repeat it")
-action2.llm.model = "gpt-3.5-turbo-1106"
+gpt35 = Config.default()
+gpt35.llm.model = "gpt-3.5-turbo-1106"
+gpt4 = Config.default()
+gpt4.llm.model = "gpt-4-1106-preview"
+action1 = Action(config=gpt4, name="AlexSay", instruction="Express your opinion with emotion and don't repeat it")
+action2 = Action(config=gpt35, name="BobSay", instruction="Express your opinion with emotion and don't repeat it")
 alex = Role(name="Alex", profile="Democratic candidate", goal="Win the election", actions=[action1], watch=[action2])
 bob = Role(name="Bob", profile="Republican candidate", goal="Win the election", actions=[action2], watch=[action1])
 env = Environment(desc="US election live broadcast")


### PR DESCRIPTION
Fix action.llm.model in examples/debate_simple

**Features**
Assigned configs for actions to prevent `action.llm.model` being overridden in `Role._init_action`.


**Feature Docs**
-

**Influence**
The settings for `action.llm.model` in the example code now work.

**Result**
2024-02-23 08:52:39.815 | INFO     | metagpt.roles.role:_act:399 - Alex(Democratic candidate): to do Action(AlexSay)
Climate change is real, urgent, and demands bold action now! We can't afford to wait.
2024-02-23 08:52:43.782 | INFO     | metagpt.utils.cost_manager:update_cost:52 - Total running cost: $0.001 | Max budget: $10.000 | Current cost: $0.001, prompt_tokens: 83, completion_tokens: 20
2024-02-23 08:52:43.785 | INFO     | metagpt.roles.role:_act:399 - Bob(Republican candidate): to do Action(BobSay)
Climate change is a pressing issue that demands immediate action. We cannot afford to delay any longer.
2024-02-23 08:52:45.168 | INFO     | metagpt.utils.cost_manager:update_cost:52 - Total running cost: $0.000 | Max budget: $10.000 | Current cost: $0.000, prompt_tokens: 95, completion_tokens: 19

**Other**
Referenced test_context_mixin/test_config_priority().