### PR TITLE
update qianfan and dashscope version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ anytree
 ipywidgets==8.1.1
 Pillow
 imap_tools==1.5.0  # Used by metagpt/tools/libs/email_login.py
-qianfan==0.3.2
+qianfan==0.3.16
 dashscope==1.14.1
 rank-bm25==0.2.2  # for tool recommendation
 gymnasium==0.29.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,8 +66,8 @@ anytree
 ipywidgets==8.1.1
 Pillow
 imap_tools==1.5.0  # Used by metagpt/tools/libs/email_login.py
-qianfan==0.3.16
-dashscope==1.14.1
+qianfan~=0.3.16
+dashscope~=1.19.3
 rank-bm25==0.2.2  # for tool recommendation
 gymnasium==0.29.1
 boto3~=1.34.69


### PR DESCRIPTION
The current version of Qianfan (0.3.2) and Dashscope(1.14.1) don't not support the latest version of ERNIE Bot and needs to be updated to the latest version.
![img_v3_02c1_581fd6f1-8a1b-4e7f-afde-8a2bdf87143g](https://github.com/geekan/MetaGPT/assets/93753250/c1f269f1-3a55-4cc8-9724-4d8e27aa984d)
https://github.com/geekan/MetaGPT/issues/1315

1. from `qianfan=0.3.2` to `qianfan=0.3.16`
2. from `dashscope=1.14.1 to `qianfan=1.19.3`