### PR TITLE
Use model_name in embedding

### DIFF
--- a/metagpt/rag/factories/embedding.py
+++ b/metagpt/rag/factories/embedding.py
@@ -89,9 +89,9 @@ class RAGEmbeddingFactory(GenericFactory):
         return OllamaEmbedding(**params)
 
     def _try_set_model_and_batch_size(self, params: dict):
-        """Set the model and embed_batch_size only when they are specified."""
+        """Set the model_name and embed_batch_size only when they are specified."""
         if config.embedding.model:
-            params["model"] = config.embedding.model
+            params["model_name"] = config.embedding.model
 
         if config.embedding.embed_batch_size:
             params["embed_batch_size"] = config.embedding.embed_batch_size

--- a/tests/metagpt/rag/factories/test_embedding.py
+++ b/tests/metagpt/rag/factories/test_embedding.py
@@ -66,7 +66,7 @@ class TestRAGEmbeddingFactory:
 
     @pytest.mark.parametrize(
         "model, embed_batch_size, expected_params",
-        [("test_model", 100, {"model": "test_model", "embed_batch_size": 100}), (None, None, {})],
+        [("test_model", 100, {"model_name": "test_model", "embed_batch_size": 100}), (None, None, {})],
     )
     def test_try_set_model_and_batch_size(self, mock_config, model, embed_batch_size, expected_params):
         # Mock


### PR DESCRIPTION
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

- Use `model_name` in embedding, cause gemini and ollama using `model_name`, openai and azure support both `model_name` and `model`
    
**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->
- Related PR: https://github.com/geekan/MetaGPT/pull/1295

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->

**Result**
<!-- The screenshot/log of unittest/running result -->
<img width="1269" alt="image" src="https://github.com/geekan/MetaGPT/assets/65027140/c9934231-b19f-4c0c-a45e-f94599b47cc2">

**Other**
<!-- Something else about this PR. -->