### PR TITLE
support ask_review by llm

### DIFF
--- a/metagpt/actions/di/ask_review.py
+++ b/metagpt/actions/di/ask_review.py
@@ -33,6 +33,10 @@ class ReviewConst:
         "**Notice: The starting word in your suggestions must be one of the following:"
         f"{CHANGE_WORDS[0]}, {CONTINUE_WORDS[0]}, {GOAL_FINISHED_WORDS[0]}, {REDO_WORDS[0]} **"
     ).replace("type", "return")
+    ASK_HUMAN_FOR_HELP = (
+        "The task code execution failed, we need your help, please provide new solution ideas,"
+        f"or type {EXIT_WORDS[0]} to terminate the code"
+    )
 
 
 class AskReview(Action):
@@ -41,7 +45,7 @@ class AskReview(Action):
         context: list[Message] = [],
         plan: Plan = None,
         trigger: str = ReviewConst.TASK_REVIEW_TRIGGER,
-        review_type: Literal["human", "llm", "confirm_all"] = "human",
+        review_type: Literal["human", "llm", "disabled"] = "llm",
     ) -> Tuple[str, bool]:
         if plan:
             logger.info("Current overall plan:")
@@ -77,6 +81,10 @@ class AskReview(Action):
             rsp = "confirm"
 
         if rsp.lower() in ReviewConst.EXIT_WORDS:
+            exit()
+
+        if rsp.lower() in ReviewConst.GOAL_FINISHED_WORDS:
+            plan.finished_all_tasks()
             exit()
 
         # Confirmation can be one of "confirm", "continue", "c", "yes", "y" exactly, or sentences containing "confirm".

--- a/metagpt/actions/di/ask_review.py
+++ b/metagpt/actions/di/ask_review.py
@@ -41,7 +41,6 @@ class ReviewConst:
     PLAN_REVIEW_INSTRUCTION = (
         "You are very good at reviewing and scoring the code plan."
         "To review the information necessary and task relations for completing the `## User Requirement`, "
-        "Please note that any feedback and confirmation information must only be obtained through code tasks."
         "If you agree with the plan, respond:```\nconfirm\n```,otherwise,```\nchange,(here is your review points).\n```,"
     )
     INSTRUCTIONS = {

--- a/metagpt/actions/di/ask_review.py
+++ b/metagpt/actions/di/ask_review.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Literal, Tuple
 
 from metagpt.actions import Action
 from metagpt.logs import logger
 from metagpt.schema import Message, Plan
+from metagpt.utils.common import CodeParser
 
 
 class ReviewConst:
@@ -14,11 +15,11 @@ class ReviewConst:
     CHANGE_WORDS = ["change"]
     EXIT_WORDS = ["exit"]
     TASK_REVIEW_INSTRUCTION = (
-        f"If you want to change, add, delete a task or merge tasks in the plan, say '{CHANGE_WORDS[0]} task task_id or current task, ... (things to change)' "
+        f"If you want to change, add, delete a task or merge tasks in the plan, type '{CHANGE_WORDS[0]} task task_id or current task, ... (things to change)' "
         f"If you confirm the output from the current task and wish to continue, type: {CONTINUE_WORDS[0]}"
     )
     CODE_REVIEW_INSTRUCTION = (
-        f"If you want the codes to be rewritten, say '{CHANGE_WORDS[0]} ... (your change advice)' "
+        f"If you want the codes to be rewritten, type '{CHANGE_WORDS[0]} ... (your change advice)' "
         f"If you want to leave it as is, type: {CONTINUE_WORDS[0]} or {CONTINUE_WORDS[1]}"
     )
     EXIT_INSTRUCTION = f"If you want to terminate the process, type: {EXIT_WORDS[0]}"
@@ -26,7 +27,11 @@ class ReviewConst:
 
 class AskReview(Action):
     async def run(
-        self, context: list[Message] = [], plan: Plan = None, trigger: str = ReviewConst.TASK_REVIEW_TRIGGER
+        self,
+        context: list[Message] = [],
+        plan: Plan = None,
+        trigger: str = ReviewConst.TASK_REVIEW_TRIGGER,
+        review_type: Literal["human", "llm", "confirm_all"] = "human",
     ) -> Tuple[str, bool]:
         if plan:
             logger.info("Current overall plan:")
@@ -50,7 +55,27 @@ class AskReview(Action):
             "Please type your review below:\n"
         )
 
