### PR TITLE
reset NotebookClient from a new NotebookNode.

### DIFF
--- a/metagpt/actions/di/execute_nb_code.py
+++ b/metagpt/actions/di/execute_nb_code.py
@@ -82,7 +82,9 @@ class ExecuteNbCode(Action):
         # sleep 1s to wait for the kernel to be cleaned up completely
         await asyncio.sleep(1)
         await self.build()
-        self.nb_client = NotebookClient(self.nb, timeout=self.timeout)
+        # self.nb_client = NotebookClient(self.nb, timeout=self.timeout)
+        # reset NotebookClient from a new NotebookNode
+        self.nb_client = NotebookClient(nbformat.v4.new_notebook(), timeout=self.timeout)
 
     def add_code_cell(self, code: str):
         self.nb.cells.append(new_code_cell(source=code))


### PR DESCRIPTION
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

修改NotebookClient的reset方式，修改为从一个全新的NotebookNode创建NotebookClient，而不是从历史的NotebookNode中创建。

```python
 # self.nb_client = NotebookClient(self.nb, timeout=self.timeout)   # old
 # reset NotebookClient from a new NotebookNode
 self.nb_client = NotebookClient(nbformat.v4.new_notebook(), timeout=self.timeout)  # new
```