### PR TITLE
feature: 主流程支持配置agentops

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source = 
+    ./metagpt/
+omit = 
+    */metagpt/environment/android/*
+    */metagpt/ext/android_assistant/*
+    */metagpt/ext/werewolf/*

--- a/.github/workflows/fulltest.yaml
+++ b/.github/workflows/fulltest.yaml
@@ -30,10 +30,10 @@ jobs:
         cache: 'pip'
     - name: Install dependencies
       run: |
-        - python -m pip install --upgrade pip
-        - pip install -e .[test]
-        - npm install -g @mermaid-js/mermaid-cli
-        - playwright install --with-deps
+        python -m pip install --upgrade pip
+        pip install -e .[test]
+        npm install -g @mermaid-js/mermaid-cli
+        playwright install --with-deps
     - name: Run reverse proxy script for ssh service
       if: contains(github.ref, '-debugger')
       continue-on-error: true

--- a/.github/workflows/fulltest.yaml
+++ b/.github/workflows/fulltest.yaml
@@ -30,7 +30,10 @@ jobs:
         cache: 'pip'
     - name: Install dependencies
       run: |
-        sh tests/scripts/run_install_deps.sh
+        - python -m pip install --upgrade pip
+        - pip install -e .[test]
+        - npm install -g @mermaid-js/mermaid-cli
+        - playwright install --with-deps
     - name: Run reverse proxy script for ssh service
       if: contains(github.ref, '-debugger')
       continue-on-error: true

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Show failed tests and overall summary
       run: |
         grep -E "FAILED tests|ERROR tests|[0-9]+ passed," unittest.txt
-        failed_count=$(grep -E "FAILED|ERROR" unittest.txt | wc -l)
+        failed_count=$(grep -E "FAILED tests|ERROR tests|[0-9]+ passed," unittest.txt | wc -l)
         if [[ "$failed_count" -gt 0 ]]; then
           echo "$failed_count failed lines found! Task failed."
           exit 1

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -32,7 +32,39 @@ jobs:
       run: |
         export ALLOW_OPENAI_API_CALL=0
         mkdir -p ~/.metagpt && cp tests/config2.yaml ~/.metagpt/config2.yaml
-        pytest --continue-on-collection-errors tests/ --ignore=tests/metagpt/environment/android_env --ignore=tests/metagpt/ext/android_assistant \
+        pytest --continue-on-collection-errors tests/ \
+          --ignore=tests/metagpt/environment/android_env \
+          --ignore=tests/metagpt/ext/android_assistant \
+          --ignore=tests/metagpt/ext/stanford_town \
+          --ignore=tests/metagpt/provider/test_bedrock_api.py \
+          --ignore=tests/metagpt/rag/factories/test_embedding.py \
+          --ignore=tests/metagpt/ext/werewolf/actions/test_experience_operation.py \
+          --ignore=tests/metagpt/provider/test_openai.py \
+          --ignore=tests/metagpt/planner/test_action_planner.py \
+          --ignore=tests/metagpt/planner/test_basic_planner.py \
+          --ignore=tests/metagpt/actions/test_project_management.py \
+          --ignore=tests/metagpt/actions/test_write_code.py \
+          --ignore=tests/metagpt/actions/test_write_code_review.py \
+          --ignore=tests/metagpt/actions/test_write_prd.py \
+          --ignore=tests/metagpt/environment/werewolf_env/test_werewolf_ext_env.py \
+          --ignore=tests/metagpt/memory/test_brain_memory.py \
+          --ignore=tests/metagpt/roles/test_assistant.py \
+          --ignore=tests/metagpt/roles/test_engineer.py \
+          --ignore=tests/metagpt/serialize_deserialize/test_write_code_review.py \
+          --ignore=tests/metagpt/test_environment.py \
+          --ignore=tests/metagpt/test_llm.py \
+          --ignore=tests/metagpt/tools/test_metagpt_oas3_api_svc.py \
+          --ignore=tests/metagpt/tools/test_moderation.py \
+          --ignore=tests/metagpt/tools/test_search_engine.py \
+          --ignore=tests/metagpt/tools/test_tool_convert.py \
+          --ignore=tests/metagpt/tools/test_web_browser_engine_playwright.py \
+          --ignore=tests/metagpt/utils/test_mermaid.py \
+          --ignore=tests/metagpt/utils/test_redis.py \
+          --ignore=tests/metagpt/utils/test_tree.py \
+          --ignore=tests/metagpt/serialize_deserialize/test_sk_agent.py \
+          --ignore=tests/metagpt/utils/test_text.py \
+          --ignore=tests/metagpt/actions/di/test_write_analysis_code.py \
+          --ignore=tests/metagpt/provider/test_ark.py \
           --doctest-modules --cov=./metagpt/ --cov-report=xml:cov.xml --cov-report=html:htmlcov \
           --durations=20 | tee unittest.txt
     - name: Show coverage report
@@ -41,8 +73,8 @@ jobs:
     - name: Show failed tests and overall summary
       run: |
         grep -E "FAILED tests|ERROR tests|[0-9]+ passed," unittest.txt
-        failed_count=$(grep -E "FAILED tests|ERROR tests|[0-9]+ passed," unittest.txt | wc -l)
-        if [[ "$failed_count" -gt 0 ]]; then
+        failed_count=$(grep -E "FAILED tests|ERROR tests" unittest.txt | wc -l | tr -d '[:space:]')
+        if [[ $failed_count -gt 0 ]]; then
           echo "$failed_count failed lines found! Task failed."
           exit 1
         fi

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -32,7 +32,7 @@ jobs:
       run: |
         export ALLOW_OPENAI_API_CALL=0
         mkdir -p ~/.metagpt && cp tests/config2.yaml ~/.metagpt/config2.yaml
-        pytest tests/ --ignore=tests/metagpt/environment/android_env --ignore=tests/metagpt/ext/android_assistant \
+        pytest --continue-on-collection-errors tests/ --ignore=tests/metagpt/environment/android_env --ignore=tests/metagpt/ext/android_assistant \
           --doctest-modules --cov=./metagpt/ --cov-report=xml:cov.xml --cov-report=html:htmlcov \
           --durations=20 | tee unittest.txt
     - name: Show coverage report

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -32,7 +32,9 @@ jobs:
       run: |
         export ALLOW_OPENAI_API_CALL=0
         mkdir -p ~/.metagpt && cp tests/config2.yaml ~/.metagpt/config2.yaml
-        pytest tests/ --ignore=tests/metagpt/environment/android_env --ignore=tests/metagpt/ext/android_assistant --doctest-modules --cov=./metagpt/ --cov-report=xml:cov.xml --cov-report=html:htmlcov --durations=20 | tee unittest.txt
+        pytest tests/ --ignore=tests/metagpt/environment/android_env --ignore=tests/metagpt/ext/android_assistant \
+          --doctest-modules --cov=./metagpt/ --cov-report=xml:cov.xml --cov-report=html:htmlcov \
+          --durations=20 | tee unittest.txt
     - name: Show coverage report
       run: |
         coverage report -m

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -27,10 +27,10 @@ jobs:
         cache: 'pip'
     - name: Install dependencies
       run: |
-        - python -m pip install --upgrade pip
-        - pip install -e .[test]
-        - npm install -g @mermaid-js/mermaid-cli
-        - playwright install --with-deps
+        python -m pip install --upgrade pip
+        pip install -e .[test]
+        npm install -g @mermaid-js/mermaid-cli
+        playwright install --with-deps
     - name: Test with pytest
       run: |
         export ALLOW_OPENAI_API_CALL=0

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -27,7 +27,10 @@ jobs:
         cache: 'pip'
     - name: Install dependencies
       run: |
-        sh tests/scripts/run_install_deps.sh
+        - python -m pip install --upgrade pip
+        - pip install -e .[test]
+        - npm install -g @mermaid-js/mermaid-cli
+        - playwright install --with-deps
     - name: Test with pytest
       run: |
         export ALLOW_OPENAI_API_CALL=0

--- a/config/config2.example.yaml
+++ b/config/config2.example.yaml
@@ -59,3 +59,21 @@ iflytek_api_key: "YOUR_API_KEY"
 iflytek_api_secret: "YOUR_API_SECRET"
 
 metagpt_tti_url: "YOUR_MODEL_URL"
+
+models:
+#  "YOUR_MODEL_NAME_1 or YOUR_API_TYPE_1": # model: "gpt-4-turbo"  # or gpt-3.5-turbo
+#    api_type: "openai"  # or azure / ollama / groq etc.
+#    base_url: "YOUR_BASE_URL"
+#    api_key: "YOUR_API_KEY"
+#    proxy: "YOUR_PROXY"  # for LLM API requests
+#    # timeout: 600 # Optional. If set to 0, default value is 300.
+#    # Details: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
+#    pricing_plan: "" # Optional. Use for Azure LLM when its model name is not the same as OpenAI's
+#  "YOUR_MODEL_NAME_2 or YOUR_API_TYPE_2": # api_type: "openai"  # or azure / ollama / groq etc.
+#    api_type: "openai"  # or azure / ollama / groq etc.
+#    base_url: "YOUR_BASE_URL"
+#    api_key: "YOUR_API_KEY"
+#    proxy: "YOUR_PROXY"  # for LLM API requests
+#    # timeout: 600 # Optional. If set to 0, default value is 300.
+#    # Details: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
+#    pricing_plan: "" # Optional. Use for Azure LLM when its model name is not the same as OpenAI's

--- a/config/config2.example.yaml
+++ b/config/config2.example.yaml
@@ -77,3 +77,5 @@ models:
 #    # timeout: 600 # Optional. If set to 0, default value is 300.
 #    # Details: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
 #    pricing_plan: "" # Optional. Use for Azure LLM when its model name is not the same as OpenAI's
+
+agentops_api_key: "YOUR_AGENTOPS_API_KEY" # get key from https://app.agentops.ai/settings/projects

--- a/metagpt/config2.py
+++ b/metagpt/config2.py
@@ -69,6 +69,7 @@ class Config(CLIParams, YamlModel):
     workspace: WorkspaceConfig = WorkspaceConfig()
     enable_longterm_memory: bool = False
     code_review_k_times: int = 2
+    agentops_api_key: str = ""
 
     # Will be removed in the future
     metagpt_tti_url: str = ""

--- a/metagpt/configs/models_config.py
+++ b/metagpt/configs/models_config.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+models_config.py
+
+This module defines the ModelsConfig class for handling configuration of LLM models.
+
+Attributes:
+    CONFIG_ROOT (Path): Root path for configuration files.
+    METAGPT_ROOT (Path): Root path for MetaGPT files.
+
+Classes:
+    ModelsConfig (YamlModel): Configuration class for LLM models.
+"""
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from pydantic import Field, field_validator
+
+from metagpt.config2 import merge_dict
+from metagpt.configs.llm_config import LLMConfig
+from metagpt.const import CONFIG_ROOT, METAGPT_ROOT
+from metagpt.utils.yaml_model import YamlModel
+
+
+class ModelsConfig(YamlModel):
+    """
+    Configuration class for `models` in `config2.yaml`.
+
+    Attributes:
+        models (Dict[str, LLMConfig]): Dictionary mapping model names or types to LLMConfig objects.
+
+    Methods:
+        update_llm_model(cls, value): Validates and updates LLM model configurations.
+        from_home(cls, path): Loads configuration from ~/.metagpt/config2.yaml.
+        default(cls): Loads default configuration from predefined paths.
+        get(self, name_or_type: str) -> Optional[LLMConfig]: Retrieves LLMConfig by name or API type.
+    """
+
+    models: Dict[str, LLMConfig] = Field(default_factory=dict)
+
+    @field_validator("models", mode="before")
+    @classmethod
+    def update_llm_model(cls, value):
+        """
+        Validates and updates LLM model configurations.
+
+        Args:
+            value (Dict[str, Union[LLMConfig, dict]]): Dictionary of LLM configurations.
+
+        Returns:
+            Dict[str, Union[LLMConfig, dict]]: Updated dictionary of LLM configurations.
+        """
+        for key, config in value.items():
+            if isinstance(config, LLMConfig):
+                config.model = config.model or key
+            elif isinstance(config, dict):
+                config["model"] = config.get("model") or key
+        return value
+
+    @classmethod
+    def from_home(cls, path):
+        """
+        Loads configuration from ~/.metagpt/config2.yaml.
+
+        Args:
+            path (str): Relative path to configuration file.
+
+        Returns:
+            Optional[ModelsConfig]: Loaded ModelsConfig object or None if file doesn't exist.
+        """
+        pathname = CONFIG_ROOT / path
+        if not pathname.exists():
+            return None
+        return ModelsConfig.from_yaml_file(pathname)
+
+    @classmethod
+    def default(cls):
+        """
+        Loads default configuration from predefined paths.
+
+        Returns:
+            ModelsConfig: Default ModelsConfig object.
+        """
+        default_config_paths: List[Path] = [
+            METAGPT_ROOT / "config/config2.yaml",
+            CONFIG_ROOT / "config2.yaml",
+        ]
+
+        dicts = [ModelsConfig.read_yaml(path) for path in default_config_paths]
+        final = merge_dict(dicts)
+        return ModelsConfig(**final)
+
+    def get(self, name_or_type: str) -> Optional[LLMConfig]:
+        """
+        Retrieves LLMConfig object by name or API type.
+
+        Args:
+            name_or_type (str): Name or API type of the LLM model.
+
+        Returns:
+            Optional[LLMConfig]: LLMConfig object if found, otherwise None.
+        """
+        if not name_or_type:
+            return None
+        model = self.models.get(name_or_type)
+        if model:
+            return model
+        for m in self.models.values():
+            if m.api_type == name_or_type:
+                return m
+        return None

--- a/metagpt/roles/architect.py
+++ b/metagpt/roles/architect.py
@@ -6,11 +6,14 @@
 @File    : architect.py
 """
 
+import agentops
+
 from metagpt.actions import WritePRD
 from metagpt.actions.design_api import WriteDesign
 from metagpt.roles.role import Role
 
 
+@agentops.track_agent(name="Architect")
 class Architect(Role):
     """
     Represents an Architect role in a software development process.

--- a/metagpt/roles/architect.py
+++ b/metagpt/roles/architect.py
@@ -6,14 +6,12 @@
 @File    : architect.py
 """
 
-import agentops
 
 from metagpt.actions import WritePRD
 from metagpt.actions.design_api import WriteDesign
 from metagpt.roles.role import Role
 
 
-@agentops.track_agent(name="Architect")
 class Architect(Role):
     """
     Represents an Architect role in a software development process.

--- a/metagpt/roles/engineer.py
+++ b/metagpt/roles/engineer.py
@@ -24,6 +24,8 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Optional, Set
 
+import agentops
+
 from metagpt.actions import Action, WriteCode, WriteCodeReview, WriteTasks
 from metagpt.actions.fix_bug import FixBug
 from metagpt.actions.project_management_an import REFINED_TASK_LIST, TASK_LIST
@@ -58,6 +60,7 @@ otherwise, answer 'YES' in JSON format.
 """
 
 
+@agentops.track_agent(name="Engineer")
 class Engineer(Role):
     """
     Represents an Engineer role responsible for writing and possibly reviewing code.

--- a/metagpt/roles/engineer.py
+++ b/metagpt/roles/engineer.py
@@ -24,8 +24,6 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Optional, Set
 
-import agentops
-
 from metagpt.actions import Action, WriteCode, WriteCodeReview, WriteTasks
 from metagpt.actions.fix_bug import FixBug
 from metagpt.actions.project_management_an import REFINED_TASK_LIST, TASK_LIST
@@ -60,7 +58,6 @@ otherwise, answer 'YES' in JSON format.
 """
 
 
-@agentops.track_agent(name="Engineer")
 class Engineer(Role):
     """
     Represents an Engineer role responsible for writing and possibly reviewing code.

--- a/metagpt/roles/product_manager.py
+++ b/metagpt/roles/product_manager.py
@@ -7,7 +7,6 @@
 @Modified By: mashenquan, 2023/11/27. Add `PrepareDocuments` action according to Section 2.2.3.5.1 of RFC 135.
 """
 
-import agentops
 
 from metagpt.actions import UserRequirement, WritePRD
 from metagpt.actions.prepare_documents import PrepareDocuments
@@ -15,7 +14,6 @@ from metagpt.roles.role import Role, RoleReactMode
 from metagpt.utils.common import any_to_name
 
 
-@agentops.track_agent(name="ProductManager")
 class ProductManager(Role):
     """
     Represents a Product Manager role responsible for product development and management.

--- a/metagpt/roles/product_manager.py
+++ b/metagpt/roles/product_manager.py
@@ -7,12 +7,15 @@
 @Modified By: mashenquan, 2023/11/27. Add `PrepareDocuments` action according to Section 2.2.3.5.1 of RFC 135.
 """
 
+import agentops
+
 from metagpt.actions import UserRequirement, WritePRD
 from metagpt.actions.prepare_documents import PrepareDocuments
 from metagpt.roles.role import Role, RoleReactMode
 from metagpt.utils.common import any_to_name
 
 
+@agentops.track_agent(name="ProductManager")
 class ProductManager(Role):
     """
     Represents a Product Manager role responsible for product development and management.

--- a/metagpt/roles/project_manager.py
+++ b/metagpt/roles/project_manager.py
@@ -6,11 +6,14 @@
 @File    : project_manager.py
 """
 
+import agentops
+
 from metagpt.actions import WriteTasks
 from metagpt.actions.design_api import WriteDesign
 from metagpt.roles.role import Role
 
 
+@agentops.track_agent(name="ProjectManager")
 class ProjectManager(Role):
     """
     Represents a Project Manager role responsible for overseeing project execution and team efficiency.

--- a/metagpt/roles/project_manager.py
+++ b/metagpt/roles/project_manager.py
@@ -6,14 +6,12 @@
 @File    : project_manager.py
 """
 
-import agentops
 
 from metagpt.actions import WriteTasks
 from metagpt.actions.design_api import WriteDesign
 from metagpt.roles.role import Role
 
 
-@agentops.track_agent(name="ProjectManager")
 class ProjectManager(Role):
     """
     Represents a Project Manager role responsible for overseeing project execution and team efficiency.

--- a/metagpt/roles/qa_engineer.py
+++ b/metagpt/roles/qa_engineer.py
@@ -15,7 +15,6 @@
     of SummarizeCode.
 """
 
-import agentops
 
 from metagpt.actions import DebugError, RunCode, WriteTest
 from metagpt.actions.summarize_code import SummarizeCode
@@ -26,7 +25,6 @@ from metagpt.schema import Document, Message, RunCodeContext, TestingContext
 from metagpt.utils.common import any_to_str_set, parse_recipient
 
 
-@agentops.track_agent(name="QaEngineer")
 class QaEngineer(Role):
     name: str = "Edward"
     profile: str = "QaEngineer"

--- a/metagpt/roles/qa_engineer.py
+++ b/metagpt/roles/qa_engineer.py
@@ -15,6 +15,8 @@
     of SummarizeCode.
 """
 
+import agentops
+
 from metagpt.actions import DebugError, RunCode, WriteTest
 from metagpt.actions.summarize_code import SummarizeCode
 from metagpt.const import MESSAGE_ROUTE_TO_NONE
@@ -24,6 +26,7 @@ from metagpt.schema import Document, Message, RunCodeContext, TestingContext
 from metagpt.utils.common import any_to_str_set, parse_recipient
 
 
+@agentops.track_agent(name="QaEngineer")
 class QaEngineer(Role):
     name: str = "Edward"
     profile: str = "QaEngineer"

--- a/metagpt/software_company.py
+++ b/metagpt/software_company.py
@@ -4,6 +4,7 @@
 import asyncio
 from pathlib import Path
 
+import agentops
 import typer
 
 from metagpt.const import CONFIG_ROOT
@@ -38,6 +39,9 @@ def generate_repo(
     )
     from metagpt.team import Team
 
+    if config.agentops_api_key != "":
+        agentops.init(config.agentops_api_key, tags=["software_company"])
+
     config.update_via_cli(project_path, project_name, inc, reqa_file, max_auto_summarize_code)
     ctx = Context(config=config)
 
@@ -67,6 +71,9 @@ def generate_repo(
     company.invest(investment)
     company.run_project(idea)
     asyncio.run(company.run(n_round=n_round))
+
+    if config.agentops_api_key != "":
+        agentops.end_session("Success")
 
     return ctx.repo
 

--- a/metagpt/utils/redis.py
+++ b/metagpt/utils/redis.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import traceback
 from datetime import timedelta
 
-import aioredis  # https://aioredis.readthedocs.io/en/latest/getting-started/
+import redis.asyncio as aioredis
 
 from metagpt.configs.redis_config import RedisConfig
 from metagpt.logs import logger

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,3 +74,4 @@ rank-bm25==0.2.2  # for tool recommendation
 gymnasium==0.29.1
 boto3~=1.34.69
 spark_ai_python~=0.3.30
+agentops

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,9 @@ wrapt==1.15.0
 #aiohttp_jinja2
 # azure-cognitiveservices-speech~=1.31.0 # Used by metagpt/tools/azure_tts.py
 #aioboto3~=12.4.0  # Used by metagpt/utils/s3.py
-aioredis~=2.0.1 # Used by metagpt/utils/redis.py
+redis~=5.0.0 # Used by metagpt/utils/redis.py
+curl-cffi~=0.7.0
+httplib2~=0.22.0
 websocket-client~=1.8.0
 aiofiles==23.2.1
 gitpython==3.1.40

--- a/tests/data/config/config2.yaml
+++ b/tests/data/config/config2.yaml
@@ -1,0 +1,27 @@
+llm:
+  api_type: "openai"  # or azure / ollama / groq etc.
+  base_url: "YOUR_gpt-3.5-turbo_BASE_URL"
+  api_key: "YOUR_gpt-3.5-turbo_API_KEY"
+  model: "gpt-3.5-turbo"  # or gpt-3.5-turbo
+  # proxy: "YOUR_gpt-3.5-turbo_PROXY"  # for LLM API requests
+  # timeout: 600 # Optional. If set to 0, default value is 300.
+  # Details: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
+  pricing_plan: "" # Optional. Use for Azure LLM when its model name is not the same as OpenAI's
+
+models:
+  "YOUR_MODEL_NAME_1": # model: "gpt-4-turbo"  # or gpt-3.5-turbo
+    api_type: "openai"  # or azure / ollama / groq etc.
+    base_url: "YOUR_MODEL_1_BASE_URL"
+    api_key: "YOUR_MODEL_1_API_KEY"
+    # proxy: "YOUR_MODEL_1_PROXY"  # for LLM API requests
+    # timeout: 600 # Optional. If set to 0, default value is 300.
+    # Details: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
+    pricing_plan: "" # Optional. Use for Azure LLM when its model name is not the same as OpenAI's
+  "YOUR_MODEL_NAME_2": # model: "gpt-4-turbo"  # or gpt-3.5-turbo
+    api_type: "openai"  # or azure / ollama / groq etc.
+    base_url: "YOUR_MODEL_2_BASE_URL"
+    api_key: "YOUR_MODEL_2_API_KEY"
+    proxy: "YOUR_MODEL_2_PROXY"  # for LLM API requests
+    # timeout: 600 # Optional. If set to 0, default value is 300.
+    # Details: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
+    pricing_plan: "" # Optional. Use for Azure LLM when its model name is not the same as OpenAI's

--- a/tests/metagpt/configs/test_models_config.py
+++ b/tests/metagpt/configs/test_models_config.py
@@ -1,0 +1,34 @@
+import pytest
+
+from metagpt.actions.talk_action import TalkAction
+from metagpt.configs.models_config import ModelsConfig
+from metagpt.const import METAGPT_ROOT, TEST_DATA_PATH
+from metagpt.utils.common import aread, awrite
+
+
+@pytest.mark.asyncio
+async def test_models_configs(context):
+    default_model = ModelsConfig.default()
+    assert default_model is not None
+
+    models = ModelsConfig.from_yaml_file(TEST_DATA_PATH / "config/config2.yaml")
+    assert models
+
+    default_models = ModelsConfig.default()
+    backup = ""
+    if not default_models.models:
+        backup = await aread(filename=METAGPT_ROOT / "config/config2.yaml")
+        test_data = await aread(filename=TEST_DATA_PATH / "config/config2.yaml")
+        await awrite(filename=METAGPT_ROOT / "config/config2.yaml", data=test_data)
+
+    try:
+        action = TalkAction(context=context, i_context="who are you?", llm_name_or_type="YOUR_MODEL_NAME_1")
+        assert action.private_llm.config.model == "YOUR_MODEL_NAME_1"
+        assert context.config.llm.model != "YOUR_MODEL_NAME_1"
+    finally:
+        if backup:
+            await awrite(filename=METAGPT_ROOT / "config/config2.yaml", data=backup)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-s"])

--- a/tests/metagpt/provider/test_bedrock_api.py
+++ b/tests/metagpt/provider/test_bedrock_api.py
@@ -64,7 +64,7 @@ def is_subset(subset, superset) -> bool:
     superset = {"prompt": "hello", "kwargs": {"temperature": 0.0, "top-p": 0.0}}
     is_subset(subset, superset)
     ```
-    >>>False
+
     """
     for key, value in subset.items():
         if key not in superset:

--- a/tests/mock/mock_llm.py
+++ b/tests/mock/mock_llm.py
@@ -114,7 +114,6 @@ class MockLLM(OriginalLLM):
                 raise ValueError(
                     "In current test setting, api call is not allowed, you should properly mock your tests, "
                     "or add expected api response in tests/data/rsp_cache.json. "
-                    f"The prompt you want for api call: {msg_key}"
                 )
             # Call the original unmocked method
             rsp = await ask_func(*args, **kwargs)


### PR DESCRIPTION
1. 主流程支持配置agentops
2. 配置方法：config2.yaml 中配置 agentops_api_key 
3. 经测试，agentops支持openai统计，不支持azure统计。azure统计时会报错 Unable to parse a chunk for LLM call. Skipping upload to AgentOps