### PR TITLE
LLM.aask支持流式响应内容外部访问

### DIFF
--- a/examples/di/data_visualization.py
+++ b/examples/di/data_visualization.py
@@ -13,5 +13,5 @@ async def main(requirement: str = ""):
 
 
 if __name__ == "__main__":
-    requirement = "Run data analysis on sklearn Iris dataset, include a plot"
+    requirement = "在sklearn Iris数据集上运行数据分析，包括一个图"
     asyncio.run(main(requirement))

--- a/examples/fastapi_stream.py
+++ b/examples/fastapi_stream.py
@@ -1,0 +1,42 @@
+import asyncio
+import threading
+import queue as sync_queue
+from fastapi import FastAPI
+from sse_starlette.sse import EventSourceResponse
+import uvicorn
+from metagpt.llm import LLM
+
+
+app = FastAPI()
+llm = LLM()
+async def generate_async_stream(queue):
+    requirement = "解决这个数学问题：正整数m和n的最大公约数是6。m和n的最小公倍数是126。m + n的最小可能值是多少？"
+    await llm.aask(requirement, stream=True, queue=queue)
+
+@app.get("/stream")
+def stream():
+    queue = sync_queue.Queue()
+    print(queue)
+
+    def run_loop(queue):
+        asyncio.set_event_loop(asyncio.new_event_loop())
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(generate_async_stream(queue))
+
+    thread = threading.Thread(target=run_loop, args=(queue,))
+    thread.start()
+
+    def generate_sync_stream():
+        while True:
+            message = queue.get()
+            print(message)
+            if message is None:
+                break
+            yield f"data: {message}\n\n"
+
+    return EventSourceResponse(generate_sync_stream(), media_type='text/event-stream')
+
+if __name__ == "__main__":
+    uvicorn.run(app='examples.ping:app',
+                host="0.0.0.0",
+                port=3000)

--- a/examples/ping.py
+++ b/examples/ping.py
@@ -1,29 +1,43 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-"""
-@Time    : 2024/4/22 14:28
-@Author  : alexanderwu
-@File    : ping.py
-"""
-
 import asyncio
-
+import threading
+import queue as sync_queue
+from fastapi import FastAPI
+from sse_starlette.sse import EventSourceResponse
+import uvicorn
 from metagpt.llm import LLM
-from metagpt.logs import logger
 
+from metagpt.roles.di.data_interpreter import DataInterpreter
 
-async def ask_and_print(question: str, llm: LLM, system_prompt) -> str:
-    logger.info(f"Q: {question}")
-    rsp = await llm.aask(question, system_msgs=[system_prompt])
-    logger.info(f"A: {rsp}")
-    logger.info("\n")
-    return rsp
+app = FastAPI()
+llm = LLM()
+async def generate_async_stream(queue):
+    requirement = "解决这个数学问题：正整数m和n的最大公约数是6。m和n的最小公倍数是126。m + n的最小可能值是多少？"
+    await llm.aask(requirement, stream=True, queue=queue)
 
+@app.get("/stream")
+def stream():
+    queue = sync_queue.Queue()
+    print(queue)
 
-async def main():
-    llm = LLM()
-    await ask_and_print("ping?", llm, "Just answer pong when ping.")
+    def run_loop(queue):
+        asyncio.set_event_loop(asyncio.new_event_loop())
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(generate_async_stream(queue))
 
+    thread = threading.Thread(target=run_loop, args=(queue,))
+    thread.start()
+
+    def generate_sync_stream():
+        while True:
+            message = queue.get()
+            print(message)
+            if message is None:
+                break
+            yield f"data: {message}\n\n"
+
+    return EventSourceResponse(generate_sync_stream(), media_type='text/event-stream')
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    uvicorn.run(app='examples.ping:app',
+                host="0.0.0.0",
+                port=3000)

