### PR TITLE
add try_except for _plan_and_act in data_interpreter.

### DIFF
--- a/metagpt/roles/di/data_interpreter.py
+++ b/metagpt/roles/di/data_interpreter.py
@@ -86,9 +86,13 @@ class DataInterpreter(Role):
         return Message(content=code, role="assistant", cause_by=WriteAnalysisCode)
 
     async def _plan_and_act(self) -> Message:
-        rsp = await super()._plan_and_act()
-        await self.execute_code.terminate()
-        return rsp
+        try:
+            rsp = await super()._plan_and_act()
+            await self.execute_code.terminate()
+            return rsp
+        except Exception as e:
+            await self.execute_code.terminate()
+            raise e
 
     async def _act_on_task(self, current_task: Task) -> TaskResult:
         """Useful in 'plan_and_act' mode. Wrap the output in a TaskResult for review and confirmation."""


### PR DESCRIPTION
在data_interpreter的_plan_and_act中添加异常捕获，并在捕获异常时同样也对ExecuteNbCode执行terminate，有助于减少`[IPKernelApp] WARNING | Parent appears to have exited, shutting down.`的出现，保证ExecuteNbCode占用的资源被及时释放。可以减少此类问题对MG debug的干扰，和此有关的issue有：https://github.com/geekan/MetaGPT/issues/1014, https://github.com/geekan/MetaGPT/issues/1009, https://github.com/geekan/MetaGPT/issues/908