### PR TITLE
feat: add optional authorization header for Ollama to support Open WebUI

### DIFF
--- a/metagpt/provider/general_api_requestor.py
+++ b/metagpt/provider/general_api_requestor.py
@@ -81,7 +81,11 @@ class GeneralAPIRequestor(APIRequestor):
         self, result: aiohttp.ClientResponse, stream: bool
     ) -> Tuple[Union[bytes, AsyncGenerator[bytes, None]], bool]:
         content_type = result.headers.get("Content-Type", "")
-        if stream and ("text/event-stream" in content_type or "application/x-ndjson" in content_type):
+        if stream and (
+                "text/event-stream" in content_type or
+                "application/x-ndjson" in content_type or
+                content_type == ''
+        ):
             # the `Content-Type` of ollama stream resp is "application/x-ndjson"
             return (
                 self._interpret_response_line(line, result.status, result.headers, stream=True)

--- a/metagpt/provider/ollama_api.py
+++ b/metagpt/provider/ollama_api.py
@@ -51,9 +51,13 @@ class OllamaLLM(BaseLLM):
         return json.loads(chunk)
 
     async def _achat_completion(self, messages: list[dict], timeout: int = USE_CONFIG_TIMEOUT) -> dict:
+        headers = None if not self.config.api_key or self.config.api_key == "sk-" else {
+            "Authorization": f"Bearer {self.config.api_key}",
+        }
         resp, _, _ = await self.client.arequest(
             method=self.http_method,
             url=self.suffix_url,
+            headers=headers,
             params=self._const_kwargs(messages),
             request_timeout=self.get_timeout(timeout),
         )
@@ -66,9 +70,13 @@ class OllamaLLM(BaseLLM):
         return await self._achat_completion(messages, timeout=self.get_timeout(timeout))
 
     async def _achat_completion_stream(self, messages: list[dict], timeout: int = USE_CONFIG_TIMEOUT) -> str:
+        headers = None if not self.config.api_key or self.config.api_key == "sk-" else {
+            "Authorization": f"Bearer {self.config.api_key}",
+        }
         stream_resp, _, _ = await self.client.arequest(
             method=self.http_method,
             url=self.suffix_url,
+            headers=headers,
             stream=True,
             params=self._const_kwargs(messages, stream=True),
             request_timeout=self.get_timeout(timeout),


### PR DESCRIPTION
**Features**

- added optional authorization header for Ollama
    
**Feature Docs**

Open WebUI lets users create personal API-keys and forwards authenticated requests to Ollama. Unfortunately no content type was declared on the response.