--- a/examples/ping.py
+++ b/examples/ping.py
@@ -1,43 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+@Time    : 2024/4/22 14:28
+@Author  : alexanderwu
+@File    : ping.py
+"""
+
 import asyncio
-import threading
-import queue as sync_queue
-from fastapi import FastAPI
-from sse_starlette.sse import EventSourceResponse
-import uvicorn
+
 from metagpt.llm import LLM
+from metagpt.logs import logger
 
-from metagpt.roles.di.data_interpreter import DataInterpreter
 
-app = FastAPI()
-llm = LLM()
-async def generate_async_stream(queue):
-    requirement = "解决这个数学问题：正整数m和n的最大公约数是6。m和n的最小公倍数是126。m + n的最小可能值是多少？"
-    await llm.aask(requirement, stream=True, queue=queue)
+async def ask_and_print(question: str, llm: LLM, system_prompt) -> str:
+    logger.info(f"Q: {question}")
+    rsp = await llm.aask(question, system_msgs=[system_prompt])
+    logger.info(f"A: {rsp}")
+    logger.info("\n")
+    return rsp
 
-@app.get("/stream")
-def stream():
-    queue = sync_queue.Queue()
-    print(queue)
 
-    def run_loop(queue):
-        asyncio.set_event_loop(asyncio.new_event_loop())
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(generate_async_stream(queue))
+async def main():
+    llm = LLM()
+    await ask_and_print("ping?", llm, "Just answer pong when ping.")
 
-    thread = threading.Thread(target=run_loop, args=(queue,))
-    thread.start()
-
-    def generate_sync_stream():
-        while True:
-            message = queue.get()
-            print(message)
-            if message is None:
-                break
-            yield f"data: {message}\n\n"
-
-    return EventSourceResponse(generate_sync_stream(), media_type='text/event-stream')
-
-if __name__ == "__main__":
-    uvicorn.run(app='examples.ping:app',
-                host="0.0.0.0",
-                port=3000)

--- a/metagpt/logs.py
+++ b/metagpt/logs.py
@@ -27,7 +27,7 @@ def define_log_level(print_level="INFO", logfile_level="DEBUG", name: str = None
 
     _logger.remove()
     _logger.add(sys.stderr, level=print_level)
-    _logger.add(METAGPT_ROOT / f"logs/{log_name}.txt", level=logfile_level)
+    _logger.add(METAGPT_ROOT / f"logs/{log_name}.log", level=logfile_level)
     return _logger
 
 

--- a/metagpt/provider/base_llm.py
+++ b/metagpt/provider/base_llm.py
@@ -133,6 +133,7 @@ class BaseLLM(ABC):
         images: Optional[Union[str, list[str]]] = None,
         timeout=USE_CONFIG_TIMEOUT,
         stream=None,
+        queue=None
     ) -> str:
         if system_msgs:
             message = self._system_msgs(system_msgs)
@@ -149,7 +150,7 @@ class BaseLLM(ABC):
         if stream is None:
             stream = self.config.stream
         logger.debug(message)
-        rsp = await self.acompletion_text(message, stream=stream, timeout=self.get_timeout(timeout))
+        rsp = await self.acompletion_text(message, stream=stream, timeout=self.get_timeout(timeout), queue=queue)
         return rsp
 
     def _extract_assistant_rsp(self, context):
@@ -184,7 +185,7 @@ class BaseLLM(ABC):
         """
 
     @abstractmethod
-    async def _achat_completion_stream(self, messages: list[dict], timeout: int = USE_CONFIG_TIMEOUT) -> str:
+    async def _achat_completion_stream(self, messages: list[dict], timeout: int = USE_CONFIG_TIMEOUT, queue=None) -> str:
         """_achat_completion_stream implemented by inherited class"""
 
     @retry(
@@ -195,11 +196,11 @@ class BaseLLM(ABC):
         retry_error_callback=log_and_reraise,
     )
     async def acompletion_text(
-        self, messages: list[dict], stream: bool = False, timeout: int = USE_CONFIG_TIMEOUT
+        self, messages: list[dict], stream: bool = False, timeout: int = USE_CONFIG_TIMEOUT, queue=None
     ) -> str:
         """Asynchronous version of completion. Return str. Support stream-print"""
         if stream:
-            return await self._achat_completion_stream(messages, timeout=self.get_timeout(timeout))
+            return await self._achat_completion_stream(messages, timeout=self.get_timeout(timeout), queue=queue)
         resp = await self._achat_completion(messages, timeout=self.get_timeout(timeout))
         return self.get_choice_text(resp)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,3 +72,4 @@ rank-bm25==0.2.2  # for tool recommendation
 gymnasium==0.29.1
 boto3~=1.34.69
 spark_ai_python~=0.3.30
+fastapi


### PR DESCRIPTION
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->
针对问题 https://github.com/geekan/MetaGPT/issues/1301#issue-2317168847
openai_llm做了流式输出的一些改造，使得LLM.aask可以将大模型的流式输出实时存入queue，方便在http接口中实现流式输出

- 使用openai接口的LLM.aask现在可以传入参数queue，用于临时存储llm流式响应
    
**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->
示例代码放在examples/fastapi_stream.py

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->
使用队列存储llm流式响应，使其可以被外部访问

**Result**
<!-- The screenshot/log of unittest/running result -->
![image](https://github.com/geekan/MetaGPT/assets/96409687/727282cc-50af-4413-a6cf-5dacdb0ecb95)