-        rsp = input(prompt)
+        if review_type == "human":
+            rsp = input(prompt)
+        elif review_type == "llm":
+            sys_msg = [
+                f"You are very good at reviewing *code*, {review_instruction}",
+                "you will get the *current task* and *code execution results*.",
+                "Please give sound suggestions to improve the effectiveness of the current task.",
+                "Dont return code, just suggestionsjust like the follwing with three backquote ```:",
+                f"```\n{ReviewConst.CHANGE_WORDS[0]} ... (your change advice).\n```",
+                "```\nconfirm\n```",
+                "```\nredo, (reason for re-executing the task)\n```",
+                "```\nexit\n```",
+                "**Notice: The starting word in your suggestions must be one of the following: ",
+                f"{ReviewConst.CHANGE_WORDS[0]}, confirm, redo**",
+            ]
+            review_msg = "\n".join([str(c) for c in context])
+            _rsp = await self.llm.aask(msg=review_msg, system_msgs=sys_msg)
+            rsp = CodeParser.parse_code(None, _rsp)
+            rsp = rsp[:-1] if rsp.endswith("\n") else rsp
+        else:
+            rsp = "confirm"
 
         if rsp.lower() in ReviewConst.EXIT_WORDS:
             exit()
@@ -59,4 +84,5 @@ class AskReview(Action):
         # One could say "confirm this task, but change the next task to ..."
         confirmed = rsp.lower() in ReviewConst.CONTINUE_WORDS or ReviewConst.CONTINUE_WORDS[0] in rsp.lower()
 
+        logger.info(f"Ask Review Result: `{rsp}` for above phase.")
         return rsp, confirmed

--- a/metagpt/actions/di/ask_review.py
+++ b/metagpt/actions/di/ask_review.py
@@ -39,11 +39,10 @@ class ReviewConst:
         f"or type {EXIT_WORDS[0]} to terminate the code"
     )
     PLAN_REVIEW_INSTRUCTION = (
-        "You first determine the requirement type and analyze the necessary information and tasks to complete it."
-        "Analyze what are the common unknown information that need to be explored, and whether there are tasks to explore it."
-        "Then, review the reasonableness of the tasks orders and relations in the plan."
-        f"If you confirm the plan, respond: ```\nconfirm\n```,"
-        f"If you want make new plan, respond: ```\n{CHANGE_WORDS[0]}, (your review result)\n```,"
+        "You are very good at reviewing and scoring the code plan."
+        "To review the information necessary and task relations for completing the `## User Requirement`, "
+        "Please note that any feedback and confirmation information must only be obtained through code tasks."
+        "If you agree with the plan, respond:```\nconfirm\n```,otherwise,```\nchange,(here is your review points).\n```,"
     )
     INSTRUCTIONS = {
         TASK_REVIEW_TRIGGER: TASK_REVIEW_INSTRUCTION,
@@ -102,7 +101,6 @@ class AskReview(Action):
         if review_type == "human":
             confirmed = rsp.lower() in ReviewConst.CONTINUE_WORDS or ReviewConst.CONTINUE_WORDS[0] in rsp.lower()
         else:
-            confirmed = rsp.lower().startswith("confirm")
-
+            confirmed = "confirm" in rsp.lower()
         logger.info(f"Ask Review Result: `{rsp}` for above phase.")
         return rsp, confirmed

--- a/metagpt/actions/di/ask_review.py
+++ b/metagpt/actions/di/ask_review.py
@@ -45,7 +45,7 @@ class AskReview(Action):
         context: list[Message] = [],
         plan: Plan = None,
         trigger: str = ReviewConst.TASK_REVIEW_TRIGGER,
-        review_type: Literal["human", "llm", "disabled"] = "llm",
+        review_type: Literal["human", "llm", "disabled"] = "disabled",
     ) -> Tuple[str, bool]:
         if plan:
             logger.info("Current overall plan:")

