### PR TITLE
fixbug: TypeError: _evaluate() got an unexpected keyword argument 'recursive_guard'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ openai==1.6.1
 openpyxl
 beautifulsoup4==4.12.3
 pandas==2.1.1
-pydantic==2.5.3
+pydantic==2.6.4
 #pygame==2.1.3
 #pymilvus==2.2.8
 # pytest==7.2.2 # test extras require

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ extras_require["dev"] = (["pylint~=3.0.3", "black~=23.3.0", "isort~=5.12.0", "pr
 
 setup(
     name="metagpt",
-    version="0.8.0",
+    version="0.8.1",
     description="The Multi-Agent Framework",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
**Features**
- fixbug: `TypeError: _evaluate() got an unexpected keyword argument 'recursive_guard'` in windows os.