### PR TITLE
fix(provider): ensure base_url is always included in params

### DIFF
--- a/metagpt/provider/openai_api.py
+++ b/metagpt/provider/openai_api.py
@@ -80,8 +80,8 @@ class OpenAILLM(BaseLLM):
         params = {}
         if self.config.proxy:
             params = {"proxies": self.config.proxy}
-            if self.config.base_url:
-                params["base_url"] = self.config.base_url
+        if self.config.base_url:
+            params["base_url"] = self.config.base_url
 
         return params
 


### PR DESCRIPTION
Previously, the base_url was only added to params if a proxy was configured. This change ensures that base_url is included in params regardless of whether a proxy is set. This improves the flexibility and correctness of the configuration handling.
