### PR TITLE
Fixing Streamed Output Misalignment

### DIFF
--- a/metagpt/utils/stream_pipe.py
+++ b/metagpt/utils/stream_pipe.py
@@ -11,8 +11,10 @@ from multiprocessing import Pipe
 
 
 class StreamPipe:
-    parent_conn, child_conn = Pipe()
-    finish: bool = False
+    def __init__(self,name=None):
+        self.name = name
+        self.parent_conn, self.child_conn = Pipe()
+        self.finish: bool = False
 
     format_data = {
         "id": "chatcmpl-96bVnBOOyPFZZxEoTIGbdpFcVEnur",


### PR DESCRIPTION
When running stream_output_via_api.py with Flask, if there are multiple concurrent requests, a situation may arise where the responses are mismatched: data meant for request A is returned to request B. The main reason for this issue is the failure to initialize member variables properly during instantiation. The instantiation occurs at: stream_pipe = StreamPipe().