### PR TITLE
fix: correct typos 'seperate' and 'occurence'

### DIFF
--- a/metagpt/utils/a11y_tree.py
+++ b/metagpt/utils/a11y_tree.py
@@ -165,7 +165,7 @@ async def get_element_center(node_info):
 
 
 def extract_step(response: str, action_splitter: str = "```") -> str:
-    # find the first occurence of action
+    # find the first occurrence of action
     pattern = rf"{action_splitter}((.|\n)*?){action_splitter}"
     match = re.search(pattern, response)
     if match:

--- a/metagpt/utils/special_tokens.py
+++ b/metagpt/utils/special_tokens.py
@@ -1,4 +1,4 @@
 # token to separate different code messages in a WriteCode Message content
 MSG_SEP = "#*000*#"
-# token to seperate file name and the actual code text in a code message
+# token to separate file name and the actual code text in a code message
 FILENAME_CODE_SEP = "#*001*#"


### PR DESCRIPTION
Fixed typos in comments:

- seperate → separate (special_tokens.py)
- occurence → occurrence (a11y_tree.py)