### PR TITLE
修复QA-Engineer在RunCode(执行用例)结束后，要求Engineer WriteCode(修改代码）, Engineer未修改，业务流直接结束的问题

### DIFF
--- a/metagpt/provider/base_llm.py
+++ b/metagpt/provider/base_llm.py
@@ -148,6 +148,7 @@ class BaseLLM(ABC):
             message.extend(msg)
         logger.debug(message)
         rsp = await self.acompletion_text(message, stream=stream, timeout=self.get_timeout(timeout))
+        logger.debug(f"llm {rsp=}")
         return rsp
 
     def _extract_assistant_rsp(self, context):

--- a/metagpt/roles/engineer.py
+++ b/metagpt/roles/engineer.py
@@ -141,6 +141,7 @@ class Engineer(Role):
     async def _act(self) -> Message | None:
         """Determines the mode of action based on whether code review is used."""
         if self.rc.todo is None:
+            logger.warning("engineer got no todo to act.")
             return None
         if isinstance(self.rc.todo, WriteCodePlanAndChange):
             self.next_todo_action = any_to_name(WriteCode)
@@ -151,6 +152,7 @@ class Engineer(Role):
         if isinstance(self.rc.todo, SummarizeCode):
             self.next_todo_action = any_to_name(WriteCode)
             return await self._act_summarize()
+        logger.warning(f"engineer act got nothing done: {self.rc.todo=}")
         return None
 
     async def _act_write_code(self):

--- a/metagpt/roles/engineer.py
+++ b/metagpt/roles/engineer.py
@@ -27,6 +27,7 @@ from typing import Optional, Set
 from metagpt.actions import Action, WriteCode, WriteCodeReview, WriteTasks
 from metagpt.actions.fix_bug import FixBug
 from metagpt.actions.project_management_an import REFINED_TASK_LIST, TASK_LIST
+from metagpt.actions.run_code import RunCode
 from metagpt.actions.summarize_code import SummarizeCode
 from metagpt.actions.write_code_plan_and_change_an import WriteCodePlanAndChange
 from metagpt.const import (
@@ -242,7 +243,7 @@ class Engineer(Role):
         if not self.src_workspace:
             self.src_workspace = self.git_repo.workdir / self.git_repo.workdir.name
         write_plan_and_change_filters = any_to_str_set([WriteTasks, FixBug])
-        write_code_filters = any_to_str_set([WriteTasks, WriteCodePlanAndChange, SummarizeCode])
+        write_code_filters = any_to_str_set([WriteTasks, WriteCodePlanAndChange, SummarizeCode, RunCode])
         summarize_code_filters = any_to_str_set([WriteCode, WriteCodeReview])
         if not self.rc.news:
             return None

--- a/metagpt/roles/qa_engineer.py
+++ b/metagpt/roles/qa_engineer.py
@@ -32,7 +32,7 @@ class QaEngineer(Role):
         "The test code you write should conform to code standard like PEP8, be modular, easy to read and maintain."
         "Use same language as user requirement"
     )
-    test_round_allowed: int = 5
+    test_round_allowed: int = 20
     test_round: int = 0
 
     def __init__(self, **kwargs):

--- a/metagpt/roles/role.py
+++ b/metagpt/roles/role.py
@@ -361,8 +361,8 @@ class Role(SerializationMixin, ContextMixin, BaseModel):
         """Consider what to do and decide on the next course of action. Return false if nothing can be done."""
         if len(self.actions) == 1:
             # If there is only one action, then only this one can be performed
+            logger.debug("actions number == 1")
             self._set_state(0)
-
             return True
 
         if self.recovered and self.rc.state >= 0:
@@ -462,10 +462,12 @@ class Role(SerializationMixin, ContextMixin, BaseModel):
             # think
             await self._think()
             if self.rc.todo is None:
+                logger.warning("no todo, skip acting")
                 break
             # act
             logger.debug(f"{self._setting}: {self.rc.state=}, will do {self.rc.todo}")
             rsp = await self._act()
+            logger.debug(f"{actions_taken=}")
             actions_taken += 1
         return rsp  # return output from the last action
 


### PR DESCRIPTION
### **User description**
**Features**
修复QA-Engineer在RunCode(执行用例)结束后，要求Engineer WriteCode(修改代码）, Engineer未修改，业务流直接结束的问题
    
**Influence**
导致过早结束业务流程，Engineer代码有问题而直接结束流程；修复后会增加代码修改流程，增加成功率，但同时会降低完成率。请慎重评估是否合入。

**Result**
修改后，在QA测试发现原码有问题时，Engineer继续修改代码，进行重试。


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added and enhanced debug and warning logs across multiple roles to improve traceability and debugging.
- Increased the test rounds allowed for QA engineers to ensure thorough testing and bug fixing.
- Included `RunCode` in the actions that can trigger code writing, enhancing the engineer's role responsiveness.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_llm.py</strong><dd><code>Add Debug Logging for LLM Response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
metagpt/provider/base_llm.py

- Added debug logging for the response from the language model.



</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1267/files#diff-7b80d6287bf4cf75c4061b77e9af5c5e017ba6d774301fa43823e6997c6b423f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>engineer.py</strong><dd><code>Enhance Logging and Action Handling in Engineer Role</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
metagpt/roles/engineer.py

<li>Added import for <code>RunCode</code>.<br> <li> Added warning logs for cases where no action is determined or nothing <br>gets done.<br> <li> Included <code>RunCode</code> in the set of actions that trigger writing code.<br>


</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1267/files#diff-670e1154f69ca119cd089e5aa9dd579e771211cddcffec1ef1fb66637e385b2a">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>qa_engineer.py</strong><dd><code>Increase QA Engineer Test Rounds Limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
metagpt/roles/qa_engineer.py

- Increased the allowed test rounds from 5 to 20.



</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1267/files#diff-aec52f9a5a8049637d41195b2837722f211e2aff9e96766c6ec7aeafb70fd80b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>role.py</strong><dd><code>Improve Logging for Role Actions and Decisions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
metagpt/roles/role.py

<li>Added debug logging for actions handling and process flow.<br> <li> Added warning log when no actionable todo is present.<br>


</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1267/files#diff-57eb0c9c5adc353ba3e4db36bb4443d7b86c62b79bd4a084fa105674a253be0d">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

