### PR TITLE
Feat fix test_an ut failed without simulator

### DIFF
--- a/metagpt/environment/werewolf/env_space.py
+++ b/metagpt/environment/werewolf/env_space.py
@@ -39,7 +39,9 @@ def get_observation_space() -> spaces.Dict:
                 (spaces.Text(16), spaces.Text(16))
             ),  # TODO should be tuple of variable length
             "player_hunted": spaces.Text(16),
-            "player_current_dead": spaces.Tuple((spaces.Text(16))),  # TODO should be tuple of variable length
+            "player_current_dead": spaces.Tuple(
+                (spaces.Text(16), spaces.Text(16))
+            ),  # TODO should be tuple of variable length
             "witch_poison_left": spaces.Discrete(2),
             "witch_antidote_left": spaces.Discrete(2),
             "winner": spaces.Text(16),

--- a/tests/metagpt/ext/android_assistant/test_an.py
+++ b/tests/metagpt/ext/android_assistant/test_an.py
@@ -6,6 +6,7 @@ import asyncio
 import time
 from pathlib import Path
 
+import metagpt
 from metagpt.const import TEST_DATA_PATH
 from metagpt.environment.android.android_env import AndroidEnv
 from metagpt.ext.android_assistant.actions.manual_record import ManualRecord
@@ -13,6 +14,10 @@ from metagpt.ext.android_assistant.actions.parse_record import ParseRecord
 from metagpt.ext.android_assistant.actions.screenshot_parse import ScreenshotParse
 from metagpt.ext.android_assistant.actions.self_learn_and_reflect import (
     SelfLearnAndReflect,
+)
+from tests.metagpt.environment.android_env.test_android_ext_env import (
+    mock_device_shape,
+    mock_list_devices,
 )
 
 TASK_PATH = TEST_DATA_PATH.joinpath("andriod_assistant/unitest_Contacts")
@@ -24,6 +29,11 @@ PARSE_RECORD_DOC_PATH = TASK_PATH.joinpath("demo_docs")
 device_id = "emulator-5554"
 xml_dir = Path("/sdcard")
 screenshot_dir = Path("/sdcard/Pictures/Screenshots")
+
+
+metagpt.environment.android.android_ext_env.AndroidExtEnv.execute_adb_with_cmd = mock_device_shape
+metagpt.environment.android.android_ext_env.AndroidExtEnv.list_devices = mock_list_devices
+
 
 test_env_self_learn_android = AndroidEnv(
     device_id=device_id,


### PR DESCRIPTION
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

- fix test_an ut failed without simulator
    
**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->

**Result**
<!-- The screenshot/log of unittest/running result -->

```
(metagpt) MacBook-Pro:MetaGPT xxxx$ pytest tests/metagpt/ext/android_assistant/*
========================================================================================================= test session starts ==========================================================================================================
collected 0 items                                                                                                                                                                                                                      

=========================================================================================================== warnings summary ===========================================================================================================

========================================================================================================== 1 warning in 1.16s ==========================================================================================================
(metagpt) MacBook-Pro:MetaGPT xxxx$ pytest tests/metagpt/environment/android_env/
__init__.py              __pycache__/             test_android_ext_env.py  
(metagpt) MacBook-Pro:MetaGPT xxxx$ pytest tests/metagpt/environment/android_env/*
========================================================================================================= test session starts ==========================================================================================================
collected 2 items                                                                                                                                                                                                                      

tests/metagpt/environment/android_env/test_android_ext_env.py ..
===================================================================================================== 2 passed, 1 warning in 1.02s =====================================================================================================
```

**Other**
<!-- Something else about this PR. -->