### PR TITLE
Feat: Add Ark support (For Doubao)

### DIFF
--- a/config/examples/huoshan_ark.yaml
+++ b/config/examples/huoshan_ark.yaml
@@ -1,0 +1,8 @@
+# Full Example: https://github.com/geekan/MetaGPT/blob/main/config/config2.example.yaml
+# Reflected Code: https://github.com/geekan/MetaGPT/blob/main/metagpt/config2.py
+# Config Docs: https://docs.deepwisdom.ai/main/en/guide/get_started/configuration.html
+llm:
+  api_type: "ark"  # or azure / ollama / groq etc.
+  model: ""  # your model endpoint like ep-xxx
+  base_url: "https://ark.cn-beijing.volces.com/api/v3"  # or forward url / other llm url
+  api_key: "" # your api-key like ey……

--- a/config/examples/huoshan_ark.yaml
+++ b/config/examples/huoshan_ark.yaml
@@ -1,8 +1,5 @@
-# Full Example: https://github.com/geekan/MetaGPT/blob/main/config/config2.example.yaml
-# Reflected Code: https://github.com/geekan/MetaGPT/blob/main/metagpt/config2.py
-# Config Docs: https://docs.deepwisdom.ai/main/en/guide/get_started/configuration.html
 llm:
-  api_type: "ark"  # or azure / ollama / groq etc.
+  api_type: "ark"  
   model: ""  # your model endpoint like ep-xxx
-  base_url: "https://ark.cn-beijing.volces.com/api/v3"  # or forward url / other llm url
+  base_url: "https://ark.cn-beijing.volces.com/api/v3"  
   api_key: "" # your api-key like ey……

--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -33,6 +33,7 @@ class LLMType(Enum):
     YI = "yi"  # lingyiwanwu
     OPENROUTER = "openrouter"
     BEDROCK = "bedrock"
+    ARK = "ark"
 
     def __missing__(self, key):
         return self.OPENAI

--- a/metagpt/provider/__init__.py
+++ b/metagpt/provider/__init__.py
@@ -33,5 +33,5 @@ __all__ = [
     "DashScopeLLM",
     "AnthropicLLM",
     "BedrockLLM",
-    "ArkLLM"
+    "ArkLLM",
 ]

--- a/metagpt/provider/__init__.py
+++ b/metagpt/provider/__init__.py
@@ -18,6 +18,7 @@ from metagpt.provider.qianfan_api import QianFanLLM
 from metagpt.provider.dashscope_api import DashScopeLLM
 from metagpt.provider.anthropic_api import AnthropicLLM
 from metagpt.provider.bedrock_api import BedrockLLM
