### PR TITLE
Fix the potential duplicate embeddings in the RAG module

### DIFF
--- a/examples/rag_pipeline.py
+++ b/examples/rag_pipeline.py
@@ -40,7 +40,10 @@ class Player(BaseModel):
 
 
 class RAGExample:
-    """Show how to use RAG."""
+    """Show how to use RAG.
+
+    Default engine use LLM Reranker, if the answer from the LLM is incorrect, may encounter `IndexError: list index out of range`.
+    """
 
     def __init__(self, engine: SimpleEngine = None):
         self._engine = engine
@@ -59,6 +62,7 @@ class RAGExample:
     def engine(self, value: SimpleEngine):
         self._engine = value
 
+    @handle_exception
     async def run_pipeline(self, question=QUESTION, print_title=True):
         """This example run rag pipeline, use faiss retriever and llm ranker, will print something like:
 
@@ -79,6 +83,7 @@ class RAGExample:
         answer = await self.engine.aquery(question)
         self._print_query_result(answer)
 
+    @handle_exception
     async def add_docs(self):
         """This example show how to add docs.
 
@@ -148,6 +153,7 @@ class RAGExample:
         except Exception as e:
             logger.error(f"nodes is empty, llm don't answer correctly, exception: {e}")
 
+    @handle_exception
     async def init_objects(self):
         """This example show how to from objs, will print something like:
 
@@ -160,6 +166,7 @@ class RAGExample:
         await self.add_objects(print_title=False)
         self.engine = pre_engine
 
+    @handle_exception
     async def init_and_query_chromadb(self):
         """This example show how to use chromadb. how to save and load index. will print something like:
 
@@ -233,7 +240,7 @@ class RAGExample:
 
 
 async def main():
-    """RAG pipeline"""
+    """RAG pipeline."""
     e = RAGExample()
     await e.run_pipeline()
     await e.add_docs()

--- a/metagpt/rag/engines/simple.py
+++ b/metagpt/rag/engines/simple.py
@@ -220,7 +220,9 @@ class SimpleEngine(RetrieverQueryEngine):
         embed_model = cls._resolve_embed_model(embed_model, retriever_configs)
         llm = llm or get_rag_llm()
 
