### PR TITLE
fix protobuf conflicts caused by google-generativeai

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ gitignore-parser==0.1.9
 websockets>=10.0,<12.0
 networkx~=3.2.1
 google-generativeai==0.4.1
-protobuf~=3.19
+protobuf~=3.19.5
 playwright>=1.26  # used at metagpt/tools/libs/web_scraping.py
 anytree
 ipywidgets==8.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,7 @@ gitignore-parser==0.1.9
 websockets>=10.0,<12.0
 networkx~=3.2.1
 google-generativeai==0.4.1
+protobuf~=3.19
 playwright>=1.26  # used at metagpt/tools/libs/web_scraping.py
 anytree
 ipywidgets==8.1.1


### PR DESCRIPTION
I noticed that the build of all PR failed since last week because `google-generativeai` doesn't specify the version of its dependency protobuf. 
![img_v3_02b4_f5625049-ec48-45e1-97b4-1f84caaf22ag](https://github.com/geekan/MetaGPT/assets/93753250/3a841671-7975-4e6a-96d4-afb5266c68cb)

It should be:
![image](https://github.com/geekan/MetaGPT/assets/93753250/97c668e6-42e9-43b0-8a24-ae8ecdadfebd)
but the newest version of probobuf installed, resulting dependencies conflicts
![image](https://github.com/geekan/MetaGPT/assets/93753250/94dfb914-1dc2-4157-8c7d-a04c8b0ae272)

