### PR TITLE
Add api key to ollama client to support open webui

### DIFF
--- a/metagpt/provider/ollama_api.py
+++ b/metagpt/provider/ollama_api.py
@@ -193,7 +193,7 @@ class OllamaLLM(BaseLLM):
     """
 
     def __init__(self, config: LLMConfig):
-        self.client = GeneralAPIRequestor(base_url=config.base_url)
+        self.client = GeneralAPIRequestor(base_url=config.base_url, key=config.api_key)
         self.config = config
         self.http_method = "post"
         self.use_system_prompt = False


### PR DESCRIPTION
**Features**
This commit enables authentication as required by Open WebUI.

**Feature Docs**
My previously accepted PR #1465 didn't work anylonger after some refactoring.

**Influence**
Tested it on both, a local instance of Ollama and a running Open WebUI instance. Both work fine with these changes.

**Result**


**Other**
