### PR TITLE
Feature mute stream log for info level

### DIFF
--- a/metagpt/logs.py
+++ b/metagpt/logs.py
@@ -14,9 +14,13 @@ from loguru import logger as _logger
 
 from metagpt.const import METAGPT_ROOT
 
+_print_level = "INFO"
 
 def define_log_level(print_level="INFO", logfile_level="DEBUG", name: str = None):
     """Adjust the log level to above level"""
+    global _print_level
+    _print_level = print_level
+
     current_date = datetime.now()
     formatted_date = current_date.strftime("%Y%m%d")
     log_name = f"{name}_{formatted_date}" if name else formatted_date  # name a log with prefix name
@@ -31,7 +35,8 @@ logger = define_log_level()
 
 
 def log_llm_stream(msg):
-    _llm_stream_log(msg)
+  if _print_level in ["DEBUG"]:
+        _llm_stream_log(msg)
 
 
 def set_llm_stream_logfunc(func):

--- a/metagpt/logs.py
+++ b/metagpt/logs.py
@@ -35,8 +35,7 @@ logger = define_log_level()
 
 
 def log_llm_stream(msg):
-  if _print_level in ["DEBUG"]:
-        _llm_stream_log(msg)
+    _llm_stream_log(msg)
 
 
 def set_llm_stream_logfunc(func):
@@ -44,4 +43,6 @@ def set_llm_stream_logfunc(func):
     _llm_stream_log = func
 
 
-_llm_stream_log = partial(print, end="")
+def _llm_stream_log(msg):
+    if _print_level in ["DEBUG"]:
+        print(msg, end="")


### PR DESCRIPTION
**Features**
see issue : #1109 
llm stream_response alway been print regardless of debug flag
I modified `logs.py` rather than `config2.py`.
This is because log is been set via `define_log_level` rather than `config.yaml`
To keep things simple, a global variable `_print_level` is introduced in `logs.py`
    
**Influence**
`define_log_level(print_level="INFO")` will mute `log_llm_stream`