-        retriever = get_retriever(configs=retriever_configs, nodes=nodes, embed_model=embed_model)
+        retriever = get_retriever(
+            configs=retriever_configs, nodes=nodes, embed_model=embed_model
+        )  # Default VectorStoreIndex(nodes, embed_model).as_retriever
         rankers = get_rankers(configs=ranker_configs, llm=llm)  # Default []
 
         return cls(

--- a/metagpt/rag/engines/simple.py
+++ b/metagpt/rag/engines/simple.py
@@ -220,9 +220,7 @@ class SimpleEngine(RetrieverQueryEngine):
         embed_model = cls._resolve_embed_model(embed_model, retriever_configs)
         llm = llm or get_rag_llm()
 
-        retriever = get_retriever(
-            configs=retriever_configs, nodes=nodes, embed_model=embed_model
-        )  # Default VectorStoreIndex(nodes, embed_model).as_retriever
+        retriever = get_retriever(configs=retriever_configs, nodes=nodes, embed_model=embed_model)
         rankers = get_rankers(configs=ranker_configs, llm=llm)  # Default []
 
         return cls(

--- a/metagpt/rag/factories/base.py
+++ b/metagpt/rag/factories/base.py
@@ -36,19 +36,26 @@ class ConfigBasedFactory(GenericFactory):
     """Designed to get objects based on object type."""
 
     def get_instance(self, key: Any, **kwargs) -> Any:
-        """Key is config, such as a pydantic model.
+        """Get instance by the type of key.
 
-        Call func by the type of key, and the key will be passed to func.
+        Key is config, such as a pydantic model, call func by the type of key, and the key will be passed to func.
+        Raise Exception if key not found.
         """
         creator = self._creators.get(type(key))
         if creator:
             return creator(key, **kwargs)
 
+        self._raise_for_key(key)
+
+    def _raise_for_key(self, key: Any):
         raise ValueError(f"Unknown config: `{type(key)}`, {key}")
 
     @staticmethod
     def _val_from_config_or_kwargs(key: str, config: object = None, **kwargs) -> Any:
-        """It prioritizes the configuration object's value unless it is None, in which case it looks into kwargs."""
+        """It prioritizes the configuration object's value unless it is None, in which case it looks into kwargs.
+
+        Return None if not found.
+        """
         if config is not None and hasattr(config, key):
             val = getattr(config, key)
             if val is not None:
@@ -57,6 +64,4 @@ class ConfigBasedFactory(GenericFactory):
         if key in kwargs:
             return kwargs[key]
 
-        raise KeyError(
-            f"The key '{key}' is required but not provided in either configuration object or keyword arguments."
-        )
+        return None

--- a/metagpt/rag/factories/retriever.py
+++ b/metagpt/rag/factories/retriever.py
@@ -31,9 +31,9 @@ from metagpt.rag.schema import (
 
 
 def get_or_build_index(build_index_func):
-    """Find index using `_extract_index` method.
+    """Decorator to get or build an index.
 
-    If no index is found, using build_index_func.
+    Get index using `_extract_index` method, if not found, using build_index_func.
     """
 
     @wraps(build_index_func)

--- a/tests/metagpt/rag/factories/test_base.py
+++ b/tests/metagpt/rag/factories/test_base.py
@@ -97,6 +97,5 @@ class TestConfigBasedFactory:
     def test_val_from_config_or_kwargs_key_error(self):
         # Test KeyError when the key is not found in both config object and kwargs
         config = DummyConfig(name=None)
-        with pytest.raises(KeyError) as exc_info:
-            ConfigBasedFactory._val_from_config_or_kwargs("missing_key", config)
-        assert "The key 'missing_key' is required but not provided" in str(exc_info.value)
+        val = ConfigBasedFactory._val_from_config_or_kwargs("missing_key", config)
+        assert val is None

--- a/tests/metagpt/rag/factories/test_retriever.py
+++ b/tests/metagpt/rag/factories/test_retriever.py
@@ -119,3 +119,19 @@ class TestRetrieverFactory:
         extracted_index = self.retriever_factory._extract_index(index=mock_vector_store_index)
 
         assert extracted_index == mock_vector_store_index
+
+    def test_get_or_build_when_get(self, mocker):
+        want = "existing_index"
+        mocker.patch.object(self.retriever_factory, "_extract_index", return_value=want)
+
+        got = self.retriever_factory._build_es_index(None)
+
+        assert got == want
+
+    def test_get_or_build_when_build(self, mocker):
+        want = "call_build_es_index"
+        mocker.patch.object(self.retriever_factory, "_build_es_index", return_value=want)
+
+        got = self.retriever_factory._build_es_index(None)
+
+        assert got == want

--- a/tests/metagpt/rag/factories/test_retriever.py
+++ b/tests/metagpt/rag/factories/test_retriever.py
@@ -1,6 +1,8 @@
 import faiss
 import pytest
 from llama_index.core import VectorStoreIndex
+from llama_index.core.embeddings import MockEmbedding
+from llama_index.core.schema import TextNode
 from llama_index.vector_stores.chroma import ChromaVectorStore
 from llama_index.vector_stores.elasticsearch import ElasticsearchStore
 
@@ -43,6 +45,14 @@ class TestRetrieverFactory:
     def mock_es_vector_store(self, mocker):
         return mocker.MagicMock(spec=ElasticsearchStore)
 
+    @pytest.fixture
+    def mock_nodes(self, mocker):
+        return [TextNode(text="msg")]
+
+    @pytest.fixture
+    def mock_embedding(self):
+        return MockEmbedding(embed_dim=1)
+
     def test_get_retriever_with_faiss_config(self, mock_faiss_index, mocker, mock_vector_store_index):
         mock_config = FAISSRetrieverConfig(dimensions=128)
         mocker.patch("faiss.IndexFlatL2", return_value=mock_faiss_index)
@@ -52,42 +62,40 @@ class TestRetrieverFactory:
 
         assert isinstance(retriever, FAISSRetriever)
 
-    def test_get_retriever_with_bm25_config(self, mocker, mock_vector_store_index):
+    def test_get_retriever_with_bm25_config(self, mocker, mock_nodes):
         mock_config = BM25RetrieverConfig()
         mocker.patch("rank_bm25.BM25Okapi.__init__", return_value=None)
-        mocker.patch.object(self.retriever_factory, "_extract_index", return_value=mock_vector_store_index)
 
-        retriever = self.retriever_factory.get_retriever(configs=[mock_config])
+        retriever = self.retriever_factory.get_retriever(configs=[mock_config], nodes=mock_nodes)
 
         assert isinstance(retriever, DynamicBM25Retriever)
 
-    def test_get_retriever_with_multiple_configs_returns_hybrid(self, mocker, mock_vector_store_index):
-        mock_faiss_config = FAISSRetrieverConfig(dimensions=128)
+    def test_get_retriever_with_multiple_configs_returns_hybrid(self, mocker, mock_nodes, mock_embedding):
+        mock_faiss_config = FAISSRetrieverConfig(dimensions=1)
         mock_bm25_config = BM25RetrieverConfig()
         mocker.patch("rank_bm25.BM25Okapi.__init__", return_value=None)
-        mocker.patch.object(self.retriever_factory, "_extract_index", return_value=mock_vector_store_index)
 
-        retriever = self.retriever_factory.get_retriever(configs=[mock_faiss_config, mock_bm25_config])
+        retriever = self.retriever_factory.get_retriever(
+            configs=[mock_faiss_config, mock_bm25_config], nodes=mock_nodes, embed_model=mock_embedding
+        )
 
         assert isinstance(retriever, SimpleHybridRetriever)
 
-    def test_get_retriever_with_chroma_config(self, mocker, mock_vector_store_index, mock_chroma_vector_store):
+    def test_get_retriever_with_chroma_config(self, mocker, mock_chroma_vector_store, mock_embedding):
         mock_config = ChromaRetrieverConfig(persist_path="/path/to/chroma", collection_name="test_collection")
         mock_chromadb = mocker.patch("metagpt.rag.factories.retriever.chromadb.PersistentClient")
         mock_chromadb.get_or_create_collection.return_value = mocker.MagicMock()
         mocker.patch("metagpt.rag.factories.retriever.ChromaVectorStore", return_value=mock_chroma_vector_store)
-        mocker.patch.object(self.retriever_factory, "_extract_index", return_value=mock_vector_store_index)
 
-        retriever = self.retriever_factory.get_retriever(configs=[mock_config])
+        retriever = self.retriever_factory.get_retriever(configs=[mock_config], nodes=[], embed_model=mock_embedding)
 
         assert isinstance(retriever, ChromaRetriever)
 
-    def test_get_retriever_with_es_config(self, mocker, mock_vector_store_index, mock_es_vector_store):
+    def test_get_retriever_with_es_config(self, mocker, mock_es_vector_store, mock_embedding):
         mock_config = ElasticsearchRetrieverConfig(store_config=ElasticsearchStoreConfig())
         mocker.patch("metagpt.rag.factories.retriever.ElasticsearchStore", return_value=mock_es_vector_store)
-        mocker.patch.object(self.retriever_factory, "_extract_index", return_value=mock_vector_store_index)
 
-        retriever = self.retriever_factory.get_retriever(configs=[mock_config])
+        retriever = self.retriever_factory.get_retriever(configs=[mock_config], nodes=[], embed_model=mock_embedding)
 
         assert isinstance(retriever, ElasticsearchRetriever)
 


### PR DESCRIPTION
## **User description**
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

- Avoid duplicate embeddings. In some cases, such as pass the retriever_configs in from_docs, `get_retriver` rebuild index, but not reuse the embeddings actually.    

**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->

**Result**
<!-- The screenshot/log of unittest/running result -->
<img width="1268" alt="image" src="https://github.com/geekan/MetaGPT/assets/65027140/fc532e92-be6e-49de-a342-bed307d26df9">

**Other**
<!-- Something else about this PR. -->


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Enhanced the `RAGExample` class with detailed docstrings and added exception handling to improve robustness.
- Refactored `SimpleEngine` to use a transformation-based approach instead of a direct index, enhancing flexibility and maintainability.
- Improved error handling in `ConfigBasedFactory` and modified value retrieval to prevent unnecessary exceptions.
- Introduced dynamic index handling in `RetrieverFactory` to optimize retriever creation based on configurations.
- Updated unit tests to align with the refactoring and new features in the codebase.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rag_pipeline.py</strong><dd><code>Enhance RAGExample with Docstrings and Exception Handling</code></dd></summary>
<hr>
      
examples/rag_pipeline.py

<li>Added detailed docstrings to the RAGExample class and its methods.<br> <li> Introduced exception handling decorators to various asynchronous <br>methods.<br>


</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1224/files#diff-22dc68240d69aa8bd66518e84f939ae7ca898231508e815ddda45a2a797340a5">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>simple.py</strong><dd><code>Refactor SimpleEngine to Use Transformations Instead of Direct Index</code></dd></summary>
<hr>
      
metagpt/rag/engines/simple.py

<li>Removed dependency on <code>VectorStoreIndex</code> and shifted to a <br>transformation-based architecture.<br> <li> Added a new method <code>_from_nodes</code> to create an engine instance from node <br>transformations.<br> <li> Refactored methods to use transformations instead of a direct index.<br>


</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1224/files#diff-74c030db9f8e624d5c5fda603b58223514a8c6ac9c92c3e9400e9750e6bed9a3">+49/-14</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Improve Error Handling and Configuration Value Retrieval in Factories</code></dd></summary>
<hr>
      
metagpt/rag/factories/base.py

<li>Updated error handling in <code>ConfigBasedFactory</code> to provide clearer error <br>messages.<br> <li> Modified <code>_val_from_config_or_kwargs</code> to return None instead of raising <br>KeyError.<br>


</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1224/files#diff-e2a979c626ec5f360bff886b30ffca954913bd3afc4a402bd4ca05301ec58ecf">+11/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>retriever.py</strong><dd><code>Enhance Retriever Factory with Dynamic Index Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
metagpt/rag/factories/retriever.py

<li>Added decorators to handle index building or retrieval dynamically.<br> <li> Refactored methods to support building or retrieving indexes based on <br>configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1224/files#diff-4019a8642495596dfd67bd39ab3ad4badac9dac694f754033c23fa21667a6617">+69/-20</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_simple.py</strong><dd><code>Update Tests for SimpleEngine Refactoring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tests/metagpt/rag/engines/test_simple.py

<li>Updated tests to reflect changes in the <code>SimpleEngine</code> regarding <br>transformations.<br> <li> Removed outdated mocks related to <code>VectorStoreIndex</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1224/files#diff-554a5968ad8248c222bde7c38764cdcb7109b6485f5ade3a144cdc333fb5b3a8">+7/-17</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_base.py</strong><dd><code>Update Factory Base Tests for Configuration Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tests/metagpt/rag/factories/test_base.py

<li>Updated tests to reflect new behavior of returning None instead of <br>raising KeyError.<br>


</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1224/files#diff-7f97c25af083eeb36a33adc7885af3d99729483ae5fc172a124fa87d657cfc0c">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_retriever.py</strong><dd><code>Enhance Tests for Retriever Factory's Dynamic Index Handling</code></dd></summary>
<hr>
      
tests/metagpt/rag/factories/test_retriever.py

<li>Added tests for new dynamic index handling in the retriever factory.<br>


</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1224/files#diff-7974fa5983d0c8eca06439df62ade66ae04486d4da86b02d5f5c0090f774f9c1">+37/-13</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

