### PR TITLE
fix openai image schema bug

### DIFF
--- a/metagpt/provider/base_llm.py
+++ b/metagpt/provider/base_llm.py
@@ -65,7 +65,7 @@ class BaseLLM(ABC):
             # image url or image base64
             url = image if image.startswith("http") else f"data:image/jpeg;base64,{image}"
             # it can with multiple-image inputs
-            content.append({"type": "image_url", "image_url": url})
+            content.append({"type": "image_url", "image_url": {"url": url}})
         return {"role": "user", "content": content}
 
     def _assistant_msg(self, msg: str) -> dict[str, str]:


### PR DESCRIPTION
### **User description**
I try to run android assistant with gpt-4-turbo, but there was an error indicating the messages schema was incorrect:
`"Invalid type for 'messages[1].content[1].image_url': expected an object, but got a string instead`
by checking the openai-sdk doc https://platform.openai.com/docs/guides/vision  and https://platform.openai.com/docs/api-reference/chat/create
"I found that the format {"type":"image_url","image_url":YOUR_IMAGE_URL} can be used on gpt-4-vision-preview, but not on gpt-4-turbo, whereas the format {"type":"image_url","image_url":{"url":YOUR_IMAGE_URL}} can be used on both."

Consequently, I update the schema for more compability.
