### PR TITLE
fix(editor): allow create_file tool to accept content argument

### DIFF
--- a/metagpt/tools/libs/editor.py
+++ b/metagpt/tools/libs/editor.py
@@ -354,21 +354,23 @@ class Editor(BaseModel):
         output += self._print_window(self.current_file, self.current_line, self.window)
         return output
 
-    async def create_file(self, filename: str) -> str:
-        """Creates and opens a new file with the given name.
+    async def create_file(self, filename: str, content: str = "") -> str:
+        """Creates and opens a new file with the given name and optional content.
 
         Args:
-            filename: str: The name of the file to create. If the parent directory does not exist, it will be created.
+            filename: str: The name of the file to create.
+            content: str: (Optional) The initial content to write to the file.
         """
         filename = self._try_fix_path(filename)
 
         if filename.exists():
             raise FileExistsError(f"File '{filename}' already exists.")
-        await awrite(filename, "\n")
+        
+        # Write content if provided, otherwise default to newline
+        await awrite(filename, content if content else "\n")
 
         self.open_file(filename)
-        return f"[File {filename} created.]"
-
+        return f"[File {filename} created with {len(content)} characters.]"
     @staticmethod
     def _append_impl(lines, content):
         """Internal method to handle appending to a file.


### PR DESCRIPTION
## What does this PR do?
Updates the `Editor.create_file` method to accept an optional `content` argument.

## Why is this change necessary?
Fixes #1920

When LLMs (like Gemini or GPT-4) use the `Editor.create_file` tool, they frequently attempt to pass a `content` or `text` argument to write data immediately upon creation. The current implementation rejects these arguments with a `TypeError`, causing agents to crash or fail to save generated work.

## How to verify
1. Run a Data Interpreter agent with a task that requires saving a file.
2. Observe that the agent attempts to call `create_file(filename="...", content="...")`.
3. Verify the file is created successfully with the content, instead of throwing a TypeError.

<img width="1600" height="75" alt="image" src="https://github.com/user-attachments/assets/66b9c941-7430-4b5d-a3f8-49ead9838b3b" />