--- a/metagpt/actions/di/ask_review.py
+++ b/metagpt/actions/di/ask_review.py
@@ -39,9 +39,12 @@ class ReviewConst:
         f"or type {EXIT_WORDS[0]} to terminate the code"
     )
     PLAN_REVIEW_INSTRUCTION = (
-        "You are very good at reviewing and scoring the code plan."
-        "To review the information necessary and task relations for completing the `## User Requirement`, "
-        "If you agree with the plan, respond:```\nconfirm\n```,otherwise,```\nchange,(here is your review points).\n```,"
+        "You are very good at reviewing and improving the plan. Let's think step by step: "
+        "1. Enumerate the necessary information (Label which are known or unknown) for completing the `## User Requirement`, "
+        "2. For each unknown information, is there a corresponding exploration task?"
+        "3. It is better for each task to focus on one thing rather than multiple things."
+        "4. If there are prerequisite tasks that acquire unknown information, when evaluating tasks that use this unknown information, you can assume that the unknown information is already known."
+        "5. If you agree with the plan,respond:```\nconfirm\n```,otherwise,```\nchange,(here is your review results...)\n```"
     )
     INSTRUCTIONS = {
         TASK_REVIEW_TRIGGER: TASK_REVIEW_INSTRUCTION,
@@ -100,6 +103,6 @@ class AskReview(Action):
         if review_type == "human":
             confirmed = rsp.lower() in ReviewConst.CONTINUE_WORDS or ReviewConst.CONTINUE_WORDS[0] in rsp.lower()
         else:
-            confirmed = "confirm" in rsp.lower()
+            confirmed = rsp.lower().startswith(("confirm", "```\nconfirm", "````confirm"))
         logger.info(f"Ask Review Result: `{rsp}` for above phase.")
         return rsp, confirmed

--- a/metagpt/roles/di/data_interpreter.py
+++ b/metagpt/roles/di/data_interpreter.py
@@ -135,7 +135,7 @@ class DataInterpreter(Role):
 
             if not success and counter >= max_retry:
                 logger.info("coding failed!")
-                review, _ = await self.planner.ask_review(auto_run=False, trigger=ReviewConst.CODE_REVIEW_TRIGGER)
+                review, _ = await self.planner.ask_review(review_type="human", trigger=ReviewConst.CODE_REVIEW_TRIGGER)
                 if ReviewConst.CHANGE_WORDS[0] in review:
                     counter = 0  # redo the task again with help of human suggestions
 

--- a/metagpt/roles/di/data_interpreter.py
+++ b/metagpt/roles/di/data_interpreter.py
@@ -35,7 +35,7 @@ Output a json following the format:
 class DataInterpreter(Role):
     name: str = "David"
     profile: str = "DataInterpreter"
-    auto_run: bool = True
+    review_type: Literal["human", "llm", "disabled"] = "disabled"
     use_plan: bool = True
     use_reflection: bool = False
     execute_code: ExecuteNbCode = Field(default_factory=ExecuteNbCode, exclude=True)
@@ -45,8 +45,10 @@ class DataInterpreter(Role):
     max_react_loop: int = 10  # used for react mode
 
     @model_validator(mode="after")
-    def set_plan_and_tool(self) -> "Interpreter":
-        self._set_react_mode(react_mode=self.react_mode, max_react_loop=self.max_react_loop, auto_run=self.auto_run)
+    def set_plan_and_tool(self) -> "DataInterpreter":
+        self._set_react_mode(
+            react_mode=self.react_mode, max_react_loop=self.max_react_loop, review_type=self.review_type
+        )
         self.use_plan = (
             self.react_mode == "plan_and_act"
         )  # create a flag for convenience, overwrite any passed-in value

--- a/metagpt/roles/role.py
+++ b/metagpt/roles/role.py
@@ -23,7 +23,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING, Iterable, Optional, Set, Type, Union
+from typing import TYPE_CHECKING, Iterable, Literal, Optional, Set, Type, Union
 
 from pydantic import BaseModel, ConfigDict, Field, SerializeAsAny, model_validator
 
@@ -283,7 +283,13 @@ class Role(SerializationMixin, ContextMixin, BaseModel):
             self.actions.append(i)
             self.states.append(f"{len(self.actions) - 1}. {action}")
 
-    def _set_react_mode(self, react_mode: str, max_react_loop: int = 1, auto_run: bool = True):
+    def _set_react_mode(
+        self,
+        react_mode: str,
+        max_react_loop: int = 1,
+        review_type: Literal["human", "llm", "disabled"] = "llm",
+        use_tools: bool = False,
+    ):
         """Set strategy of the Role reacting to observed Message. Variation lies in how
         this Role elects action to perform during the _think stage, especially if it is capable of multiple Actions.
 
@@ -304,7 +310,9 @@ class Role(SerializationMixin, ContextMixin, BaseModel):
         if react_mode == RoleReactMode.REACT:
             self.rc.max_react_loop = max_react_loop
         elif react_mode == RoleReactMode.PLAN_AND_ACT:
-            self.planner = Planner(goal=self.goal, working_memory=self.rc.working_memory, auto_run=auto_run)
+            self.planner = Planner(
+                goal=self.goal, working_memory=self.rc.working_memory, review_type=review_type, use_tools=use_tools
+            )
 
     def _watch(self, actions: Iterable[Type[Action]] | Iterable[Action]):
         """Watch Actions of interest. Role will select Messages caused by these Actions from its personal message

--- a/metagpt/schema.py
+++ b/metagpt/schema.py
@@ -523,6 +523,15 @@ class Plan(BaseModel):
         """
         return [task for task in self.tasks if task.is_finished]
 
+    def finished_all_tasks(self):
+        """Finish all tasks, set Task.is_finished=True, set current task to last task"""
+        tasks: list[Task] = []
+        for task in self.tasks:
+            task.is_finished = True
+            tasks.append(task)
+        self.tasks = tasks
+        self.current_task_id = tasks[-1].task_id
+
 
 class MessageQueue(BaseModel):
     """Message queue which supports asynchronous updates."""

--- a/metagpt/strategy/planner.py
+++ b/metagpt/strategy/planner.py
@@ -52,7 +52,7 @@ class Planner(BaseModel):
     working_memory: Memory = Field(
         default_factory=Memory
     )  # memory for working on each task, discarded each time a task is done
-    review_type: Literal["human", "llm", "disabled"] = ("llm",)
+    review_type: Literal["human", "llm", "disabled"] = "disabled"
     use_tools: bool = False
 
     def __init__(self, goal: str = "", plan: Plan = None, **kwargs):
@@ -114,7 +114,7 @@ class Planner(BaseModel):
     async def ask_review(
         self,
         task_result: TaskResult = None,
-        review_type: Literal["human", "llm", "disabled"] = "llm",
+        review_type: Literal["human", "llm", "disabled"] = "disabled",
         trigger: str = ReviewConst.TASK_REVIEW_TRIGGER,
         review_context_len: int = 5,
     ):
@@ -139,9 +139,8 @@ class Planner(BaseModel):
             context=context,
             plan=self.plan,
             trigger=trigger,
-            review_type=review_type
-            if task_result
-            else "disabled",  # llm模式下, 不对plan进行review, 只有在plan review时task_result为None.
+            # 暂时不对plan进行review.
+            review_type=review_type if task_result else "disabled",  # 当task_result为None，说明是在review plan.
         )
 
         if not confirmed:

--- a/tests/metagpt/actions/di/test_ask_review.py
+++ b/tests/metagpt/actions/di/test_ask_review.py
@@ -1,6 +1,7 @@
 import pytest
 
 from metagpt.actions.di.ask_review import AskReview
+from metagpt.schema import AIMessage, Message
 
 
 @pytest.mark.asyncio
@@ -15,18 +16,18 @@ async def test_ask_review(mocker):
 @pytest.mark.asyncio
 async def test_ask_review_llm():
     context = [
-        Message("Train a model to predict wine class using the training set."),
-        Message(
+        Message("task instruction: Train a model to predict wine class using the training set."),
+        AIMessage(
             """
-                       from sklearn.datasets import load_wine
-                       wine_data = load_wine()
-                       plt.hist(wine_data.target, bins=len(wine_data.target_names))
-                       plt.xlabel('Class')
-                       plt.ylabel('Number of Samples')
-                       plt.title('Distribution of Wine Classes')
-                       plt.xticks(range(len(wine_data.target_names)), wine_data.target_names)
-                       plt.show()
-                       """
+            from sklearn.datasets import load_wine
+            wine_data = load_wine()
+            plt.hist(wine_data.target, bins=len(wine_data.target_names))
+            plt.xlabel('Class')
+            plt.ylabel('Number of Samples')
+            plt.title('Distribution of Wine Classes')
+            plt.xticks(range(len(wine_data.target_names)), wine_data.target_names)
+            plt.show()
+            """.strip()
         ),
     ]
     rsp, confirmed = await AskReview().run(context, review_type="llm")

