### PR TITLE
Make RAG embedding model dimension configurable

### DIFF
--- a/config/config2.example.yaml
+++ b/config/config2.example.yaml
@@ -18,6 +18,7 @@ embedding:
   model: ""
   api_version: ""
   embed_batch_size: 100
+  dimensions: 
 
 repair_llm_output: true  # when the output is not a valid json, try to repair it
 

--- a/config/config2.example.yaml
+++ b/config/config2.example.yaml
@@ -18,7 +18,7 @@ embedding:
   model: ""
   api_version: ""
   embed_batch_size: 100
-  dimensions: 
+  dimensions: # output dimension of embedding model
 
 repair_llm_output: true  # when the output is not a valid json, try to repair it
 

--- a/metagpt/configs/embedding_config.py
+++ b/metagpt/configs/embedding_config.py
@@ -20,11 +20,13 @@ class EmbeddingConfig(YamlModel):
     ---------
     api_type: "openai"
     api_key: "YOU_API_KEY"
+    dimensions: "YOUR_MODEL_DIMENSIONS"
 
     api_type: "azure"
     api_key: "YOU_API_KEY"
     base_url: "YOU_BASE_URL"
     api_version: "YOU_API_VERSION"
+    dimensions: "YOUR_MODEL_DIMENSIONS"
 
     api_type: "gemini"
     api_key: "YOU_API_KEY"
@@ -32,6 +34,7 @@ class EmbeddingConfig(YamlModel):
     api_type: "ollama"
     base_url: "YOU_BASE_URL"
     model: "YOU_MODEL"
+    dimensions: "YOUR_MODEL_DIMENSIONS"
     """
 
     api_type: Optional[EmbeddingType] = None
@@ -41,6 +44,7 @@ class EmbeddingConfig(YamlModel):
 
     model: Optional[str] = None
     embed_batch_size: Optional[int] = None
+    dimensions: Optional[int] = None  # output dimension of embedding model
 
     @field_validator("api_type", mode="before")
     @classmethod

--- a/metagpt/rag/schema.py
+++ b/metagpt/rag/schema.py
@@ -48,7 +48,7 @@ class FAISSRetrieverConfig(IndexRetrieverConfig):
             self.dimensions = config.embedding.dimensions or self._embedding_type_to_dimensions.get(
                 config.embedding.api_type, 1536
             )
-            if config.embedding.api_type not in self._embedding_type_to_dimensions:
+            if not config.embedding.dimensions and config.embedding.api_type not in self._embedding_type_to_dimensions:
                 logger.warning(
                     f"You didn't set dimensions in config when using {config.embedding.api_type}, default to 1536"
                 )


### PR DESCRIPTION
## **User description**
For #1213 and #1239. When using  text-embedding-3-large(the dimension is 3072) from OpenAI, or some other embedding models deployed by fastchat(e.g. bce-embedding-base_v1 the dimension is 512), it will cause assertion error due to mismatch between query and index.

Consequently,I think it's reasonable to make dimension configurable.

```yaml
# fastchat API
embedding:
  api_type: "openai"
  base_url: "http://127.0.0.1:8000/v1/embeddings"
  model: "bce-embedding-base_v1"
  dimensions: 512
```
