### PR TITLE
Added support for the HyDE method in quey analysis for RAG plates

### DIFF
--- a/config/config2.example.yaml
+++ b/config/config2.example.yaml
@@ -20,6 +20,10 @@ embedding:
   embed_batch_size: 100
   dimensions: # output dimension of embedding model
 
+
+hyde:
+  include_original: true
+
 repair_llm_output: true  # when the output is not a valid json, try to repair it
 
 proxy: "YOUR_PROXY"  # for tools like requests, playwright, selenium, etc.

--- a/config/config2.example.yaml
+++ b/config/config2.example.yaml
@@ -20,9 +20,9 @@ embedding:
   embed_batch_size: 100
   dimensions: # output dimension of embedding model
 
-
+# RAG Analysis
 hyde:
-  include_original: true
+  include_original: true  # In the query rewrite the content whether to add the original question
 
 repair_llm_output: true  # when the output is not a valid json, try to repair it
 

--- a/config/config2.yaml
+++ b/config/config2.yaml
@@ -1,6 +1,9 @@
 # Full Example: https://github.com/geekan/MetaGPT/blob/main/config/config2.example.yaml
 # Reflected Code: https://github.com/geekan/MetaGPT/blob/main/metagpt/config2.py
 # Config Docs: https://docs.deepwisdom.ai/main/en/guide/get_started/configuration.html
+llm:
+  api_type: "openai"  # or azure / ollama / groq etc.
+  model: "gpt-4-turbo"  # or gpt-3.5-turbo
+  base_url: "https://api.openai.com/v1"  # or forward url / other llm url
+  api_key: "YOUR_API_KEY"
 
-hyde:
-    include_original: true

--- a/config/config2.yaml
+++ b/config/config2.yaml
@@ -1,12 +1,6 @@
 # Full Example: https://github.com/geekan/MetaGPT/blob/main/config/config2.example.yaml
 # Reflected Code: https://github.com/geekan/MetaGPT/blob/main/metagpt/config2.py
 # Config Docs: https://docs.deepwisdom.ai/main/en/guide/get_started/configuration.html
-llm:
-  api_type: 'azure'
-  base_url: 'https://deepwisdomai03.openai.azure.com/'
-  api_key: '006a9c24a03e46609f49c84e85e707dd'
-  api_version: '2024-05-01-preview'
-  model: 'gpt-4o'
 
 hyde:
     include_original: true

--- a/config/config2.yaml
+++ b/config/config2.yaml
@@ -2,7 +2,11 @@
 # Reflected Code: https://github.com/geekan/MetaGPT/blob/main/metagpt/config2.py
 # Config Docs: https://docs.deepwisdom.ai/main/en/guide/get_started/configuration.html
 llm:
-  api_type: "openai"  # or azure / ollama / groq etc.
-  model: "gpt-4-turbo"  # or gpt-3.5-turbo
-  base_url: "https://api.openai.com/v1"  # or forward url / other llm url
-  api_key: "YOUR_API_KEY"
+  api_type: 'azure'
+  base_url: 'https://deepwisdomai03.openai.azure.com/'
+  api_key: '006a9c24a03e46609f49c84e85e707dd'
+  api_version: '2024-05-01-preview'
+  model: 'gpt-4o'
+
+hyde:
+    include_original: true

--- a/examples/rag_pipeline.py
+++ b/examples/rag_pipeline.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from metagpt.const import DATA_PATH, EXAMPLE_DATA_PATH
 from metagpt.logs import logger
 from metagpt.rag.engines import SimpleEngine
