### PR TITLE
fixbug: gbk UnicodeEncodeError

### DIFF
--- a/metagpt/learn/skill_loader.py
+++ b/metagpt/learn/skill_loader.py
@@ -9,11 +9,11 @@
 from pathlib import Path
 from typing import Dict, List, Optional
 
-import aiofiles
 import yaml
 from pydantic import BaseModel, Field
 
 from metagpt.context import Context
+from metagpt.utils.common import aread
 
 
 class Example(BaseModel):
@@ -68,8 +68,7 @@ class SkillsDeclaration(BaseModel):
     async def load(skill_yaml_file_name: Path = None) -> "SkillsDeclaration":
         if not skill_yaml_file_name:
             skill_yaml_file_name = Path(__file__).parent.parent.parent / "docs/.well-known/skills.yaml"
-        async with aiofiles.open(str(skill_yaml_file_name), mode="r") as reader:
-            data = await reader.read(-1)
+        data = await aread(filename=skill_yaml_file_name)
         skill_data = yaml.safe_load(data)
         return SkillsDeclaration(**skill_data)
 

--- a/metagpt/provider/google_gemini_api.py
+++ b/metagpt/provider/google_gemini_api.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # @Desc   : Google Gemini LLM from https://ai.google.dev/tutorials/python_quickstart
-
+import os
 from typing import Optional, Union
 
 import google.generativeai as genai
@@ -58,6 +58,10 @@ class GeminiLLM(BaseLLM):
         self.llm = GeminiGenerativeModel(model_name=self.model)
 
     def __init_gemini(self, config: LLMConfig):
+        if config.proxy:
+            logger.info(f"Use proxy: {config.proxy}")
+            os.environ["HTTP_PROXY"] = config.proxy
+            os.environ["HTTP_PROXYS"] = config.proxy
         genai.configure(api_key=config.api_key)
 
     def _user_msg(self, msg: str, images: Optional[Union[str, list[str]]] = None) -> dict[str, str]:

--- a/metagpt/utils/dependency_file.py
+++ b/metagpt/utils/dependency_file.py
@@ -13,9 +13,7 @@ import re
 from pathlib import Path
 from typing import Set
 
-import aiofiles
-
-from metagpt.utils.common import aread
+from metagpt.utils.common import aread, awrite
 from metagpt.utils.exceptions import handle_exception
 
 
@@ -45,8 +43,7 @@ class DependencyFile:
     async def save(self):
         """Save dependencies to the file asynchronously."""
         data = json.dumps(self._dependencies)
-        async with aiofiles.open(str(self._filename), mode="w") as writer:
-            await writer.write(data)
+        await awrite(filename=self._filename, data=data)
 
     async def update(self, filename: Path | str, dependencies: Set[Path | str], persist=True):
         """Update dependencies for a file asynchronously.

--- a/metagpt/utils/file_repository.py
+++ b/metagpt/utils/file_repository.py
@@ -14,11 +14,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Set
 
-import aiofiles
-
 from metagpt.logs import logger
 from metagpt.schema import Document
-from metagpt.utils.common import aread
+from metagpt.utils.common import aread, awrite
 from metagpt.utils.json_to_markdown import json_to_markdown
 
 
@@ -55,8 +53,7 @@ class FileRepository:
         pathname = self.workdir / filename
         pathname.parent.mkdir(parents=True, exist_ok=True)
         content = content if content else ""  # avoid `argument must be str, not None` to make it continue
-        async with aiofiles.open(str(pathname), mode="w") as writer:
-            await writer.write(content)
+        await awrite(filename=str(pathname), data=content)
         logger.info(f"save to: {str(pathname)}")
 
         if dependencies is not None:

--- a/metagpt/utils/mermaid.py
+++ b/metagpt/utils/mermaid.py
@@ -9,11 +9,9 @@ import asyncio
 import os
 from pathlib import Path
 
-import aiofiles
-
 from metagpt.config2 import config
 from metagpt.logs import logger
-from metagpt.utils.common import check_cmd_exists
+from metagpt.utils.common import awrite, check_cmd_exists
 
 
 async def mermaid_to_file(engine, mermaid_code, output_file_without_suffix, width=2048, height=2048) -> int:
@@ -30,9 +28,7 @@ async def mermaid_to_file(engine, mermaid_code, output_file_without_suffix, widt
     if dir_name and not os.path.exists(dir_name):
         os.makedirs(dir_name)
     tmp = Path(f"{output_file_without_suffix}.mmd")
-    async with aiofiles.open(tmp, "w", encoding="utf-8") as f:
-        await f.write(mermaid_code)
-    # tmp.write_text(mermaid_code, encoding="utf-8")
+    await awrite(filename=tmp, data=mermaid_code)
 
     if engine == "nodejs":
         if check_cmd_exists(config.mermaid.path) != 0:

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ extras_require["dev"] = (["pylint~=3.0.3", "black~=23.3.0", "isort~=5.12.0", "pr
 
 setup(
     name="metagpt",
-    version="0.7.5",
+    version="0.7.6",
     description="The Multi-Agent Framework",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ extras_require["dev"] = (["pylint~=3.0.3", "black~=23.3.0", "isort~=5.12.0", "pr
 
 setup(
     name="metagpt",
-    version="0.7.4",
+    version="0.7.5",
     description="The Multi-Agent Framework",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/metagpt/roles/test_tutorial_assistant.py
+++ b/tests/metagpt/roles/test_tutorial_assistant.py
@@ -6,11 +6,11 @@
 @File    : test_tutorial_assistant.py
 """
 
