### PR TITLE
fix(ollama): TypeError

### DIFF
--- a/metagpt/provider/ollama_api.py
+++ b/metagpt/provider/ollama_api.py
@@ -23,7 +23,7 @@ class OllamaLLM(BaseLLM):
         self.__init_ollama(config)
         self.client = GeneralAPIRequestor(base_url=config.base_url)
         self.config = config
-        self.suffix_url = "/chat"
+        self.suffix_url = "/api/chat"
         self.http_method = "post"
         self.use_system_prompt = False
         self.cost_manager = TokenCostManager()


### PR DESCRIPTION
 Ollama | TypeError: 'async for' requires an object with __aiter__ method, got bytes #1024

```yaml
llm:
  api_type: ollama
  model: qwen:72b-chat
  base_url: http://192.168.1.180:11434
  api_key: x
```