### PR TITLE
fixbug: vscode, FileNotFoundError: [Errno 2] No such file or directory: '.vs/MetaGPT/v16/.suo'

### DIFF
--- a/metagpt/utils/git_repository.py
+++ b/metagpt/utils/git_repository.py
@@ -78,7 +78,7 @@ class GitRepository:
         self._repository = Repo.init(path=Path(local_path))
 
         gitignore_filename = Path(local_path) / ".gitignore"
-        ignores = ["__pycache__", "*.pyc"]
+        ignores = ["__pycache__", "*.pyc", ".vs"]
         with open(str(gitignore_filename), mode="w") as writer:
             writer.write("\n".join(ignores))
         self._repository.index.add([".gitignore"])


### PR DESCRIPTION
**Fixbug**
- The files in vscode's private folder will cause this error. Add vscode's private folder to avoid this error.