### PR TITLE
Add detailed error message for missing model configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,4 +194,4 @@ metagpt/ext/sela/results/*
 .chainlit/
 
 metagpt/ext/aflow/data
-metagpt/ext/aflow/scripts
+metagpt/ext/aflow/scripts/optimized

--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ cov.xml
 *.csv
 metagpt/ext/sela/results/*
 .chainlit/
+
+metagpt/ext/aflow/data
+metagpt/ext/aflow/scripts


### PR DESCRIPTION
**Features**

- Added command-line flags `--opt_model_name` and `--exec_model_name` to specify models for optimization and execution tasks.
- Improved the exception handling with more detailed error messages when the models are not found in the configuration file.


**Result**

```bash
python -m examples.aflow.optimize --dataset MATH --opt_model_name claude-3-5-sonnet-20240620 --exec_model_name gpt-4o-mini
```