+from metagpt.provider.ark_api import ArkLLM
 
 __all__ = [
     "GeminiLLM",
@@ -32,4 +33,5 @@ __all__ = [
     "DashScopeLLM",
     "AnthropicLLM",
     "BedrockLLM",
+    "ArkLLM"
 ]

--- a/metagpt/provider/ark_api.py
+++ b/metagpt/provider/ark_api.py
@@ -1,0 +1,43 @@
+from openai import AsyncStream
+from openai.types import CompletionUsage
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
+
+from metagpt.provider.openai_api import OpenAILLM
+from metagpt.configs.llm_config import LLMType
+from metagpt.provider.llm_provider_registry import register_provider
+from metagpt.const import USE_CONFIG_TIMEOUT
+from metagpt.logs import log_llm_stream
+
+@register_provider(LLMType.ARK)
+class ArkLLM(OpenAILLM):
+    """
+    用于火山方舟的API
+    见：https://www.volcengine.com/docs/82379/1263482
+    """
+    
+    async def _achat_completion_stream(self, messages: list[dict], timeout=USE_CONFIG_TIMEOUT) -> str:
+        response: AsyncStream[ChatCompletionChunk] = await self.aclient.chat.completions.create(
+            **self._cons_kwargs(messages, timeout=self.get_timeout(timeout)), 
+            stream=True,
+            extra_body={"stream_options": {"include_usage": True}}
+        )
+        usage = None
+        collected_messages = []
+        async for chunk in response:
+            chunk_message = chunk.choices[0].delta.content or "" if chunk.choices else ""  # extract the message
+            log_llm_stream(chunk_message)
+            collected_messages.append(chunk_message)
+            if chunk.usage:
+                # the usage of ark when streaming is in the last chunk while others are null
+                usage=CompletionUsage(**chunk.usage)
+
+        log_llm_stream("\n")
+        full_reply_content = "".join(collected_messages)
+        self._update_costs(usage,chunk.model)
+        return full_reply_content
+    
+    async def _achat_completion(self, messages: list[dict], timeout=USE_CONFIG_TIMEOUT) -> ChatCompletion:
+        kwargs = self._cons_kwargs(messages, timeout=self.get_timeout(timeout))
+        rsp: ChatCompletion = await self.aclient.chat.completions.create(**kwargs)
+        self._update_costs(rsp.usage,rsp.model)
+        return rsp

--- a/metagpt/provider/ark_api.py
+++ b/metagpt/provider/ark_api.py
@@ -20,7 +20,7 @@ class ArkLLM(OpenAILLM):
         response: AsyncStream[ChatCompletionChunk] = await self.aclient.chat.completions.create(
             **self._cons_kwargs(messages, timeout=self.get_timeout(timeout)),
             stream=True,
-            extra_body={"stream_options": {"include_usage": True}}
+            extra_body={"stream_options": {"include_usage": True}}  # 只有增加这个参数才会在流式时最后返回usage
         )
         usage = None
         collected_messages = []
@@ -29,7 +29,7 @@ class ArkLLM(OpenAILLM):
             log_llm_stream(chunk_message)
             collected_messages.append(chunk_message)
             if chunk.usage:
-                # the usage of ark when streaming is in the last chunk while others are null
+                # 火山方舟的流式调用会在最后一个chunk中返回usage,最后一个chunk的choices为[]
                 usage = CompletionUsage(**chunk.usage)
 
         log_llm_stream("\n")

--- a/metagpt/provider/ark_api.py
+++ b/metagpt/provider/ark_api.py
@@ -2,11 +2,12 @@ from openai import AsyncStream
 from openai.types import CompletionUsage
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
-from metagpt.provider.openai_api import OpenAILLM
 from metagpt.configs.llm_config import LLMType
-from metagpt.provider.llm_provider_registry import register_provider
 from metagpt.const import USE_CONFIG_TIMEOUT
 from metagpt.logs import log_llm_stream
+from metagpt.provider.llm_provider_registry import register_provider
+from metagpt.provider.openai_api import OpenAILLM
+
 
 @register_provider(LLMType.ARK)
 class ArkLLM(OpenAILLM):
@@ -14,10 +15,10 @@ class ArkLLM(OpenAILLM):
     用于火山方舟的API
     见：https://www.volcengine.com/docs/82379/1263482
     """
-    
+
     async def _achat_completion_stream(self, messages: list[dict], timeout=USE_CONFIG_TIMEOUT) -> str:
         response: AsyncStream[ChatCompletionChunk] = await self.aclient.chat.completions.create(
-            **self._cons_kwargs(messages, timeout=self.get_timeout(timeout)), 
+            **self._cons_kwargs(messages, timeout=self.get_timeout(timeout)),
             stream=True,
             extra_body={"stream_options": {"include_usage": True}}
         )
@@ -29,15 +30,15 @@ class ArkLLM(OpenAILLM):
             collected_messages.append(chunk_message)
             if chunk.usage:
                 # the usage of ark when streaming is in the last chunk while others are null
-                usage=CompletionUsage(**chunk.usage)
+                usage = CompletionUsage(**chunk.usage)
 
         log_llm_stream("\n")
         full_reply_content = "".join(collected_messages)
-        self._update_costs(usage,chunk.model)
+        self._update_costs(usage, chunk.model)
         return full_reply_content
-    
+
     async def _achat_completion(self, messages: list[dict], timeout=USE_CONFIG_TIMEOUT) -> ChatCompletion:
         kwargs = self._cons_kwargs(messages, timeout=self.get_timeout(timeout))
         rsp: ChatCompletion = await self.aclient.chat.completions.create(**kwargs)
-        self._update_costs(rsp.usage,rsp.model)
+        self._update_costs(rsp.usage, rsp.model)
         return rsp

--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -72,9 +72,9 @@ TOKEN_COSTS = {
     "doubao-lite-4k-240515": {"prompt": 0.000042, "completion": 0.000084},
     "doubao-lite-32k-240515": {"prompt": 0.000042, "completion": 0.000084},
     "doubao-lite-128k-240515": {"prompt": 0.00011, "completion": 0.00013},
-    "doubao-pro-4k-240515":{"prompt":0.00011,"completion":0.00028},
-    "doubao-pro-32k-240515":{"prompt":0.00011,"completion":0.00028},
-    "doubao-pro-128k-240515":{"prompt":0.0007,"completion":0.0012},
+    "doubao-pro-4k-240515": {"prompt": 0.00011, "completion": 0.00028},
+    "doubao-pro-32k-240515": {"prompt": 0.00011, "completion": 0.00028},
+    "doubao-pro-128k-240515": {"prompt": 0.0007, "completion": 0.0012},
 }
 
 
@@ -216,6 +216,12 @@ TOKEN_MAX = {
     "openai/gpt-4-turbo-preview": 128000,
     "deepseek-chat": 32768,
     "deepseek-coder": 16385,
+    "doubao-lite-4k-240515": 4000,
+    "doubao-lite-32k-240515": 32000,
+    "doubao-lite-128k-240515": 128000,
+    "doubao-pro-4k-240515": 4000,
+    "doubao-pro-32k-240515": 32000,
+    "doubao-pro-128k-240515": 128000,
 }
 
 # For Amazon Bedrock US region

--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -68,13 +68,15 @@ TOKEN_COSTS = {
     "openai/gpt-4-turbo-preview": {"prompt": 0.01, "completion": 0.03},
     "deepseek-chat": {"prompt": 0.00014, "completion": 0.00028},
     "deepseek-coder": {"prompt": 0.00014, "completion": 0.00028},
-    # For ark model
+    # For ark model https://www.volcengine.com/docs/82379/1099320
     "doubao-lite-4k-240515": {"prompt": 0.000042, "completion": 0.000084},
     "doubao-lite-32k-240515": {"prompt": 0.000042, "completion": 0.000084},
     "doubao-lite-128k-240515": {"prompt": 0.00011, "completion": 0.00013},
     "doubao-pro-4k-240515": {"prompt": 0.00011, "completion": 0.00028},
     "doubao-pro-32k-240515": {"prompt": 0.00011, "completion": 0.00028},
     "doubao-pro-128k-240515": {"prompt": 0.0007, "completion": 0.0012},
+    "llama3-70b-llama3-70b-instruct": {"prompt": 0.0, "completion": 0.0},
+    "llama3-8b-llama3-8b-instruct": {"prompt": 0.0, "completion": 0.0},
 }
 
 

--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -68,6 +68,13 @@ TOKEN_COSTS = {
     "openai/gpt-4-turbo-preview": {"prompt": 0.01, "completion": 0.03},
     "deepseek-chat": {"prompt": 0.00014, "completion": 0.00028},
     "deepseek-coder": {"prompt": 0.00014, "completion": 0.00028},
+    # For ark model
+    "doubao-lite-4k-240515": {"prompt": 0.000042, "completion": 0.000084},
+    "doubao-lite-32k-240515": {"prompt": 0.000042, "completion": 0.000084},
+    "doubao-lite-128k-240515": {"prompt": 0.00011, "completion": 0.00013},
+    "doubao-pro-4k-240515":{"prompt":0.00011,"completion":0.00028},
+    "doubao-pro-32k-240515":{"prompt":0.00011,"completion":0.00028},
+    "doubao-pro-128k-240515":{"prompt":0.0007,"completion":0.0012},
 }
 
 

--- a/tests/metagpt/provider/mock_llm_config.py
+++ b/tests/metagpt/provider/mock_llm_config.py
@@ -69,3 +69,5 @@ mock_llm_config_bedrock = LLMConfig(
     secret_key="123abc",
     max_token=10000,
 )
+
+mock_llm_config_ark = LLMConfig(api_type="ark", api_key="eyxxx", base_url="xxx", model="ep-xxx")

--- a/tests/metagpt/provider/test_ark.py
+++ b/tests/metagpt/provider/test_ark.py
@@ -1,0 +1,85 @@
+"""
+用于火山方舟Python SDK V3的测试用例
+API文档：https://www.volcengine.com/docs/82379/1263482
+"""
+
+from typing import AsyncIterator, List, Union
+
+import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
+from openai.types.chat.chat_completion_chunk import Choice, ChoiceDelta
+
+from metagpt.provider.ark_api import ArkLLM
+from tests.metagpt.provider.mock_llm_config import mock_llm_config
+from tests.metagpt.provider.req_resp_const import (
+    get_openai_chat_completion,
+    llm_general_chat_funcs_test,
+    messages,
+    prompt,
+    resp_cont_tmpl,
+)
+
+name = "AI assistant"
+resp_cont = resp_cont_tmpl.format(name=name)
+USAGE = {"completion_tokens": 1000, "prompt_tokens": 1000, "total_tokens": 2000}
+default_resp = get_openai_chat_completion(name)
+default_resp.model = "doubao-pro-32k-240515"
+default_resp.usage = USAGE
+
+
+def create_chat_completion_chunk(
+    content: str, finish_reason: str = None, choices: List[Choice] = None
+) -> ChatCompletionChunk:
+    if choices is None:
+        choices = [
+            Choice(
+                delta=ChoiceDelta(content=content, function_call=None, role="assistant", tool_calls=None),
+                finish_reason=finish_reason,
+                index=0,
+                logprobs=None,
+            )
+        ]
+
+    return ChatCompletionChunk(
+        id="012",
+        choices=choices,
+        created=1716278586,
+        model="doubao-pro-32k-240515",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        usage=None if choices else USAGE,
+    )
+
+
+ark_resp_chunk = create_chat_completion_chunk(content="")
+ark_resp_chunk_finish = create_chat_completion_chunk(content=resp_cont, finish_reason="stop")
+ark_resp_chunk_last = create_chat_completion_chunk(content="", choices=[])
+
+
+async def chunk_iterator(chunks: List[ChatCompletionChunk]) -> AsyncIterator[ChatCompletionChunk]:
+    for chunk in chunks:
+        yield chunk
+
+
+async def mock_ark_acompletions_create(
+    self, stream: bool = False, **kwargs
+) -> Union[ChatCompletionChunk, ChatCompletion]:
+    if stream:
+        chunks = [ark_resp_chunk, ark_resp_chunk_finish, ark_resp_chunk_last]
+        return chunk_iterator(chunks)
+    else:
+        return default_resp
+
+
+@pytest.mark.asyncio
+async def test_ark_acompletion(mocker):
+    mocker.patch("openai.resources.chat.completions.AsyncCompletions.create", mock_ark_acompletions_create)
+
+    llm = ArkLLM(mock_llm_config)
+
+    resp = await llm.acompletion(messages)
+    assert resp.choices[0].finish_reason == "stop"
+    assert resp.choices[0].message.content == resp_cont
+    assert resp.usage == USAGE
+
+    await llm_general_chat_funcs_test(llm, prompt, messages, resp_cont)

--- a/tests/metagpt/provider/test_ark.py
+++ b/tests/metagpt/provider/test_ark.py
@@ -10,7 +10,7 @@ from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from openai.types.chat.chat_completion_chunk import Choice, ChoiceDelta
 
 from metagpt.provider.ark_api import ArkLLM
-from tests.metagpt.provider.mock_llm_config import mock_llm_config
+from tests.metagpt.provider.mock_llm_config import mock_llm_config_ark
 from tests.metagpt.provider.req_resp_const import (
     get_openai_chat_completion,
     llm_general_chat_funcs_test,
@@ -75,7 +75,7 @@ async def mock_ark_acompletions_create(
 async def test_ark_acompletion(mocker):
     mocker.patch("openai.resources.chat.completions.AsyncCompletions.create", mock_ark_acompletions_create)
 
-    llm = ArkLLM(mock_llm_config)
+    llm = ArkLLM(mock_llm_config_ark)
 
     resp = await llm.acompletion(messages)
     assert resp.choices[0].finish_reason == "stop"


### PR DESCRIPTION
支持火山方舟中的豆包大模型，目前只支持火山方舟的Python SDK V3版本
https://www.volcengine.com/product/doubao


```shell
@usamirenko_zwjver ➜ MetaGPT git(huoshan)  pytest tests\metagpt\provider
=============================================================== test session starts ================================================================
platform win32 -- Python 3.9.19, pytest-8.1.1, pluggy-1.5.0
rootdir: D:\python_projects\MetaGPT
plugins: anyio-4.3.0, asyncio-0.23.6, cov-5.0.0, html-4.1.1, metadata-3.1.1, mock-3.14.0, timeout-2.3.1, xdist-3.5.0
asyncio: mode=strict
collected 118 items                                                                                                                                  

tests\metagpt\provider\postprocess\test_base_postprocess_plugin.py .                                                                          [  0%] 
tests\metagpt\provider\postprocess\test_llm_output_postprocess.py .                                                                           [  1%] 
tests\metagpt\provider\test_anthropic_api.py .                                                                                                [  2%] 
tests\metagpt\provider\test_ark.py .                                                                                                          [  3%] 
tests\metagpt\provider\test_azure_llm.py .                                                                                                    [  4%] 
tests\metagpt\provider\test_base_llm.py ..                                                                                                    [  5%] 
tests\metagpt\provider\test_bedrock_api.py ................................................................................                   [ 73%] 
tests\metagpt\provider\test_dashscope_api.py .                                                                                                [ 74%] 
tests\metagpt\provider\test_general_api_base.py .......                                                                                       [ 80%] 
tests\metagpt\provider\test_general_api_requestor.py ...                                                                                      [ 83%] 
tests\metagpt\provider\test_google_gemini_api.py .                                                                                            [ 83%] 
tests\metagpt\provider\test_human_provider.py .                                                                                               [ 84%] 
tests\metagpt\provider\test_metagpt_llm.py .                                                                                                  [ 85%] 
tests\metagpt\provider\test_ollama_api.py .                                                                                                   [ 86%] 
tests\metagpt\provider\test_openai.py ........                                                                                                [ 93%]
tests\metagpt\provider\test_qianfan_api.py .                                                                                                  [ 94%]
tests\metagpt\provider\test_spark_api.py ...                                                                                                  [ 96%]
tests\metagpt\provider\test_zhipuai_api.py ..                                                                                                 [ 98%]
tests\metagpt\provider\zhipuai\test_async_sse_client.py .                                                                                     [ 99%]
tests\metagpt\provider\zhipuai\test_zhipu_model_api.py .                                                                                      [100%]

================================================================= warnings summary =================================================================
tests/metagpt/provider/test_azure_llm.py::test_azure_llm
tests/metagpt/provider/test_azure_llm.py::test_azure_llm
tests/metagpt/provider/test_openai.py::TestOpenAI::test_make_client_kwargs_with_proxy
tests/metagpt/provider/test_openai.py::TestOpenAI::test_make_client_kwargs_with_proxy
tests/metagpt/provider/test_openai.py::TestOpenAI::test_get_choice_function_arguments_for_aask_code
  D:\anaconda\envs\metagpt\lib\site-packages\httpx\_client.py:1417: DeprecationWarning: The 'proxies' argument is now deprecated. Use 'proxy' or 'mounts' instead.
    warnings.warn(message, DeprecationWarning)

tests/metagpt/provider/test_general_api_requestor.py::test_api_requestor
  D:\anaconda\envs\metagpt\lib\site-packages\_pytest\unraisableexception.py:80: PytestUnraisableExceptionWarning: Exception ignored in: <function _SSLProtocolTransport.__del__ at 0x00000267AC4ED8B0>

  Traceback (most recent call last):
    File "D:\anaconda\envs\metagpt\lib\asyncio\sslproto.py", line 690, in _process_write_backlog
      self._transport.write(chunk)
    File "D:\anaconda\envs\metagpt\lib\asyncio\proactor_events.py", line 359, in write
      self._loop_writing(data=bytes(data))
    File "D:\anaconda\envs\metagpt\lib\asyncio\proactor_events.py", line 395, in _loop_writing
      self._write_fut = self._loop._proactor.send(self._sock, data)
  AttributeError: 'NoneType' object has no attribute 'send'

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "D:\anaconda\envs\metagpt\lib\asyncio\sslproto.py", line 321, in __del__
      self.close()
    File "D:\anaconda\envs\metagpt\lib\asyncio\sslproto.py", line 316, in close
      self._ssl_protocol._start_shutdown()
    File "D:\anaconda\envs\metagpt\lib\asyncio\sslproto.py", line 599, in _start_shutdown
      self._write_appdata(b'')
    File "D:\anaconda\envs\metagpt\lib\asyncio\sslproto.py", line 604, in _write_appdata
      self._process_write_backlog()
    File "D:\anaconda\envs\metagpt\lib\asyncio\sslproto.py", line 712, in _process_write_backlog
      self._fatal_error(exc, 'Fatal error on SSL transport')
    File "D:\anaconda\envs\metagpt\lib\asyncio\sslproto.py", line 726, in _fatal_error
      self._transport._force_close(exc)
    File "D:\anaconda\envs\metagpt\lib\asyncio\proactor_events.py", line 151, in _force_close
      self._loop.call_soon(self._call_connection_lost, exc)
    File "D:\anaconda\envs\metagpt\lib\asyncio\base_events.py", line 751, in call_soon
      self._check_closed()
    File "D:\anaconda\envs\metagpt\lib\asyncio\base_events.py", line 515, in _check_closed
      raise RuntimeError('Event loop is closed')
  RuntimeError: Event loop is closed

    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 118 passed, 6 warnings in 54.28s ========================================================= 
@usamirenko_zwjver ➜ MetaGPT git(huoshan) 
```