--- a/tests/metagpt/actions/di/test_ask_review.py
+++ b/tests/metagpt/actions/di/test_ask_review.py
@@ -1,6 +1,6 @@
 import pytest
 
-from metagpt.actions.di.ask_review import AskReview
+from metagpt.actions.di.ask_review import AskReview, ReviewConst
 from metagpt.schema import AIMessage, Message
 
 
@@ -33,3 +33,45 @@ async def test_ask_review_llm():
     rsp, confirmed = await AskReview().run(context, review_type="llm")
     assert rsp.startswith(("redo", "change"))
     assert not confirmed
+
+
+@pytest.fixture()
+def unreasonable_plan():
+    CONTEXT = """
+    ## User Requirement
+    "Get paper list that title must include `multiagent` or `large language model` from table in https://papercopilot.com/statistics/iclr-statistics/iclr-2024-statistics/,and save it to a csv file.[I have confirmed the robot protocol, and it is permissible to crawl the website.]"
+    ## Context
+
+    ## Current Plan
+
+    ## Current Task
+
+    """
+    # 不合理的地方是有很多未知信息需要先探索：1）网页中的哪张表格是论文表；2）论文表的哪个字段是标题；
+    unreasonable_plan = """
+    [
+        {
+            "task_id": "1",
+            "dependent_task_ids": [],
+            "instruction": "Scrape the list of paper titles from the ICLR 2024 statistics page that include 'multiagent' or 'large language model'.",
+            "task_type": "web scraping"
+        },
+        {
+            "task_id": "2",
+            "dependent_task_ids": ["1"],
+            "instruction": "Save the scraped list of paper titles to a CSV file.",
+            "task_type": "data preprocessing"
+        }
+    ]
+    """
+    return [Message(CONTEXT), AIMessage(unreasonable_plan)]
+
+
+@pytest.mark.asyncio
+async def test_llm_review_plan(unreasonable_plan):
+    rsp, confirmed = await AskReview().run(
+        unreasonable_plan, trigger=ReviewConst.PLAN_REVIEW_TRIGGER, review_type="llm"
+    )
+    print(rsp)
+    assert not confirmed
+    assert rsp.startswith(("redo", "change"))

