### PR TITLE
fix: Update in environment publish message

### DIFF
--- a/metagpt/environment/base_env.py
+++ b/metagpt/environment/base_env.py
@@ -185,7 +185,7 @@ class Environment(ExtEnv):
         found = False
         # According to the routing feature plan in Chapter 2.2.3.2 of RFC 113
         for role, addrs in self.member_addrs.items():
-            if is_send_to(message, addrs):
+            if is_send_to(message, addrs) and role.is_watch(message.cause_by):
                 role.put_message(message)
                 found = True
         if not found:


### PR DESCRIPTION
- Publish message in env. also considering cause_by, to only those roles having cause_by in watch action of interest.

**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

- Now only the roles, whose `watch actions` are set same as `metagpt.schema.message.cause_by` will get the message.

**Result**
<!-- The screenshot/log of unittest/running result -->
- Resolves this open issue: https://github.com/geekan/MetaGPT/issues/1304
