### PR TITLE
optimize error message when validating api_key failed

### DIFF
--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -94,8 +94,8 @@ class LLMConfig(YamlModel):
     @classmethod
     def check_llm_key(cls, v):
         if v in ["", None, "YOUR_API_KEY"]:
-            repo_config_path=(METAGPT_ROOT / "config/config2.yaml")
-            root_config_path=(CONFIG_ROOT / "config2.yaml")
+            repo_config_path = METAGPT_ROOT / "config/config2.yaml"
+            root_config_path = CONFIG_ROOT / "config2.yaml"
             if root_config_path.exists():
                  raise ValueError(
                     f"Please set your API key in {root_config_path}. If you also set your config in {repo_config_path}, \nthe former will overwrite the latter. This may cause unexpected result.\n")

--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -12,7 +12,7 @@ from pydantic import field_validator
 
 from metagpt.const import LLM_API_TIMEOUT
 from metagpt.utils.yaml_model import YamlModel
-
+from metagpt.const import METAGPT_ROOT, CONFIG_ROOT
 
 class LLMType(Enum):
     OPENAI = "openai"
@@ -94,7 +94,15 @@ class LLMConfig(YamlModel):
     @classmethod
     def check_llm_key(cls, v):
         if v in ["", None, "YOUR_API_KEY"]:
-            raise ValueError("Please set your API key in config2.yaml")
+            repo_config_path=(METAGPT_ROOT / "config/config2.yaml")
+            root_config_path=(CONFIG_ROOT / "config2.yaml")
+            if root_config_path.exists():
+                 raise ValueError(
+                    f"Please set your API key in {root_config_path}. If you also set your config in {repo_config_path}, \nthe former will overwrite the latter. This may cause unexpected result.\n")
+            elif repo_config_path.exists():
+                raise ValueError(f"Please set your API key in {repo_config_path}")
+            else:
+                raise ValueError(f"Please set your API key in config2.yaml")
         return v
 
     @field_validator("timeout")


### PR DESCRIPTION
**Features**
Added a more user-friendly error message for API_KEY validation failure for https://github.com/geekan/MetaGPT/issues/1290, https://github.com/geekan/MetaGPT/issues/1322 and  https://github.com/geekan/MetaGPT/issues/1220.
Users can use `metagpt --init-config` to add a config2.yaml under `home/username/.metagpt/config2.yaml`. 
However, the config file in the home directory will overwrite the one in the MetaGPT repository, which may cause unexpected results. Therefore, the error message has been optimized.
**Result**
1. When two paths exist or only the config under home path exists and there is no api_key in the home path one:
```shell
ValidationError: 1 validation error for Config
llm.api_key
  Value error, Please set your API key in /home/usamimeri/.metagpt/config2.yaml. If you also set your config in /home/usamimeri/MetaGPT/config/config2.yaml, 
the former will overwrite the latter. This may cause unexpected result.
 [type=value_error, input_value='YOUR_API_KEY', input_type=str]
    For further information visit https://errors.pydantic.dev/2.6/v/value_error
```
2. When only the config under the repository exists:
```shell
ValidationError: 1 validation error for Config
llm.api_key
  Value error, Please set your API key in /home/usamimeri/MetaGPT/config/config2.yaml [type=value_error, input_value='YOUR_API_KEY', input_type=str]
    For further information visit https://errors.pydantic.dev/2.6/v/value_error
```