--- a/tests/metagpt/actions/di/test_ask_review.py
+++ b/tests/metagpt/actions/di/test_ask_review.py
@@ -67,11 +67,75 @@ def unreasonable_plan():
     return [Message(CONTEXT), AIMessage(unreasonable_plan)]
 
 
+@pytest.fixture()
+def reasonable_plan():
+    CONTEXT = """
+    ## User Requirement
+    "Get paper list that title must include `multiagent` or `large language model` from table in https://papercopilot.com/statistics/iclr-statistics/iclr-2024-statistics/,and save it to a csv file.[I have confirmed the robot protocol, and it is permissible to crawl the website.]"
+    ## Context
+
+    ## Current Plan
+
+    ## Current Task
+
+    """
+    reasonable_plan = """
+    [
+        {
+            "task_id": "1",
+            "dependent_task_ids": [],
+            "instruction": "Programmatically confirm the robot protocol at https://papercopilot.com/robots.txt, and ensure that scraping the ICLR 2024 statistics page is allowed."
+        },
+        {
+            "task_id": "2",
+            "dependent_task_ids": ["1"],
+            "instruction": "Access the website https://papercopilot.com/statistics/iclr-statistics/iclr-2024-statistics/, parse the web structure using an HTML parser, and locate the specific table with ICLR 2024 paper information."
+        },
+        {
+            "task_id": "3",
+            "dependent_task_ids": ["2"],
+            "instruction": "Confirm the accessibility and structure of the website to ensure proper scraping. Verify that the identified table contains the necessary paper information."
+        },
+        {
+            "task_id": "4",
+            "dependent_task_ids": ["3"],
+            "instruction": "Extract the data from the identified table, ensuring to capture all relevant columns."
+        },
+        {
+            "task_id": "5",
+            "dependent_task_ids": ["4"],
+            "instruction": "Filter the extracted data to include only papers with titles containing `multiagent` or `large language model`, performing a case-insensitive search."
+        },
+        {
+            "task_id": "6",
+            "dependent_task_ids": ["5"],
+            "instruction": "Define the CSV file structure, including headers for the relevant columns such as title, authors, abstract, and publication date. Specify the format for saving the paper titles."
+        },
+        {
+            "task_id": "7",
+            "dependent_task_ids": ["6"],
+            "instruction": "Save the filtered data to a CSV file named 'filtered_papers.csv' in a specified directory, and handle any exceptions or errors during the saving process."
+        },
+        {
+            "task_id": "8",
+            "dependent_task_ids": ["7"],
+            "instruction": "Validate the CSV file to ensure the data is correctly formatted and complete."
+        }
+    ]
+    """
+    return [Message(CONTEXT), AIMessage(reasonable_plan)]
+
+
 @pytest.mark.asyncio
