### PR TITLE
Update crawl_webpage.py

### DIFF
--- a/examples/di/crawl_webpage.py
+++ b/examples/di/crawl_webpage.py
@@ -6,7 +6,11 @@
 """
 
 from metagpt.roles.di.data_interpreter import DataInterpreter
-from metagpt.tools.libs.web_scraping import view_page_element_to_scrape
+
+# from metagpt.tools.libs.web_scraping import view_page_element_to_scrape
+# This function has been refactored in MetaGPT v0.7+version, 
+# and the web crawling related functions have been integrated into the scrape_web_playwright tool
+
 
 PAPER_LIST_REQ = """"
 Get data from `paperlist` table in https://papercopilot.com/statistics/iclr-statistics/iclr-2024-statistics/,
@@ -32,9 +36,12 @@ NEWS_36KR_REQ = """从36kr创投平台https://pitchhub.36kr.com/financing-flash 
 
 
 async def main():
-    di = DataInterpreter(tools=[view_page_element_to_scrape.__name__])
-
+    # di = DataInterpreter(tools=[view_page_element_to_scrape.__name__])
+    
+    # The above has expired，Modify as follows：
+    di = DataInterpreter(tools=["scrape_web_playwright"]) 
     await di.run(ECOMMERCE_REQ)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The 'view_page_ element_to-scrape' function does not exist. This function has been refactored in MetaGPT v0.7+version,  and web crawling related functions have been integrated into the scrape_web_playwright tool



##Function Change Record (Updated in 2025)
###Original function: view_page_element_to_scrape
**Last valid version * *: v0.6.3
**Function * *: Web page element visualization inspection tool
**Reason for abandonment * *: Function integration into Playwright toolchain
    
```python
# old version(v0.6-)
from metagpt.tools.libs.web_scraping import view_page_element_to_scrape

# new version(v0.7+)
from metagpt.tools import scrape_web_playwright

# old define
async def main():
    di = DataInterpreter(tools=[tools=[view_page_element_to_scrape.__name__]])  

# new define
async def main():
    di = DataInterpreter(tools=["scrape_web_playwright"])  