### PR TITLE
feat: fix JSONDecodeError error caused by incorrect indentation used …

### DIFF
--- a/config/config2.example.yaml
+++ b/config/config2.example.yaml
@@ -3,7 +3,6 @@ llm:
   base_url: "YOUR_BASE_URL"
   api_key: "YOUR_API_KEY"
   model: "gpt-4-turbo-preview"  # or gpt-3.5-turbo-1106 / gpt-4-1106-preview
-  repair_llm_output: true  # when the output is not a valid json, try to repair it
   proxy: "YOUR_PROXY"  # for LLM API requests
   pricing_plan: "" # Optional. If invalid, it will be automatically filled in with the value of the `model`.
   # Azure-exclusive pricing plan mappings：
@@ -12,6 +11,8 @@ llm:
   # - gpt-4-turbo-vision: "gpt-4-vision-preview"
   # - gpt-4 8k: "gpt-4"
   # See for more: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
+
+repair_llm_output: true  # when the output is not a valid json, try to repair it
 
 proxy: "YOUR_PROXY"  # for tools like requests, playwright, selenium, etc.
 


### PR DESCRIPTION
**Features**

Issue: https://github.com/geekan/MetaGPT/issues/733
![c57e4e482e5c370d78e525e50867bc6](https://github.com/geekan/MetaGPT/assets/66004192/21ebefcb-85b5-429a-9c02-17307db6e898)

We often encounter this issue when using ZHIPU AI instead of OpenAI
Although the repair_llm.output option is enabled in the configuration file, the JSON correction function cannot be used.

**Feature Docs**
By reading config2. py, I learned that the repair_llm output option in config2. yaml should be placed in the first level indentation instead of under llm, so I modified config2. example. yaml

**Result**
![db78db8aec4898731bfd31f715ca1a2](https://github.com/geekan/MetaGPT/assets/66004192/e2d9ca9d-410d-4a43-8c69-8eeabff8b1e0)

