### PR TITLE
add asyncio.CancelledError to serialize_decorator

### DIFF
--- a/metagpt/utils/common.py
+++ b/metagpt/utils/common.py
@@ -23,6 +23,7 @@ import platform
 import re
 import sys
 import traceback
+import asyncio
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Callable, List, Literal, Tuple, Union
@@ -625,6 +626,8 @@ def serialize_decorator(func):
             return result
         except KeyboardInterrupt:
             logger.error(f"KeyboardInterrupt occurs, start to serialize the project, exp:\n{format_trackback_info()}")
+        except asyncio.CancelledError:
+            logger.error(f"KeyboardInterrupt occured inside async call, start to serialize the project, exp:\n{format_trackback_info()}")
         except Exception:
             logger.error(f"Exception occurs, start to serialize the project, exp:\n{format_trackback_info()}")
         self.serialize()  # Team.serialize

--- a/metagpt/utils/common.py
+++ b/metagpt/utils/common.py
@@ -637,7 +637,7 @@ def role_raise_decorator(func):
     async def wrapper(self, *args, **kwargs):
         try:
             return await func(self, *args, **kwargs)
-        except KeyboardInterrupt as kbi:
+        except (asyncio.CancelledError, KeyboardInterrupt) as kbi:
             logger.error(f"KeyboardInterrupt: {kbi} occurs, start to serialize the project")
             if self.latest_observed_msg:
                 self.rc.memory.delete(self.latest_observed_msg)

--- a/metagpt/utils/common.py
+++ b/metagpt/utils/common.py
@@ -624,10 +624,8 @@ def serialize_decorator(func):
         try:
             result = await func(self, *args, **kwargs)
             return result
-        except KeyboardInterrupt:
+        except (asyncio.CancelledError, KeyboardInterrupt):
             logger.error(f"KeyboardInterrupt occurs, start to serialize the project, exp:\n{format_trackback_info()}")
-        except asyncio.CancelledError:
-            logger.error(f"KeyboardInterrupt occured inside async call, start to serialize the project, exp:\n{format_trackback_info()}")
         except Exception:
             logger.error(f"Exception occurs, start to serialize the project, exp:\n{format_trackback_info()}")
         self.serialize()  # Team.serialize


### PR DESCRIPTION
while investigating issue #1013 I tried `ctrl + c` to start serializing for a deserialize run, but `Team.serialize` was not being triggered. 

the traceback looks something like
```
... 
  File "/Users/zibo/fun/MetaGPT/.venv/lib/python3.11/site-packages/grpc/aio/_call.py", line 370, in _read                                                                            
    raw_response = await self._cython_call.receive_serialized_message()                                                                                                              
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                              
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi", line 372, in receive_serialized_message                                                                            
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi", line 126, in _receive_message                                                                           
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi", line 99, in execute_batch                                                                               
asyncio.exceptions.CancelledError                                                                                                                                                    
                                                                                                                                                                                     
During handling of the above exception, another exception occurred:                                                                                                                  
                                                                                                                                                                                     
Traceback (most recent call last):                                                                                                                                                   
  File "/Users/zibo/fun/MetaGPT/test.py", line 29, in <module>                                                                                                                       
    asyncio.run(startup("write number guessing game lol but make sure to cause error"))                                                                                              
  File "/opt/homebrew/Cellar/python@3.11/3.11.6/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/runners.py", line 190, in run                                       
    return runner.run(main)                                                                                                                                                          
           ^^^^^^^^^^^^^^^^                                                                                                                                                          
  File "/opt/homebrew/Cellar/python@3.11/3.11.6/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/runners.py", line 123, in run                                       
    raise KeyboardInterrupt()                                                                                                                                                        
KeyboardInterrupt                                  
```

where the `KeyboardInterrupt` was triggered inside `asyncio.exceptions.CancelledError`. 
`asyncio.exceptions.CancelledError` was also not being caught by `Exception` because it inherits from `BaseException` 
so `ctrl + c` ends the program without serializing.

not sure if this is intended or not since I'm very new to this repo

for the fix, I kept KeyboardInterrupt in in case non-async code gets added.                                                                                                                                          