### PR TITLE
Fix potential NoneType error

### DIFF
--- a/examples/rag_pipeline.py
+++ b/examples/rag_pipeline.py
@@ -18,13 +18,13 @@ from metagpt.rag.schema import (
 )
 from metagpt.utils.exceptions import handle_exception
 
+LLM_TIP = "If you not sure, just answer I don't know."
+
 DOC_PATH = EXAMPLE_DATA_PATH / "rag/writer.txt"
-QUESTION = "What are key qualities to be a good writer?"
+QUESTION = f"What are key qualities to be a good writer? {LLM_TIP}"
 
 TRAVEL_DOC_PATH = EXAMPLE_DATA_PATH / "rag/travel.txt"
-TRAVEL_QUESTION = "What does Bob like?"
-
-LLM_TIP = "If you not sure, just answer I don't know."
+TRAVEL_QUESTION = f"What does Bob like? {LLM_TIP}"
 
 
 class Player(BaseModel):
@@ -40,21 +40,21 @@ class Player(BaseModel):
 
 
 class RAGExample:
-    """Show how to use RAG.
+    """Show how to use RAG."""
 
-    Default engine use LLM Reranker, if the answer from the LLM is incorrect, may encounter `IndexError: list index out of range`.
-    """
-
-    def __init__(self, engine: SimpleEngine = None):
+    def __init__(self, engine: SimpleEngine = None, use_llm_ranker: bool = False):
         self._engine = engine
+        self._use_llm_ranker = use_llm_ranker
 
     @property
     def engine(self):
         if not self._engine:
+            ranker_configs = [LLMRankerConfig()] if self._use_llm_ranker else None
+
             self._engine = SimpleEngine.from_docs(
                 input_files=[DOC_PATH],
                 retriever_configs=[FAISSRetrieverConfig()],
-                ranker_configs=[LLMRankerConfig()],
+                ranker_configs=ranker_configs,
             )
         return self._engine
 
@@ -105,7 +105,7 @@ class RAGExample:
         """
         self._print_title("Add Docs")
 
-        travel_question = f"{TRAVEL_QUESTION}{LLM_TIP}"
+        travel_question = f"{TRAVEL_QUESTION}"
         travel_filepath = TRAVEL_DOC_PATH
 
         logger.info("[Before add docs]")
@@ -240,8 +240,14 @@ class RAGExample:
 
 
 async def main():
-    """RAG pipeline."""
-    e = RAGExample()
+    """RAG pipeline.
+
+    Note:
+    1. If `use_llm_ranker` is True, then will use LLM Reranker to get better result, but it is not always guaranteed that the output will be parseable for reranking,
+       prefer `gpt-4-turbo`, otherwise might encounter `IndexError: list index out of range` or `ValueError: invalid literal for int() with base 10`.
+    """
+    e = RAGExample(use_llm_ranker=False)
+
     await e.run_pipeline()
     await e.add_docs()
     await e.add_objects()

--- a/examples/rag_pipeline.py
+++ b/examples/rag_pipeline.py
@@ -243,7 +243,7 @@ async def main():
     """RAG pipeline.
 
     Note:
-    1. If `use_llm_ranker` is True, then will use LLM Reranker to get better result, but it is not always guaranteed that the output will be parseable for reranking,
+    1. If `use_llm_ranker` is True, then it will use LLM Reranker to get better result, but it is not always guaranteed that the output will be parseable for reranking,
        prefer `gpt-4-turbo`, otherwise might encounter `IndexError: list index out of range` or `ValueError: invalid literal for int() with base 10`.
     """
     e = RAGExample(use_llm_ranker=False)

--- a/examples/rag_pipeline.py
+++ b/examples/rag_pipeline.py
@@ -42,7 +42,7 @@ class Player(BaseModel):
 class RAGExample:
     """Show how to use RAG."""
 
-    def __init__(self, engine: SimpleEngine = None, use_llm_ranker: bool = False):
+    def __init__(self, engine: SimpleEngine = None, use_llm_ranker: bool = True):
         self._engine = engine
         self._use_llm_ranker = use_llm_ranker
 

--- a/metagpt/rag/benchmark/base.py
+++ b/metagpt/rag/benchmark/base.py
@@ -121,7 +121,7 @@ class RAGBenchmark:
                     return mrr_sum
 
         return mrr_sum
-        
+
     async def semantic_similarity(self, response: str, reference: str) -> float:
         result = await self.evaluator.aevaluate(
             response=response,

--- a/metagpt/rag/factories/ranker.py
+++ b/metagpt/rag/factories/ranker.py
@@ -8,11 +8,11 @@ from metagpt.rag.factories.base import ConfigBasedFactory
 from metagpt.rag.rankers.object_ranker import ObjectSortPostprocessor
 from metagpt.rag.schema import (
     BaseRankerConfig,
+    BGERerankConfig,
+    CohereRerankConfig,
     ColbertRerankConfig,
     LLMRankerConfig,
     ObjectRankerConfig,
-    CohereRerankConfig,
-    BGERerankConfig
 )
 
 
@@ -60,13 +60,15 @@ class RankerFactory(ConfigBasedFactory):
 
     def _create_bge_rerank(self, config: BGERerankConfig, **kwargs) -> LLMRerank:
         try:
-            from llama_index.postprocessor.flag_embedding_reranker import FlagEmbeddingReranker
+            from llama_index.postprocessor.flag_embedding_reranker import (
+                FlagEmbeddingReranker,
+            )
         except ImportError:
             raise ImportError(
                 "`llama-index-postprocessor-flag-embedding-reranker` package not found, please run `pip install llama-index-postprocessor-flag-embedding-reranker`"
             )
         return FlagEmbeddingReranker(**config.model_dump())
-        
+
     def _create_object_ranker(self, config: ObjectRankerConfig, **kwargs) -> LLMRerank:
         return ObjectSortPostprocessor(**config.model_dump())
 

--- a/metagpt/rag/retrievers/bm25_retriever.py
+++ b/metagpt/rag/retrievers/bm25_retriever.py
@@ -40,8 +40,10 @@ class DynamicBM25Retriever(BM25Retriever):
         self._corpus = [self._tokenizer(node.get_content()) for node in self._nodes]
         self.bm25 = BM25Okapi(self._corpus)
 
-        self._index.insert_nodes(nodes, **kwargs)
+        if self._index:
+            self._index.insert_nodes(nodes, **kwargs)
 
     def persist(self, persist_dir: str, **kwargs) -> None:
         """Support persist."""
-        self._index.storage_context.persist(persist_dir)
+        if self._index:
+            self._index.storage_context.persist(persist_dir)


### PR DESCRIPTION
### **User description**
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

- Fix potential NoneType error
- Update comment in rag_pipeline example
    
**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->


**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->

**Result**
<!-- The screenshot/log of unittest/running result -->

**Other**
<!-- Something else about this PR. -->


___

### **PR Type**
bug_fix


___

### **Description**
- Added null checks to prevent `NoneType` errors when `self._index` is None in `BM25Retriever`.
- Ensures that methods `insert_nodes` and `persist` are only called if `self._index` is not None, enhancing the robustness of the code.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bm25_retriever.py</strong><dd><code>Add null checks for `self._index` in BM25Retriever</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
metagpt/rag/retrievers/bm25_retriever.py

<li>Added checks to ensure <code>self._index</code> is not None before calling <br><code>insert_nodes</code> and <code>persist</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1247/files#diff-f0b2600e8c25f8234da460459ff64c0d201b8df6af4b8c39269f9cc1e923e0ab">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

