### PR TITLE
add bocha search tool

### DIFF
--- a/metagpt/configs/search_config.py
+++ b/metagpt/configs/search_config.py
@@ -20,6 +20,7 @@ class SearchEngineType(Enum):
     DUCK_DUCK_GO = "ddg"
     CUSTOM_ENGINE = "custom"
     BING = "bing"
+    BoCha = "bocha"
 
 
 class SearchConfig(YamlModel):

--- a/metagpt/tools/search_engine.py
+++ b/metagpt/tools/search_engine.py
@@ -71,6 +71,9 @@ class SearchEngine(BaseModel):
         elif self.engine == SearchEngineType.BING:
             module = "metagpt.tools.search_engine_bing"
             run_func = importlib.import_module(module).BingAPIWrapper(**kwargs).run
+        elif self.engine == SearchEngineType.BoCha:
+            module = "metagpt.tools.search_engine_bocha"
+            run_func = importlib.import_module(module).BoChaAPIWrapper(**kwargs).run
         else:
             raise NotImplementedError
         self.run_func = run_func

--- a/metagpt/tools/search_engine_bocha.py
+++ b/metagpt/tools/search_engine_bocha.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import requests
+import json
+import warnings
+from typing import Optional
+
+import aiohttp
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+class BoChaAPIWrapper(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    api_key: str
+    bocha_url: str = "https://api.bocha.cn/v1/web-search"
+    aiosession: Optional[aiohttp.ClientSession] = None
+    proxy: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_api_key(cls, values: dict) -> dict:
+        if "api_key" in values:
+            values.setdefault("api_key", values["api_key"])
+            warnings.warn("`api_key` is deprecated, use `api_key` instead", DeprecationWarning, stacklevel=2)
+        return values
+
+    async def run(
+        self,
+        query: str,
+        max_results: int = 8,
+        as_string: bool = True,
+    ) -> str | list[dict]:
+        """Return the results of a BoCha search using the official bocha API.
+
+        Args:
+            query: The search query.
+            max_results: The number of results to return.
+            as_string: A boolean flag to determine the return type of the results. If True, the function will
+                return a formatted string with the search results. If False, it will return a list of dictionaries
+                containing detailed information about each search result.
+
+        Returns:
+            The results of the search.
+        """
+        params = {
+            "query": query,
+            "freshness": "noLimit",
+            "summary": True,
+            "count": max_results,
+            "include": "",
+            "exclude": ""
+        }
+        result = await self.results(params)
+        search_results = result["webPages"]["value"]
+        focus = ["snippet", "link", "title"]
+        for item_dict in search_results:
+            item_dict["link"] = item_dict["url"]
+            item_dict["title"] = item_dict["name"]
+        details = [{i: j for i, j in item_dict.items() if i in focus} for item_dict in search_results]
+        if as_string:
+            return safe_results(details)
+        return details
+
+    async def results(self, params: dict) -> dict:
+        # 构建请求头
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json"
+        }
+        # 发送API请求
+        response = requests.post(self.bocha_url, headers=headers, json=params)
+
+        return response.json()["data"]
+
+def safe_results(results: str | list) -> str:
+    """Return the results of a bocha search in a safe format.
+
+    Args:
+        results: The search results.
+
+    Returns:
+        The results of the search.
+    """
+    if isinstance(results, list):
+        safe_message = json.dumps([result for result in results])
+    else:
+        safe_message = results.encode("utf-8", "ignore").decode("utf-8")
+    return safe_message
+
+
+if __name__ == "__main__":
+    import fire
+
+    fire.Fire(BoChaAPIWrapper().run)


### PR DESCRIPTION
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

- Add Bocha Search Tool: integrates the Bocha AI Search API to provide web search capabilities
- Returns structured results including title, URL, summary, site name, site icon
    
**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->
Use the test case examples/research.py provided by MetaGPT
In the middle bocha web search results, only include ["snippet", "link", "title"]

<img width="1280" height="409" alt="image" src="https://github.com/user-attachments/assets/734b1762-11b8-41c6-bc54-383bd01e5262" />


**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->

- Provides a feature-rich web search option for the project, enabling real-time information retrieval and structured content access
- Enhances application capabilities in scenarios requiring up-to-date web data and domain-specific knowledge (e.g., weather, calendar)

**Result**
<!-- The screenshot/log of unittest/running result -->

**Other**
<!-- Something else about this PR. -->