### PR TITLE
Pre-commit workflow添加environment，使之可以配置为分支合入时的保护

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   pre-commit-check:
     runs-on: ubuntu-latest
+    environment: pre-commit
     steps:
     - name: Checkout Source Code
       uses: actions/checkout@v2


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added an `environment` field named `pre-commit` to the `pre-commit-check` job in the GitHub Actions workflow. This enhancement allows the configuration of branch protection rules during merge operations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pre-commit.yaml</strong><dd><code>Add Environment to Pre-commit Workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/pre-commit.yaml

- Added an `environment` field to the `pre-commit-check` job.



</details>
    

  </td>
  <td><a href="https://github.com/geekan/MetaGPT/pull/1277/files#diff-3c0d80ea54e617ba55ba031dda6fc983852272f93775375ce402a66a03560548">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

