### PR TITLE
新增流式输出的例子，使用fast api和sse，将大模型的输出实时推送到客户端（浏览器）

### DIFF
--- a/examples/stream_response.py
+++ b/examples/stream_response.py
@@ -1,0 +1,65 @@
+import asyncio
+import json
+from asyncio import CancelledError, Queue
+from contextvars import ContextVar
+
+import uvicorn
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+from sse_starlette import EventSourceResponse
+
+from metagpt.logs import logger, set_llm_stream_logfunc
+from metagpt.roles.tutorial_assistant import TutorialAssistant
+
+app = FastAPI()
+
+context_var: ContextVar[Queue] = ContextVar("context_var")
+
+
+def stream_log(content):
+    if not content:
+        return
+    print(content, end="")
+    queue = context_var.get()
+    if queue:
+        queue.put_nowait(content)
+
+
+async def write_task(queue: Queue, prompt: str):
+    context_var.set(queue)
+    print("Tutorial Assistant is running")
+    role = TutorialAssistant()
+    await role.run(prompt)
+    await queue.put(None)
+
+
+class TutorialParameter(BaseModel):
+    prompt: str = Field(default="Write a tutorial about MySQL", description="The prompt for the tutorial")
+
+
+@app.get("/api/v1/write_tutorial")
+async def write_tutorial(parameter: TutorialParameter):
+    queue = Queue()
+    asyncio.create_task(write_task(queue, parameter.prompt))
+
+    async def event_generator():
+        try:
+            while True:
+                content = await queue.get()
+                if not content:
+                    print("Tutorial Assistant is done")
+                    break
+                data = json.dumps({"data": content}, ensure_ascii=False)
+                yield data
+        except CancelledError:
+            print("connection closed")
+        except Exception as e:
+            logger.error(f"Server error: {e}")
+            yield json.dumps({"data": "server error"}, ensure_ascii=False)
+
+    return EventSourceResponse(event_generator())
+
+
+if __name__ == "__main__":
+    set_llm_stream_logfunc(stream_log)
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/examples/stream_response.py
+++ b/examples/stream_response.py
@@ -44,7 +44,7 @@ class TutorialParameter(BaseModel):
     prompt: str = Field(default="Write a tutorial about MySQL", description="The prompt for the tutorial")
 
 
-@app.get("/api/v1/write_tutorial")
+@app.post("/api/v1/write_tutorial")
 async def write_tutorial(parameter: TutorialParameter):
     queue = Queue()
     asyncio.create_task(write_task(queue, parameter.prompt))
@@ -64,7 +64,12 @@ async def write_tutorial(parameter: TutorialParameter):
             logger.error(f"Server error: {e}")
             yield json.dumps({"data": "server error"}, ensure_ascii=False)
 
-    return EventSourceResponse(event_generator())
+    headers = {
+        "Cache-Control": "no-cache",
+        "Content-Type": "text/event-stream",
+        "X-Accel-Buffering": "no",
+    }
+    return EventSourceResponse(event_generator(), media_type="text/event-stream", headers=headers)
 
 
 if __name__ == "__main__":

--- a/examples/stream_response.py
+++ b/examples/stream_response.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+@Time    : 2024/7/26 19:25
+@Author  : yingfeng
+@File    : stream_response.py
+"""
 import asyncio
 import json
 from asyncio import CancelledError, Queue


### PR DESCRIPTION
**Features**
新增流式输出的例子，使用fast api和sse，将大模型的输出实时推送到客户端（浏览器）
    
**Feature Docs**
无

**Influence**
无

**Result**
![image](https://github.com/user-attachments/assets/7639da6e-120e-4246-92a5-e429af4421f8)


**Other**
无