### PR TITLE
solve the “undefined variables ‘context’” problem

### DIFF
--- a/metagpt/actions/action_node.py
+++ b/metagpt/actions/action_node.py
@@ -597,7 +597,7 @@ class ActionNode:
     async def fill(
         self,
         *,
-        req,
+        context,
         llm,
         schema="json",
         mode="auto",
@@ -609,7 +609,7 @@ class ActionNode:
     ):
         """Fill the node(s) with mode.
 
-        :param req: Everything we should know when filling node.
+        :param context: Everything we should know when filling node.
         :param llm: Large Language Model with pre-defined system message.
         :param schema: json/markdown, determine example and output format.
          - raw: free form text
@@ -628,7 +628,7 @@ class ActionNode:
         :return: self
         """
         self.set_llm(llm)
-        self.set_context(req)
+        self.set_context(context)
         if self.schema:
             schema = self.schema
 

--- a/metagpt/actions/action_node.py
+++ b/metagpt/actions/action_node.py
@@ -597,8 +597,9 @@ class ActionNode:
     async def fill(
         self,
         *,
-        context,
         llm,
+        context=None,
+        req=None,
         schema="json",
         mode="auto",
         strgy="simple",
@@ -628,7 +629,11 @@ class ActionNode:
         :return: self
         """
         self.set_llm(llm)
-        self.set_context(context)
+        if not req and context:
+            req = context
+        if not context and req:
+            context = req
+        self.set_context(req)
         if self.schema:
             schema = self.schema
 


### PR DESCRIPTION
#1839 
There does appear to be a real issue here, likely caused by a minor mistake during development. In the `ActionNode.fill` method, the parameter is incorrectly named `req`, while in `template/operator.py`, the `_fill_node` function explicitly passes an argument named `context`, leading to a parameter mismatch.

Here is a minimal reproduction of the inconsistency:

```
# template/operator.py
async def _fill_node(self, op_class, prompt, mode=None, **extra_kwargs):
    fill_kwargs = {"context": prompt, "llm": self.llm}
    if mode:
        fill_kwargs["mode"] = mode
    fill_kwargs.update(extra_kwargs)
    node = await ActionNode.from_pydantic(op_class).fill(**fill_kwargs)
    return node.instruct_content.model_dump()
# actions/action_node.py
async def fill(
    self,
    *,
    req,  # ← This should be `context`
    llm,
    schema="json",
    mode="auto",
    strgy="simple",
    images: Optional[Union[str, list[str]]] = None,
    timeout=USE_CONFIG_TIMEOUT,
    exclude=[],
    function_name: str = None,
):
    pass
```

Since the `ActionNode` class consistently uses `context` as the field name, changing the parameter name in `fill` from `req` to `context` should resolve the issue.

------

In addition, I noticed that during dataset evaluation via `benchmark.run_evaluation`, up to 50 asynchronous tasks may run concurrently. When using LLMs that produce streaming output, this results in interleaved outputs from different tasks being printed to the terminal, making logs difficult to read and debug.

It might be more helpful to either:

- Disable streaming output during evaluation, or
- Wait for each task to finish and then print the question and its answer together

This would make evaluation logs much more manageable.

------

Lastly, I’ve encountered a few other small issues during usage. It also seems that the project hasn’t seen recent updates or bug fixes, which makes me wonder if it’s still actively maintained. That would be unfortunate, as this is a valuable and meaningful project with great potential.

If needed, I’d be happy to contribute fixes via pull requests. Thank you for the great work so far!