### PR TITLE
Fix bug https://github.com/geekan/MetaGPT/issues/1430 and also make some field in design api optional.

### DIFF
--- a/metagpt/actions/design_api_an.py
+++ b/metagpt/actions/design_api_an.py
@@ -5,7 +5,7 @@
 @Author  : alexanderwu
 @File    : design_api_an.py
 """
-from typing import List
+from typing import List,Optional
 
 from metagpt.actions.action_node import ActionNode
 from metagpt.utils.mermaid import MMC1, MMC2
@@ -47,7 +47,7 @@ REFINED_FILE_LIST = ActionNode(
 
 DATA_STRUCTURES_AND_INTERFACES = ActionNode(
     key="Data structures and interfaces",
-    expected_type=str,
+    expected_type=Optional[str],
     instruction="Use mermaid classDiagram code syntax, including classes, method(__init__ etc.) and functions with type"
     " annotations, CLEARLY MARK the RELATIONSHIPS between classes, and comply with PEP8 standards. "
     "The data structures SHOULD BE VERY DETAILED and the API should be comprehensive with a complete design.",
@@ -66,7 +66,7 @@ REFINED_DATA_STRUCTURES_AND_INTERFACES = ActionNode(
 
 PROGRAM_CALL_FLOW = ActionNode(
     key="Program call flow",
-    expected_type=str,
+    expected_type=Optional[str],
     instruction="Use sequenceDiagram code syntax, COMPLETE and VERY DETAILED, using CLASSES AND API DEFINED ABOVE "
     "accurately, covering the CRUD AND INIT of each object, SYNTAX MUST BE CORRECT.",
     example=MMC2,

--- a/metagpt/actions/design_api_an.py
+++ b/metagpt/actions/design_api_an.py
@@ -45,6 +45,7 @@ REFINED_FILE_LIST = ActionNode(
     example=["main.py", "game.py", "new_feature.py"],
 )
 
+#optional,because low success reproduction of class diagram in non py project.
 DATA_STRUCTURES_AND_INTERFACES = ActionNode(
     key="Data structures and interfaces",
     expected_type=Optional[str],

--- a/metagpt/actions/project_management_an.py
+++ b/metagpt/actions/project_management_an.py
@@ -5,13 +5,13 @@
 @Author  : alexanderwu
 @File    : project_management_an.py
 """
-from typing import List
+from typing import List, Optional
 
 from metagpt.actions.action_node import ActionNode
 
 REQUIRED_PACKAGES = ActionNode(
     key="Required packages",
-    expected_type=List[str],
+    expected_type=Optional[List[str]],
     instruction="Provide required packages in requirements.txt format.",
     example=["flask==1.1.2", "bcrypt==3.2.0"],
 )


### PR DESCRIPTION
**Features**
- fix https://github.com/geekan/MetaGPT/issues/1430
- make some key in design_api_an.py optional,because from a few test run with non py projects. it seems to not have it. Could be reverted as MUST, if we can guarantee to make sure all relevant projects generate those design api.
- same pr feature as https://github.com/geekan/MetaGPT/pull/1431 but implemented using latest git.(please merge this quick for low git conflict)   

**Feature Docs**

**Influence***
Let a lot of hard error become non error and continue to *cook* project.

**Result**

**Other**