### PR TITLE
refine parse_outputs in ExecuteNbCode.

### DIFF
--- a/metagpt/actions/mi/execute_nb_code.py
+++ b/metagpt/actions/mi/execute_nb_code.py
@@ -120,8 +120,8 @@ class ExecuteNbCode(Action):
                 is_success = False
 
             output_text = remove_escape_and_color_codes(output_text)
-            # The valid information of the exception is at the end,
-            # the valid information of Normal output is at the begining.
+            # The useful information of the exception is at the end,
+            # the useful information of normal output is at the begining.
             output_text = output_text[:keep_len] if is_success else output_text[-keep_len:]
 
             parsed_output.append(output_text)

--- a/metagpt/actions/mi/execute_nb_code.py
+++ b/metagpt/actions/mi/execute_nb_code.py
@@ -96,7 +96,6 @@ class ExecuteNbCode(Action):
         assert isinstance(outputs, list)
         parsed_output, is_success = [], True
         for i, output in enumerate(outputs):
-            is_success = "traceback" not in output.keys()
             if output["output_type"] == "stream" and not any(
                 tag in output["text"]
                 for tag in ["| INFO     | metagpt", "| ERROR    | metagpt", "| WARNING  | metagpt", "DEBUG"]

--- a/tests/metagpt/actions/mi/test_execute_nb_code.py
+++ b/tests/metagpt/actions/mi/test_execute_nb_code.py
@@ -68,7 +68,7 @@ async def test_run_code_text():
     executor = ExecuteNbCode()
     message, success = await executor.run(code='print("This is a code!")', language="python")
     assert success
-    assert message == "This is a code!\n"
+    assert "This is a code!" in message
     message, success = await executor.run(code="# This is a code!", language="markdown")
     assert success
     assert message == "# This is a code!"
@@ -118,10 +118,11 @@ async def test_parse_outputs():
     import pandas as pd
     df = pd.DataFrame({'ID': [1,2,3], 'NAME': ['a', 'b', 'c']})
     print(df.columns)
+    print(f"columns num:{len(df.columns)}")
     print(df['DUMMPY_ID'])
     """
     output, is_success = await executor.run(code)
     assert not is_success
     assert "Index(['ID', 'NAME'], dtype='object')" in output
-    assert "Executed code failed," in output
     assert "KeyError: 'DUMMPY_ID'" in output
+    assert "columns num:2" in output

--- a/tests/metagpt/actions/mi/test_execute_nb_code.py
+++ b/tests/metagpt/actions/mi/test_execute_nb_code.py
@@ -100,6 +100,7 @@ async def test_terminate():
     is_kernel_alive = await executor.nb_client.km.is_alive()
     assert is_kernel_alive
     await executor.terminate()
+
     import time
 
     time.sleep(2)
@@ -123,3 +124,19 @@ async def test_reset():
     assert is_kernel_alive
     await executor.reset()
     assert executor.nb_client.km is None
+
+
+@pytest.mark.asyncio
+async def test_parse_outputs():
+    executor = ExecuteNbCode()
+    code = """
+    import pandas as pd
+    df = pd.DataFrame({'ID': [1,2,3], 'NAME': ['a', 'b', 'c']})
+    print(df.columns)
+    print(df['DUMMPY_ID'])
+    """
+    output, is_success = await executor.run(code)
+    assert not is_success
+    assert "Index(['ID', 'NAME'], dtype='object')" in output
+    assert "Executed code failed," in output
+    assert "KeyError: 'DUMMPY_ID'" in output

--- a/tests/metagpt/actions/mi/test_execute_nb_code.py
+++ b/tests/metagpt/actions/mi/test_execute_nb_code.py
@@ -1,6 +1,6 @@
 import pytest
 
-from metagpt.actions.mi.execute_nb_code import ExecuteNbCode, truncate
+from metagpt.actions.mi.execute_nb_code import ExecuteNbCode
 
 
 @pytest.mark.asyncio
@@ -52,21 +52,6 @@ async def test_plotting_code():
     executor = ExecuteNbCode()
     output, is_success = await executor.run(PLOT_CODE)
     assert is_success
-
-
-def test_truncate():
-    # 代码执行成功
-    output, is_success = truncate("hello world", 5, True)
-    assert "Truncated to show only first 5 characters\nhello" in output
-    assert is_success
-    # 代码执行失败
-    output, is_success = truncate("hello world", 5, False)
-    assert "Truncated to show only last 5 characters\nworld" in output
-    assert not is_success
-    # 异步
-    output, is_success = truncate("<coroutine object", 5, True)
-    assert not is_success
-    assert "await" in output
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
重构ExecuteNbCode中输出解析部分代码。实现同时输出代码片段中的正常打印内容和异常内容，示例如下：
```python
executor = ExecuteNbCode()
code = """
import pandas as pd
df = pd.DataFrame({'ID': [1,2,3], 'NAME': ['a', 'b', 'c']})
print(df.columns)  # 需要正常输出的内容
print(df['DUMMPY_ID'])  # 会发生异常的代码
"""
output, is_success = await executor.run(code)
assert not is_success                 # -> True
assert "Index(['ID', 'NAME'], dtype='object')" in output  # -> True
assert "Executed code failed," in output  # -> True
assert "KeyError: 'DUMMPY_ID'" in output # -> True
print(output)
#  Index(['ID', 'NAME'], dtype='object')    # 这是需要正常输出的内容，剩下的是需要输出的异常信息
#, Executed code failed, please reflect the cause of bug and then debug. Truncated to show only last 2000 characters
#-----------------------------------------------------------------
# KeyError                                  Traceback (most recent call last)
# File ~/opt/anaconda3/envs/metagpt/lib/python3.9/site-packages/pandas/core/indexes/base.py:3653, in 
# Index.get_loc(self, key)
# 3652 try:
# -> 3653     return self._engine.get_loc(casted_key)
# 3654 except KeyError as err:
# ....
```