-from metagpt.rag.query_analysis.HyDE import HyDEQueryTransformFactory
+from metagpt.rag.factories.HyDEQueryTransformFactory import HyDEQueryTransformFactory
 from metagpt.rag.schema import (
     ChromaIndexConfig,
     ChromaRetrieverConfig,

--- a/metagpt/config2.py
+++ b/metagpt/config2.py
@@ -15,6 +15,7 @@ from metagpt.configs.browser_config import BrowserConfig
 from metagpt.configs.embedding_config import EmbeddingConfig
 from metagpt.configs.llm_config import LLMConfig, LLMType
 from metagpt.configs.mermaid_config import MermaidConfig
+from metagpt.configs.query_analysis_config import HydeConfig
 from metagpt.configs.redis_config import RedisConfig
 from metagpt.configs.s3_config import S3Config
 from metagpt.configs.search_config import SearchConfig
@@ -50,6 +51,9 @@ class Config(CLIParams, YamlModel):
 
     # RAG Embedding
     embedding: EmbeddingConfig = EmbeddingConfig()
+
+    # RAG Analysis
+    hyde: HydeConfig = HydeConfig()
 
     # Global Proxy. Will be used if llm.proxy is not set
     proxy: str = ""

--- a/metagpt/configs/query_analysis_config.py
+++ b/metagpt/configs/query_analysis_config.py
@@ -1,0 +1,5 @@
+from metagpt.utils.yaml_model import YamlModel
+
+
+class HydeConfig(YamlModel):
+    include_original: bool = True

--- a/metagpt/rag/engines/simple.py
+++ b/metagpt/rag/engines/simple.py
@@ -105,7 +105,6 @@ class SimpleEngine(RetrieverQueryEngine):
 
         transformations = transformations or cls._default_transformations()
         nodes = run_transformations(documents, transformations=transformations)
-
         return cls._from_nodes(
             nodes=nodes,
             transformations=transformations,

--- a/metagpt/rag/factories/HyDEQueryTransformFactory.py
+++ b/metagpt/rag/factories/HyDEQueryTransformFactory.py
@@ -1,0 +1,20 @@
+from llama_index.core.llms import LLM
+
+from metagpt.config2 import config
+from metagpt.rag.factories import get_rag_llm
+from metagpt.rag.factories.base import ConfigBasedFactory
+from metagpt.rag.query_analysis.HyDE import HyDEQuery
+
+
+class HyDEQueryTransformFactory(ConfigBasedFactory):
+    """Factory for creating HyDEQueryTransform instances with LLM configuration."""
+
+    llm: LLM = None
+    hyde_config: dict = None
+
+    def __init__(self):
+        self.hyde_config = config.hyde
+        self.llm = get_rag_llm()
+
+    def create_hyde_query_transform(self) -> HyDEQuery:
+        return HyDEQuery(include_original=self.hyde_config.include_original, llm=self.llm)

--- a/metagpt/rag/query_analysis/HyDE.py
+++ b/metagpt/rag/query_analysis/HyDE.py
@@ -1,0 +1,43 @@
+from typing import Dict
+
+from llama_index.core.indices.query.query_transform import HyDEQueryTransform
+from llama_index.core.llms import LLM
+from llama_index.core.schema import QueryBundle
+
+from metagpt.config2 import config
+from metagpt.logs import logger
+from metagpt.rag.factories import get_rag_llm
+from metagpt.rag.factories.base import ConfigBasedFactory
+
+
+class HyDEQuery(HyDEQueryTransform):
+    def _run(self, query_bundle: QueryBundle, metadata: Dict) -> QueryBundle:
+        logger.info(f"{'#' * 5} running HyDEQuery... {'#' * 5}")
+        query_str = query_bundle.query_str
+
+        hypothetical_doc = self._llm.predict(self._hyde_prompt, context_str=query_str)
+
+        embedding_strs = [hypothetical_doc]
+
+        if self._include_original:
+            embedding_strs.extend(query_bundle.embedding_strs)
+        logger.info(f" Hypothetical doc:{embedding_strs} ")
+
+        return QueryBundle(
+            query_str=query_str,
+            custom_embedding_strs=embedding_strs,
+        )
+
+
+class HyDEQueryTransformFactory(ConfigBasedFactory):
+    """Factory for creating HyDEQueryTransform instances with LLM configuration."""
+
+    llm: LLM = None
+    hyde_config: dict = None
+
+    def __init__(self):
+        self.hyde_config = config.hyde
+        self.llm = get_rag_llm()
+
+    def create_hyde_query_transform(self) -> HyDEQuery:
+        return HyDEQuery(include_original=self.hyde_config.include_original, llm=self.llm)

--- a/metagpt/rag/query_analysis/HyDE.py
+++ b/metagpt/rag/query_analysis/HyDE.py
@@ -1,13 +1,9 @@
 from typing import Dict
 
 from llama_index.core.indices.query.query_transform import HyDEQueryTransform
-from llama_index.core.llms import LLM
 from llama_index.core.schema import QueryBundle
 
-from metagpt.config2 import config
 from metagpt.logs import logger
-from metagpt.rag.factories import get_rag_llm
-from metagpt.rag.factories.base import ConfigBasedFactory
 
 
 class HyDEQuery(HyDEQueryTransform):
@@ -27,17 +23,3 @@ class HyDEQuery(HyDEQueryTransform):
             query_str=query_str,
             custom_embedding_strs=embedding_strs,
         )
-
-
-class HyDEQueryTransformFactory(ConfigBasedFactory):
-    """Factory for creating HyDEQueryTransform instances with LLM configuration."""
-
-    llm: LLM = None
-    hyde_config: dict = None
-
-    def __init__(self):
-        self.hyde_config = config.hyde
-        self.llm = get_rag_llm()
-
-    def create_hyde_query_transform(self) -> HyDEQuery:
-        return HyDEQuery(include_original=self.hyde_config.include_original, llm=self.llm)

--- a/metagpt/rag/schema.py
+++ b/metagpt/rag/schema.py
@@ -189,6 +189,10 @@ class ElasticsearchKeywordIndexConfig(ElasticsearchIndexConfig):
     _no_embedding: bool = PrivateAttr(default=True)
 
 
+class HydeConfig(BaseRetrieverConfig):
+    """Config for HyDe"""
+
+
 class ObjectNodeMetadata(BaseModel):
     """Metadata of ObjectNode."""
 

--- a/metagpt/rag/schema.py
+++ b/metagpt/rag/schema.py
@@ -189,10 +189,6 @@ class ElasticsearchKeywordIndexConfig(ElasticsearchIndexConfig):
     _no_embedding: bool = PrivateAttr(default=True)
 
 
-class HydeConfig(BaseRetrieverConfig):
-    """Config for HyDe"""
-
-
 class ObjectNodeMetadata(BaseModel):
     """Metadata of ObjectNode."""
 

--- a/tests/metagpt/rag/factories/test_embedding.py
+++ b/tests/metagpt/rag/factories/test_embedding.py
@@ -5,6 +5,22 @@ from metagpt.configs.llm_config import LLMType
 from metagpt.rag.factories.embedding import RAGEmbeddingFactory
 
 
+def mock_azure_embedding(mocker):
+    return mocker.patch("metagpt.rag.factories.embedding.AzureOpenAIEmbedding")
+
+
+def mock_gemini_embedding(mocker):
+    return mocker.patch("metagpt.rag.factories.embedding.GeminiEmbedding")
+
+
+def mock_ollama_embedding(mocker):
+    return mocker.patch("metagpt.rag.factories.embedding.OllamaEmbedding")
+
+
+def mock_openai_embedding(mocker):
+    return mocker.patch("metagpt.rag.factories.embedding.OpenAIEmbedding")
+
+
 class TestRAGEmbeddingFactory:
     @pytest.fixture(autouse=True)
     def mock_embedding_factory(self):
@@ -13,22 +29,6 @@ class TestRAGEmbeddingFactory:
     @pytest.fixture
     def mock_config(self, mocker):
         return mocker.patch("metagpt.rag.factories.embedding.config")
-
-    @staticmethod
-    def mock_openai_embedding(mocker):
-        return mocker.patch("metagpt.rag.factories.embedding.OpenAIEmbedding")
-
-    @staticmethod
-    def mock_azure_embedding(mocker):
-        return mocker.patch("metagpt.rag.factories.embedding.AzureOpenAIEmbedding")
-
-    @staticmethod
-    def mock_gemini_embedding(mocker):
-        return mocker.patch("metagpt.rag.factories.embedding.GeminiEmbedding")
-
-    @staticmethod
-    def mock_ollama_embedding(mocker):
-        return mocker.patch("metagpt.rag.factories.embedding.OllamaEmbedding")
 
     @pytest.mark.parametrize(
         ("mock_func", "embedding_type"),
@@ -53,7 +53,7 @@ class TestRAGEmbeddingFactory:
 
     def test_get_rag_embedding_default(self, mocker, mock_config):
         # Mock
-        mock_openai_embedding = self.mock_openai_embedding(mocker)
+        mock_openai_emb = mock_openai_embedding(mocker)
 
         mock_config.embedding.api_type = None
         mock_config.llm.api_type = LLMType.OPENAI
@@ -62,7 +62,7 @@ class TestRAGEmbeddingFactory:
         self.embedding_factory.get_rag_embedding()
 
         # Assert
-        mock_openai_embedding.assert_called_once()
+        mock_openai_emb.assert_called_once()
 
     @pytest.mark.parametrize(
         "model, embed_batch_size, expected_params",


### PR DESCRIPTION
Features
Added the HyDE method for query-analysis in the RAG module, including an example for better understanding.
Fixed the issue with the static methods in TestRAGEmbeddingFactory not being callable. The previous code passed static methods as parameters for parameterized testing, but static methods are not callable objects, leading to a TypeError. This was resolved by converting static methods to regular functions and defining them outside the class.
Feature Docs
No additional documentation provided.

Influence
As an optional process in RAG, query-analysis will rewrite queries to enhance search results.

Result
All unit tests for the new features have passed.
The query-analysis process in the RAG module runs smoothly, effectively rewriting and optimizing queries for better search results.
Other
Added a detailed description of the changes and fixes made in the submission.