### PR TITLE
Refactor team leader name handling in MGX environment

### DIFF
--- a/metagpt/environment/mgx/mgx_env.py
+++ b/metagpt/environment/mgx/mgx_env.py
@@ -13,6 +13,7 @@ class MGXEnv(Environment, SerializationMixin):
 
     direct_chat_roles: set[str] = set()  # record direct chat: @role_name
 
+    team_leader_name: str = TEAMLEADER_NAME # "Mike" by default but it can be changed at any time.
     is_public_chat: bool = True
 
     def _publish_message(self, message: Message, peekable: bool = True) -> bool:
@@ -25,7 +26,7 @@ class MGXEnv(Environment, SerializationMixin):
         """let the team leader take over message publishing"""
         message = self.attach_images(message)  # for multi-modal message
 
-        tl = self.get_role(TEAMLEADER_NAME)  # TeamLeader's name is Mike
+        tl = self.get_role(self.team_leader_name)  # TeamLeader's name is Mike
 
         if user_defined_recipient:
             # human user's direct chat message to a certain role
@@ -82,7 +83,7 @@ class MGXEnv(Environment, SerializationMixin):
         # When displaying send_to, change it to those who need to react and exclude those who only need to be aware, e.g.:
         # send_to={<all>} -> Mike; send_to={Alice} -> Alice; send_to={Alice, <all>} -> Alice.
         if converted_msg.send_to == {MESSAGE_ROUTE_TO_ALL}:
-            send_to = TEAMLEADER_NAME
+            send_to = self.team_leader_name
         else:
             send_to = ", ".join({role for role in converted_msg.send_to if role != MESSAGE_ROUTE_TO_ALL})
         converted_msg.content = f"[Message] from {sent_from or 'User'} to {send_to}: {converted_msg.content}"


### PR DESCRIPTION
This pull request updates the handling of the team leader's name within the `MGXEnv` class to make it configurable instead of hardcoded. Instead of always using "Mike" as the team leader, the name can now be set dynamically, improving flexibility for different team configurations.

**Team leader name configuration:**

* Added a new attribute `team_leader_name` to the `MGXEnv` class, allowing the team leader's name to be changed from the default ("Mike") as needed.
* Updated the `publish_message` method to use `self.team_leader_name` instead of the hardcoded team leader name when retrieving the role.
* Modified the `move_message_info_to_content` method to reference `self.team_leader_name` when displaying message recipients, ensuring consistency with the configurable team leader name.