-import aiofiles
 import pytest
 
 from metagpt.const import TUTORIAL_PATH
 from metagpt.roles.tutorial_assistant import TutorialAssistant
+from metagpt.utils.common import aread
 
 
 @pytest.mark.asyncio
@@ -20,9 +20,8 @@ async def test_tutorial_assistant(language: str, topic: str, context):
     msg = await role.run(topic)
     assert TUTORIAL_PATH.exists()
     filename = msg.content
-    async with aiofiles.open(filename, mode="r", encoding="utf-8") as reader:
-        content = await reader.read()
-        assert "pip" in content
+    content = await aread(filename=filename)
+    assert "pip" in content
 
 
 if __name__ == "__main__":

--- a/tests/metagpt/utils/test_git_repository.py
+++ b/tests/metagpt/utils/test_git_repository.py
@@ -10,15 +10,14 @@
 import shutil
 from pathlib import Path
 
-import aiofiles
 import pytest
 
+from metagpt.utils.common import awrite
 from metagpt.utils.git_repository import GitRepository
 
 
 async def mock_file(filename, content=""):
-    async with aiofiles.open(str(filename), mode="w") as file:
-        await file.write(content)
+    await awrite(filename=filename, data=content)
 
 
 async def mock_repo(local_path) -> (GitRepository, Path):

--- a/tests/metagpt/utils/test_s3.py
+++ b/tests/metagpt/utils/test_s3.py
@@ -9,7 +9,6 @@ import uuid
 from pathlib import Path
 
 import aioboto3
-import aiofiles
 import pytest
 
 from metagpt.config2 import Config
@@ -37,7 +36,7 @@ async def test_s3(mocker):
     conn = S3(s3)
     object_name = "unittest.bak"
     await conn.upload_file(bucket=s3.bucket, local_path=__file__, object_name=object_name)
-    pathname = (Path(__file__).parent / uuid.uuid4().hex).with_suffix(".bak")
+    pathname = (Path(__file__).parent / "../../../workspace/unittest" / uuid.uuid4().hex).with_suffix(".bak")
     pathname.unlink(missing_ok=True)
     await conn.download_file(bucket=s3.bucket, object_name=object_name, local_path=str(pathname))
     assert pathname.exists()
@@ -45,8 +44,7 @@ async def test_s3(mocker):
     assert url
     bin_data = await conn.get_object(bucket=s3.bucket, object_name=object_name)
     assert bin_data
-    async with aiofiles.open(__file__, mode="r", encoding="utf-8") as reader:
-        data = await reader.read()
+    data = await aread(filename=__file__)
     res = await conn.cache(data, ".bak", "script")
     assert "http" in res
 
@@ -59,8 +57,6 @@ async def test_s3(mocker):
         assert not res
     except Exception:
         pass
-
-    await reader.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Features**
- Due to the absence of a specified character set, the function for saving files used the system's default character set, gbk, to save files. However, the Unicode character "\u27f6" does not have a corresponding character in gbk, resulting in a character set conversion exception being raised.
- The modified file read/write operations now uniformly adopt the utf-8 character set. In cases where a character set exception is encountered while reading files, adaptive character set detection logic has been added.

**Issue**
![img_v3_028o_c17ff164-6c18-4475-8ae3-e78e535f6dfg](https://github.com/geekan/MetaGPT/assets/46912756/f8875cf2-a9bd-48a2-9c29-116d5bb68841)
