### PR TITLE
fix stanford town game path TypeError

### DIFF
--- a/metagpt/ext/stanford_town/utils/mg_ga_transform.py
+++ b/metagpt/ext/stanford_town/utils/mg_ga_transform.py
@@ -56,10 +56,16 @@ def get_role_environment(sim_code: str, role_name: str, step: int = 0) -> dict:
 
 
 def write_curr_sim_code(curr_sim_code: dict, temp_storage_path: Optional[Path] = None):
-    temp_storage_path = Path(temp_storage_path) or TEMP_STORAGE_PATH
+    if temp_storage_path is None:
+        temp_storage_path = TEMP_STORAGE_PATH
+    else:
+        temp_storage_path = Path(temp_storage_path)
     write_json_file(temp_storage_path.joinpath("curr_sim_code.json"), curr_sim_code)
 
 
 def write_curr_step(curr_step: dict, temp_storage_path: Optional[Path] = None):
-    temp_storage_path = Path(temp_storage_path) or TEMP_STORAGE_PATH
+    if temp_storage_path is None:
+        temp_storage_path = TEMP_STORAGE_PATH
+    else:
+        temp_storage_path = Path(temp_storage_path)
     write_json_file(temp_storage_path.joinpath("curr_step.json"), curr_step)


### PR DESCRIPTION
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

执行命令`python run_st_game.py "Host a open lunch party at 13:00 pm" "base_the_ville_isabella_maria_klaus" "test_sim"`，报下面错误：

```shell
E:\python_workspace\aiagent\metagpt_a> python run_st_game.py "Host a open lunch party at 13:00 pm" "base_the_ville_isabella_maria_klaus" "test_sim"
2024-05-27 16:56:53.141 | INFO     | metagpt.const:get_metagpt_package_root:29 - Package root set to e:\python_workspace\aiagent\metagpt_a\metagpt
2024-05-27 16:56:58.883 | INFO     | __main__:startup:27 - StanfordTown init environment
2024-05-27 16:56:58.970 | INFO     | metagpt.ext.stanford_town.roles.st_role:load_from:167 - Role: Isabella Rodriguez loaded role's memory 
from e:\python_workspace\aiagent\metagpt_a\metagpt\examples\stanford_town\storage\test_sim\personas\Isabella Rodriguez
2024-05-27 16:56:58.993 | INFO     | metagpt.ext.stanford_town.roles.st_role:load_from:167 - Role: Maria Lopez loaded role's memory from e:\python_workspace\aiagent\metagpt_a\metagpt\examples\stanford_town\storage\test_sim\personas\Maria Lopez
2024-05-27 16:56:59.014 | INFO     | metagpt.ext.stanford_town.roles.st_role:load_from:167 - Role: Klaus Mueller loaded role's memory from 
e:\python_workspace\aiagent\metagpt_a\metagpt\examples\stanford_town\storage\test_sim\personas\Klaus Mueller
Traceback (most recent call last):
  File "E:\python_workspace\aiagent\metagpt_a\run_st_game.py", line 97, in <module>
    fire.Fire(main)
  File "E:\python_workspace\aiagent\metagpt_a\venv\lib\site-packages\fire\core.py", line 141, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "E:\python_workspace\aiagent\metagpt_a\venv\lib\site-packages\fire\core.py", line 466, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
  File "E:\python_workspace\aiagent\metagpt_a\venv\lib\site-packages\fire\core.py", line 681, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "E:\python_workspace\aiagent\metagpt_a\run_st_game.py", line 84, in main
    asyncio.run(
  File "C:\Users\zlj\AppData\Local\Programs\Python\Python310\lib\asyncio\runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "C:\Users\zlj\AppData\Local\Programs\Python\Python310\lib\asyncio\base_events.py", line 649, in run_until_complete
    return future.result()
  File "E:\python_workspace\aiagent\metagpt_a\run_st_game.py", line 52, in startup
    write_curr_sim_code({"sim_code": sim_code}, temp_storage_path)
  File "e:\python_workspace\aiagent\metagpt_a\metagpt\metagpt\ext\stanford_town\utils\mg_ga_transform.py", line 59, in write_curr_sim_code 
    temp_storage_path = Path(temp_storage_path) or TEMP_STORAGE_PATH
  File "C:\Users\zlj\AppData\Local\Programs\Python\Python310\lib\pathlib.py", line 960, in __new__
    self = cls._from_parts(args)
  File "C:\Users\zlj\AppData\Local\Programs\Python\Python310\lib\pathlib.py", line 594, in _from_parts
    drv, root, parts = self._parse_args(args)
  File "C:\Users\zlj\AppData\Local\Programs\Python\Python310\lib\pathlib.py", line 578, in _parse_args
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

修复方案：对方法`write_curr_sim_code`和`write_curr_step`的传入参数`temp_storage_path`判断是否为`None`
    
**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->

**Result**
<!-- The screenshot/log of unittest/running result -->

**Other**
<!-- Something else about this PR. -->
**Environment information**

- MetaGPT version or branch: commit id 92bd904
- LLM type and model name: gpt-3.5-turbo-0125
- installation method: `git clone https://github.com/geekan/MetaGPT.git  cd ./MetaGPT  pip install -e .`
- System version: Windows 10 企业版 22H2
- Python version: python 3.10.11
- Python 虚拟环境工具：venv