-async def test_llm_review_plan(unreasonable_plan):
+async def test_llm_review_plan(unreasonable_plan, reasonable_plan):
     rsp, confirmed = await AskReview().run(
         unreasonable_plan, trigger=ReviewConst.PLAN_REVIEW_TRIGGER, review_type="llm"
     )
     print(rsp)
     assert not confirmed
     assert rsp.startswith("change")
+    # test reasonable plan
+    rsp, confirmed = await AskReview().run(reasonable_plan, trigger=ReviewConst.PLAN_REVIEW_TRIGGER, review_type="llm")
+    print(rsp)
+    assert confirmed
+    assert rsp.startswith("confirm")

--- a/tests/metagpt/actions/di/test_ask_review.py
+++ b/tests/metagpt/actions/di/test_ask_review.py
@@ -127,13 +127,17 @@ def reasonable_plan():
 
 
 @pytest.mark.asyncio
-async def test_llm_review_plan(unreasonable_plan, reasonable_plan):
+async def test_llm_review_unreasonable_plan(unreasonable_plan):
     rsp, confirmed = await AskReview().run(
         unreasonable_plan, trigger=ReviewConst.PLAN_REVIEW_TRIGGER, review_type="llm"
     )
     print(rsp)
     assert not confirmed
     assert rsp.startswith("change")
+
+
+@pytest.mark.asyncio
+async def test_llm_review_reasonable_plan(reasonable_plan):
     # test reasonable plan
     rsp, confirmed = await AskReview().run(reasonable_plan, trigger=ReviewConst.PLAN_REVIEW_TRIGGER, review_type="llm")
     print(rsp)

--- a/tests/metagpt/actions/di/test_ask_review.py
+++ b/tests/metagpt/actions/di/test_ask_review.py
@@ -74,4 +74,4 @@ async def test_llm_review_plan(unreasonable_plan):
     )
     print(rsp)
     assert not confirmed
-    assert rsp.startswith(("redo", "change"))
+    assert rsp.startswith("change")

--- a/tests/metagpt/actions/di/test_ask_review.py
+++ b/tests/metagpt/actions/di/test_ask_review.py
@@ -3,13 +3,14 @@ import pytest
 from metagpt.actions.di.ask_review import AskReview, ReviewConst
 from metagpt.schema import AIMessage, Message, Plan, Task
 
