### PR TITLE
Add team_leader_name to environment initialization

### DIFF
--- a/metagpt/team.py
+++ b/metagpt/team.py
@@ -46,9 +46,9 @@ class Team(BaseModel):
         super(Team, self).__init__(**data)
         ctx = context or Context()
         if not self.env and not self.use_mgx:
-            self.env = Environment(context=ctx)
+            self.env = Environment(context=ctx, team_leader_name=data.get("team_leader_name", TEAMLEADER_NAME))
         elif not self.env and self.use_mgx:
-            self.env = MGXEnv(context=ctx)
+            self.env = MGXEnv(context=ctx, team_leader_name=data.get("team_leader_name", TEAMLEADER_NAME))
         else:
             self.env.context = ctx  # The `env` object is allocated by deserialization
         if "roles" in data:


### PR DESCRIPTION
This pull request makes a targeted update to the initialization logic in the `Team` class to ensure that the environment objects (`Environment` and `MGXEnv`) are instantiated with the correct `team_leader_name`. This change improves consistency and configurability when creating new team environments.

Initialization improvements:

* Updated the constructors for `Environment` and `MGXEnv` in the `Team.__init__` method to accept a `team_leader_name` parameter, defaulting to `TEAMLEADER_NAME` if not provided. This ensures the team leader's name is consistently set during environment initialization.