### PR TITLE
Fix 404 Navigation Issue from README_JA and README_CN to English Docs

### DIFF
--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -10,7 +10,7 @@
 
 <p align="center">
 <a href="docs/README_CN.md"><img src="https://img.shields.io/badge/文档-中文版-blue.svg" alt="CN doc"></a>
-<a href="README.md"><img src="https://img.shields.io/badge/document-English-blue.svg" alt="EN doc"></a>
+<a href="../README.md"><img src="https://img.shields.io/badge/document-English-blue.svg" alt="EN doc"></a>
 <a href="docs/README_JA.md"><img src="https://img.shields.io/badge/ドキュメント-日本語-blue.svg" alt="JA doc"></a>
 <a href="https://discord.gg/DYn29wFk9z"><img src="https://dcbadge.vercel.app/api/server/DYn29wFk9z?style=flat" alt="Discord Follow"></a>
 <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -10,7 +10,7 @@
 
 <p align="center">
 <a href="docs/README_CN.md"><img src="https://img.shields.io/badge/文档-中文版-blue.svg" alt="CN doc"></a>
-<a href="README.md"><img src="https://img.shields.io/badge/document-English-blue.svg" alt="EN doc"></a>
+<a href="../README.md"><img src="https://img.shields.io/badge/document-English-blue.svg" alt="EN doc"></a>
 <a href="docs/README_JA.md"><img src="https://img.shields.io/badge/ドキュメント-日本語-blue.svg" alt="JA doc"></a>
 <a href="https://discord.gg/wCp6Q3fsAk"><img src="https://img.shields.io/badge/Discord-Join-blue?logo=discord&logoColor=white&color=blue" alt="Discord Follow"></a>
 <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>


### PR DESCRIPTION
This PR resolves issue [#1502](https://github.com/geekan/MetaGPT/issues/1502) by updating the navigation links in the README_JA and README_CN.

- **Issue**: Error 404 when redirecting to README.md (English docs) from README_CN.md and README_JA.md.
- **Problem**: The files redirected within the `docs` folder, while the `README.md` was located outside the folder.
- **Solution**: Changed the URL to correctly redirect outside the `docs` folder.

**Files Changed:**
- [README_JA.md](https://github.com/geekan/MetaGPT/blob/main/docs/README_JA.md)
- [README_CN.md](https://github.com/geekan/MetaGPT/blob/main/docs/README_CN.md)

This contribution is part of **Hacktoberfest 2024**.
