### PR TITLE
fixbug: Werewolf game has ended, but the team is still running idle

### DIFF
--- a/metagpt/team.py
+++ b/metagpt/team.py
@@ -126,6 +126,9 @@ class Team(BaseModel):
             self.run_project(idea=idea, send_to=send_to)
 
         while n_round > 0:
+            if self.env.is_idle:
+                logger.debug("All roles are idle.")
+                break
             n_round -= 1
             self._check_balance()
             await self.env.run()


### PR DESCRIPTION
**Features**
如果n_round和investment都设置较大，观察Moderator已经输出game over，但team的run方法内部仍在无效循环，并遍历运行每个role的run
    
**Feature Docs**
无

**Influence**
team会在所以role都空闲时主动退出循环

**Result**
改造并使用build_customized_multi_agents进行测试，通过日志可以发现，当所以role都空闲时，team将退出循环
2024-07-19 17:54:32.170 | DEBUG    | metagpt.environment.base_env:run:208 - is idle: False
2024-07-19 17:54:32.170 | DEBUG    | metagpt.team:run:136 - max n_round=3 left.
2024-07-19 17:54:32.171 | DEBUG    | metagpt.roles.role:run:550 - Alice(SimpleCoder): no news. waiting.
2024-07-19 17:54:32.171 | DEBUG    | metagpt.roles.role:run:550 - Bob(SimpleTester): no news. waiting.
2024-07-19 17:54:32.171 | DEBUG    | metagpt.roles.role:run:550 - Charlie(SimpleReviewer): no news. waiting.
2024-07-19 17:54:32.172 | DEBUG    | metagpt.environment.base_env:run:208 - is idle: True
2024-07-19 17:54:32.172 | DEBUG    | metagpt.team:run:136 - max n_round=2 left.
2024-07-19 17:54:32.172 | DEBUG    | metagpt.team:run:130 - All roles are idle.

**Other**
无