### PR TITLE
fix: upgrade typer dependency to resolve CLI crash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ channels==4.0.0
 #faiss==1.5.3
 faiss_cpu==1.7.4
 fire==0.4.0
-typer==0.9.0
+typer>=0.9.4
 # godot==0.1.1
 # google_api_python_client==2.93.0  # Used by search_engine.py
 lancedb==0.4.0


### PR DESCRIPTION
**Features**
- Fixed incompatibility between typer 0.9.0 and click >= 8.1.4 which caused `metagpt` command to crash.
- Upgraded `typer>=0.9.4` in requirements.txt.

**Feature Docs**

**Influence**
- Fixes `TypeError: Secondary flag is not valid for non-boolean flag` when running `metagpt` command.
- Ensures compatibility with current python environments where `click` is updated.

**Result**
- `metagpt --version` now works correctly.
- `metagpt --help` now works correctly.

**Other**
Fixes issue where `typer==0.9.0` conflicts with `click>=8.1.4` (secondary flag validation).