### PR TITLE
fix: failure when usage is none

### DIFF
--- a/metagpt/provider/openai_api.py
+++ b/metagpt/provider/openai_api.py
@@ -100,7 +100,7 @@ class OpenAILLM(BaseLLM):
             log_llm_stream(chunk_message)
             collected_messages.append(chunk_message)
             if finish_reason:
-                if hasattr(chunk, "usage"):
+                if hasattr(chunk, "usage") and chunk.usage:
                     # Some services have usage as an attribute of the chunk, such as Fireworks
                     usage = CompletionUsage(**chunk.usage)
                 elif hasattr(chunk.choices[0], "usage"):

--- a/metagpt/provider/openai_api.py
+++ b/metagpt/provider/openai_api.py
@@ -100,7 +100,7 @@ class OpenAILLM(BaseLLM):
             log_llm_stream(chunk_message)
             collected_messages.append(chunk_message)
             if finish_reason:
-                if hasattr(chunk, "usage") and chunk.usage:
+                if hasattr(chunk, "usage") and chunk.usage is not None:
                     # Some services have usage as an attribute of the chunk, such as Fireworks
                     usage = CompletionUsage(**chunk.usage)
                 elif hasattr(chunk.choices[0], "usage"):


### PR DESCRIPTION
### **User description**
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

- https://github.com/geekan/MetaGPT/issues/233
    
**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->

**Result**
<!-- The screenshot/log of unittest/running result -->

**Other**
<!-- Something else about this PR. -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where the application could encounter errors if `chunk.usage` was present but had a `None` value. Now, the code checks that `chunk.usage` is truthy before proceeding to use it.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openai_api.py</strong><dd><code>Fix handling of `None` value in `chunk.usage`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
metagpt/provider/openai_api.py

<li>Added a condition to check if <code>chunk.usage</code> is not only present but also <br>truthy before using it.<br>


</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1253/files#diff-cd17ae392ed66ef3b371223ed87b28bc804a7de14e6f4ae9a24d9d8edcfae3cb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

