### PR TITLE
fix aask() got an unexpected keyword argument 'images'

### DIFF
--- a/metagpt/provider/human_provider.py
+++ b/metagpt/provider/human_provider.py
@@ -33,6 +33,7 @@ class HumanProvider(BaseLLM):
         format_msgs: Optional[list[dict[str, str]]] = None,
         generator: bool = False,
         timeout=USE_CONFIG_TIMEOUT,
+        **kwargs
     ) -> str:
         return self.ask(msg, timeout=self.get_timeout(timeout))
 


### PR DESCRIPTION
### **User description**
This fixes the error when running `software_company` with `is_human` flag True for ProjectManager.

The issue is that `BaseLLM.aask` takes in more keyword arguments than handled by `HumanProvider.aask` and that results in the following error.
```
aask() got an unexpected keyword argument 'images'
```

Tested the code after the fix.


___

### **PR Type**
Bug fix


___

### **Description**
- Added support for flexible keyword arguments in the `aask` method of `HumanProvider` class. This prevents errors when unexpected keyword arguments are passed, enhancing the method's robustness.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>human_provider.py</strong><dd><code>Add flexible keyword argument handling to `aask` method</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
metagpt/provider/human_provider.py

<li>Added <code>**kwargs</code> to the <code>aask</code> method to handle additional unexpected <br>keyword arguments.<br>


</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1264/files#diff-b4678221d3e1b86f18a79b4acd533d93fe0101c84f664f6a0a5b8974070bc6f2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

