### PR TITLE
Fix ipykernel error in _plan_and_act of Interpreter.

### DIFF
--- a/metagpt/actions/mi/execute_nb_code.py
+++ b/metagpt/actions/mi/execute_nb_code.py
@@ -58,7 +58,8 @@ class ExecuteNbCode(Action):
 
     async def terminate(self):
         """kill NotebookClient"""
-        await self.nb_client._async_cleanup_kernel()
+        if self.nb_client.km is not None:
+            await self.nb_client._async_cleanup_kernel()
 
     async def reset(self):
         """reset NotebookClient"""

--- a/metagpt/roles/mi/interpreter.py
+++ b/metagpt/roles/mi/interpreter.py
@@ -42,6 +42,10 @@ class Interpreter(Role):
     def working_memory(self):
         return self.rc.working_memory
 
+    async def _plan_and_act(self) -> Message:
+        await super()._plan_and_act()
+        await self.execute_code.terminate()
+
     async def _act_on_task(self, current_task: Task) -> TaskResult:
         code, result, is_success = await self._write_and_exec_code()
         task_result = TaskResult(code=code, result=result, is_success=is_success)

--- a/metagpt/roles/role.py
+++ b/metagpt/roles/role.py
@@ -503,9 +503,6 @@ class Role(SerializationMixin, ContextMixin, BaseModel):
 
         self.rc.memory.add(rsp)  # add to persistent memory
 
-        if hasattr(self, "execute_code") and hasattr(self.execute_code, "terminate"):
-            await self.execute_code.terminate()
-
         return rsp
 
     async def _act_on_task(self, current_task: Task) -> TaskResult:

--- a/metagpt/roles/role.py
+++ b/metagpt/roles/role.py
@@ -503,6 +503,9 @@ class Role(SerializationMixin, ContextMixin, BaseModel):
 
         self.rc.memory.add(rsp)  # add to persistent memory
 
+        if hasattr(self, "execute_code") and hasattr(self.execute_code, "terminate"):
+            await self.execute_code.terminate()
+
         return rsp
 
     async def _act_on_task(self, current_task: Task) -> TaskResult:

--- a/tests/metagpt/actions/mi/test_execute_nb_code.py
+++ b/tests/metagpt/actions/mi/test_execute_nb_code.py
@@ -104,6 +104,15 @@ async def test_terminate():
 
     time.sleep(2)
     assert executor.nb_client.km is None
+    for _ in range(200):
+        executor = ExecuteNbCode()
+        await executor.run(code='print("This is a code!")', language="python")
+        is_kernel_alive = await executor.nb_client.km.is_alive()
+        assert is_kernel_alive
+        await executor.terminate()
+        assert executor.nb_client.km is None
+        assert executor.nb_client.kc is None
+    await executor.terminate()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fix ipykernel error in _plan_and_act of Role: If you create a lot of ExecuteNbCode instance objects without closing it, you will face the following error:
Traceback (most recent call last):
  File "/anaconda3/lib/python3.9/runpy.py", line 197, in _run_module_as_main
  File "/opt/anaconda3/lib/python3.9/runpy.py", line 87, in _run_code
  File "/opt/anaconda3/lib/python3.9/site-packages/ipykernel_launcher.py", line 17, in <module>
  File "/opt/anaconda3/lib/python3.9/site-packages/traitlets/config/application.py", line 991, in launch_instance
  File "/opt/anaconda3/lib/python3.9/site-packages/traitlets/config/application.py", line 113, in inner
  File "/opt/anaconda3/lib/python3.9/site-packages/ipykernel/kernelapp.py", line 692, in initialize
  File "/opt/anaconda3/lib/python3.9/site-packages/ipykernel/kernelapp.py", line 329, in init_sockets
  File "/opt/anaconda3/lib/python3.9/site-packages/zmq/sugar/context.py", line 362, in socket
  File "/opt/anaconda3/lib/python3.9/site-packages/zmq/sugar/socket.py", line 159, in __init__
  File "zmq/backend/cython/socket.pyx", line 332, in zmq.backend.cython.socket.Socket.__init__
zmq.error.ZMQError: Too many open files in system

Finally, the error `Fatal Python error: _Py_HashRandomization_Init: failed to get random numbers to initialize Python
Python runtime state: preinitialized [IPKernelApp] WARNING | Parent appears to have exited, shutting down.` may be found.