-# @pytest.mark.asyncio
-# async def test_ask_review(mocker):
-#     mock_review_input = "confirm"
-#     mocker.patch("builtins.input", return_value=mock_review_input)
-#     rsp, confirmed = await AskReview().run(review_type="human")
-#     assert rsp == mock_review_input
-#     assert confirmed
+
+@pytest.mark.asyncio
+async def test_ask_review(mocker):
+    mock_review_input = "confirm"
+    mocker.patch("builtins.input", return_value=mock_review_input)
+    rsp, confirmed = await AskReview().run(review_type="human")
+    assert rsp == mock_review_input
+    assert confirmed
 
 
 @pytest.mark.asyncio

--- a/tests/metagpt/actions/di/test_ask_review.py
+++ b/tests/metagpt/actions/di/test_ask_review.py
@@ -8,7 +8,7 @@ from metagpt.schema import AIMessage, Message
 async def test_ask_review(mocker):
     mock_review_input = "confirm"
     mocker.patch("builtins.input", return_value=mock_review_input)
-    rsp, confirmed = await AskReview().run()
+    rsp, confirmed = await AskReview().run(review_type="human")
     assert rsp == mock_review_input
     assert confirmed
 

--- a/tests/metagpt/actions/di/test_ask_review.py
+++ b/tests/metagpt/actions/di/test_ask_review.py
@@ -10,3 +10,25 @@ async def test_ask_review(mocker):
     rsp, confirmed = await AskReview().run()
     assert rsp == mock_review_input
     assert confirmed
+
+
+@pytest.mark.asyncio
+async def test_ask_review_llm():
+    context = [
+        Message("Train a model to predict wine class using the training set."),
+        Message(
+            """
+                       from sklearn.datasets import load_wine
+                       wine_data = load_wine()
+                       plt.hist(wine_data.target, bins=len(wine_data.target_names))
+                       plt.xlabel('Class')
+                       plt.ylabel('Number of Samples')
+                       plt.title('Distribution of Wine Classes')
+                       plt.xticks(range(len(wine_data.target_names)), wine_data.target_names)
+                       plt.show()
+                       """
+        ),
+    ]
+    rsp, confirmed = await AskReview().run(context, review_type="llm")
+    assert rsp.startswith(("redo", "change"))
+    assert not confirmed

--- a/tests/metagpt/test_schema.py
+++ b/tests/metagpt/test_schema.py
@@ -349,6 +349,15 @@ class TestPlan:
         plan._update_current_task()
         assert plan.current_task_id == "2"
 
+    def test_finish_all_task(self):
+        task1 = Task(task_id="1", is_finished=True)
+        task2 = Task(task_id="2")
+        task3 = Task(task_id="3")
+        plan = Plan(goal="Test", tasks=[task1, task2, task3])
+        plan.finished_all_tasks()
+        assert len(plan.get_finished_tasks()) == 3
+        assert plan.current_task_id == "3"
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-s"])


### PR DESCRIPTION
add ask_review by llm, and adjust the generated code to fit the jupyter notebook.

**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

- add 3 review_type : ["human", "llm", "confirm_all"];


**Result**
<!-- The screenshot/log of unittest/running result -->
If the generated code is executed successfully, but the code does not match the task requirements, it can be detected through `llm's ask review`, and it will make modification suggestions. The example is as follows,
```python
@pytest.mark.asyncio
async def test_ask_review_llm():
    context = [
        Message("Train a model to predict wine class using the training set."),
        Message(
               """
               from sklearn.datasets import load_wine
               wine_data = load_wine()
               plt.hist(wine_data.target, bins=len(wine_data.target_names))
               plt.xlabel('Class')
               plt.ylabel('Number of Samples')
               plt.title('Distribution of Wine Classes')
               plt.xticks(range(len(wine_data.target_names)), wine_data.target_names)
               plt.show()
               """
        ),
    ]
    rsp, confirmed = await AskReview().run(context, review_type="llm")
    assert rsp.startswith(("redo", "change"))   # -> True
    assert not confirmed                        # -> True
    pirnt(rsp)
    # ```
    # redo the task, the provided code only includes data loading and visualization, but does not include any steps related 
    # to training a model.
    # ```

```
![image](https://github.com/geekan/MetaGPT/assets/84325228/b7d2506c-a01a-4156-9fc7-72f987e9e4e2)

