### PR TITLE
Correct bad URL in token_counter

### DIFF
--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -229,7 +229,7 @@ def count_message_tokens(messages, model="gpt-3.5-turbo-0125"):
     else:
         raise NotImplementedError(
             f"num_tokens_from_messages() is not implemented for model {model}. "
-            f"See https://github.com/openai/openai-python/blob/main/chatml.md "
+            f"See https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken "
             f"for information on how messages are converted to tokens."
         )
     num_tokens = 0


### PR DESCRIPTION
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

Fix bug:
```
2024-03-19 14:52:18.433 | WARNING  | metagpt.provider.openai_api:_calc_usage:250 - usage calculation failed: num_tokens_from_messages() is not implemented for model gpt4. See https://github.com/openai/openai-python/blob/main/chatml.md for information on how messages are converted to tokens.
```

In fact the link `https://github.com/openai/openai-python/blob/main/chatml.md` as been removed long time, that mislead users. The PR is correct the link.

With the changes, the output as following:
```
2024-03-19 15:59:26.193 | WARNING  | metagpt.provider.openai_api:_calc_usage:247 - usage calculation failed: num_tokens_from_messages() is not implemented for model gpt4. See https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken for information on how messages are converted to tokens.
```
    
**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->

**Result**
<!-- The screenshot/log of unittest/running result -->

**Other**
<!-- Something else about this PR. -->