### PR TITLE
fix api_version bug

### DIFF
--- a/examples/werewolf_game/actions/experience_operation.py
+++ b/examples/werewolf_game/actions/experience_operation.py
@@ -17,7 +17,7 @@ EMB_FN = embedding_functions.OpenAIEmbeddingFunction(
     api_base=CONFIG.openai_api_base,
     api_type=CONFIG.openai_api_type,
     model_name="text-embedding-ada-002",
-    api_version="2",
+    # api_version="2",
 )
 
 class AddNewExperiences(Action):


### PR DESCRIPTION
Without commenting out this line, there seems to be a problem when I run `start_game.py`, and this is caused by setting `api_version` to 2. After commenting out this line, everything works fine
```
Traceback (most recent call last):
  File "/opt/homebrew/anaconda3/envs/venv311/lib/python3.11/site-packages/tenacity/_asyncio.py", line 50, in __call__
    result = await fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/collin/Documents/Projects/MetaGPT/examples/werewolf_game/actions/common_actions.py", line 211, in run
    rsp = await self._aask(prompt)
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/collin/Documents/Projects/MetaGPT/metagpt/actions/action.py", line 50, in _aask
    return await self.llm.aask(prompt, system_msgs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/collin/Documents/Projects/MetaGPT/metagpt/provider/base_gpt_api.py", line 44, in aask
    rsp = await self.acompletion_text(message, stream=True)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/venv311/lib/python3.11/site-packages/tenacity/_asyncio.py", line 88, in async_wrapped
    return await fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/venv311/lib/python3.11/site-packages/tenacity/_asyncio.py", line 47, in __call__
    do = self.iter(retry_state=retry_state)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/venv311/lib/python3.11/site-packages/tenacity/__init__.py", line 314, in iter
    return fut.result()
           ^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/venv311/lib/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/venv311/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/opt/homebrew/anaconda3/envs/venv311/lib/python3.11/site-packages/tenacity/_asyncio.py", line 50, in __call__
    result = await fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/collin/Documents/Projects/MetaGPT/metagpt/provider/openai_api.py", line 238, in acompletion_text
    return await self._achat_completion_stream(messages)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/collin/Documents/Projects/MetaGPT/metagpt/provider/openai_api.py", line 163, in _achat_completion_stream
    response = await openai.ChatCompletion.acreate(**self._cons_kwargs(messages), stream=True)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/venv311/lib/python3.11/site-packages/openai/api_resources/chat_completion.py", line 45, in acreate
    return await super().acreate(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/venv311/lib/python3.11/site-packages/openai/api_resources/abstract/engine_api_resource.py", line 219, in acreate
    response, _, api_key = await requestor.arequest(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/venv311/lib/python3.11/site-packages/openai/api_requestor.py", line 384, in arequest
    resp, got_stream = await self._interpret_async_response(result, stream)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/venv311/lib/python3.11/site-packages/openai/api_requestor.py", line 738, in _interpret_async_response
    self._interpret_response_line(
  File "/opt/homebrew/anaconda3/envs/venv311/lib/python3.11/site-packages/openai/api_requestor.py", line 775, in _interpret_response_line
    raise self.handle_error_response(
openai.error.InvalidRequestError: Unsupported OpenAI-Version header provided: 2. (HINT: you can provide any of the following supported versions: 2020-10-01, 2020-11-07. Alternatively, you can simply omit this header to use the default version associated with your account.)
```