### PR TITLE
FIx:Correction of the calculation of the MRR indicator in the RAG benchmark

### DIFF
--- a/metagpt/rag/benchmark/base.py
+++ b/metagpt/rag/benchmark/base.py
@@ -114,14 +114,14 @@ class RAGBenchmark:
     def mean_reciprocal_rank(self, nodes: list[NodeWithScore], reference_docs: list[str]) -> float:
         mrr_sum = 0.0
 
-        for i, doc in enumerate(reference_docs, start=1):
-            for node in nodes:
-                if node.text in doc:
+        for i, node in enumerate(nodes, start=1):
+            for doc in reference_docs:
+                if text in doc:
                     mrr_sum += 1.0 / i
-                    break
+                    return mrr_sum
 
-        return mrr_sum / len(reference_docs) if reference_docs else 0.0
-
+        return mrr_sum
+        
     async def semantic_similarity(self, response: str, reference: str) -> float:
         result = await self.evaluator.aevaluate(
             response=response,


### PR DESCRIPTION
## **User description**
1. When calculating the MRR metric, we only calculate the first correctly recalled countdown sort score and return that score

2. It depends on the specifics of your document as to how to determine if the documents are being recalled correctly; here we use a direct determination of equality, but in fact this is not an optimal approach


___

## **Type**
bug_fix


___

## **Description**
- Refactored the `mean_reciprocal_rank` function in `base.py` to improve the calculation logic:
  - Changed loop order to iterate nodes first, enhancing the logical flow.
  - Adjusted the condition to check for text match in documents.
  - Updated the return statement to immediately return upon match, simplifying the function.
  - Removed the averaging of `mrr_sum` which was previously conditional on `reference_docs` being non-empty.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Refactor mean_reciprocal_rank Calculation Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
metagpt/rag/benchmark/base.py

<li>Updated the loop structure in <code>mean_reciprocal_rank</code> to iterate over <br>nodes first and then reference documents.<br> <li> Changed the condition to check if <code>text</code> is in <code>doc</code>.<br> <li> Modified the return logic to immediately return <code>mrr_sum</code> upon finding a <br>match.<br> <li> Removed the conditional average calculation at the end of the <br>function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1228/files#diff-434f146a1d34a86b05c5be1ad008bffb52abc747dc467a91cef37b29bd96c836">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

