### PR TITLE
pass the reigion name to the boto3.session.client to use region gated…

### DIFF
--- a/metagpt/provider/bedrock_api.py
+++ b/metagpt/provider/bedrock_api.py
@@ -38,7 +38,7 @@ class BedrockLLM(BaseLLM):
             "region_name": os.environ.get("AWS_DEFAULT_REGION", self.config.region_name),
         }
         session = boto3.Session(**self.__credential_kwargs)
-        client = session.client(service_name,region_name = self.__credential_kwargs["region_name"])
+        client = session.client(service_name, region_name=self.__credential_kwargs["region_name"])
         return client
 
     @property

--- a/metagpt/provider/bedrock_api.py
+++ b/metagpt/provider/bedrock_api.py
@@ -38,7 +38,7 @@ class BedrockLLM(BaseLLM):
             "region_name": os.environ.get("AWS_DEFAULT_REGION", self.config.region_name),
         }
         session = boto3.Session(**self.__credential_kwargs)
-        client = session.client(service_name)
+        client = session.client(service_name,region_name = self.__credential_kwargs["region_name"])
         return client
 
     @property


### PR DESCRIPTION
A small fix to be able to use aws bedrock models that are specific to some region.

**bugfix**
https://github.com/geekan/MetaGPT/issues/1643
