### PR TITLE
fix: replace 15 bare except clauses with except Exception

### DIFF
--- a/examples/di/InfiAgent-DABench/run_InfiAgent-DABench_all.py
+++ b/examples/di/InfiAgent-DABench/run_InfiAgent-DABench_all.py
@@ -23,7 +23,7 @@ async def main():
             temp_prediction, temp_istrue = bench.eval(key, str(result))
             is_true.append(str(temp_istrue))
             predictions.append(str(temp_prediction))
-        except:
+        except Exception:
             is_true.append(str(bench.eval(key, "")))
             predictions.append(str(""))
     df = pd.DataFrame({"Label": labels, "Prediction": predictions, "T/F": is_true})

--- a/metagpt/actions/action_node.py
+++ b/metagpt/actions/action_node.py
@@ -581,14 +581,14 @@ class ActionNode:
                         extracted_data[field_name] = eval(raw_value)
                         if not isinstance(extracted_data[field_name], list):
                             raise ValueError
-                    except:
+                    except Exception:
                         extracted_data[field_name] = []  # 默认空列表
                 elif field_type == dict:
                     try:
                         extracted_data[field_name] = eval(raw_value)
                         if not isinstance(extracted_data[field_name], dict):
                             raise ValueError
-                    except:
+                    except Exception:
                         extracted_data[field_name] = {}  # 默认空字典
 
         return extracted_data

--- a/metagpt/ext/aflow/benchmark/math.py
+++ b/metagpt/ext/aflow/benchmark/math.py
@@ -46,12 +46,12 @@ class MATHBenchmark(BaseBenchmark):
                 prediction = self.parse_digits(prediction)
                 reference = self.parse_digits(reference)
                 return isclose(prediction, reference, abs_tol=1e-3)
-        except:
+        except Exception:
             pass
 
         try:
             return self.symbolic_equal(prediction, reference)
-        except:
+        except Exception:
             pass
 
         return False
@@ -63,14 +63,14 @@ class MATHBenchmark(BaseBenchmark):
         num = regex.sub(",", "", str(num))
         try:
             return float(num)
-        except:
+        except Exception:
             if num.endswith("%"):
                 num = num[:-1]
                 if num.endswith("\\"):
                     num = num[:-1]
                 try:
                     return float(num) / 100
-                except:
+                except Exception:
                     pass
         return None
 
@@ -79,7 +79,7 @@ class MATHBenchmark(BaseBenchmark):
             for f in [parse_latex, parse_expr]:
                 try:
                     return f(s)
-                except:
+                except Exception:
                     pass
             return s
 
@@ -89,13 +89,13 @@ class MATHBenchmark(BaseBenchmark):
         try:
             if simplify(a - b) == 0:
                 return True
-        except:
+        except Exception:
             pass
 
         try:
             if isclose(N(a), N(b), abs_tol=1e-3):
                 return True
-        except:
+        except Exception:
             pass
         return False
 

--- a/metagpt/memory/brain_memory.py
+++ b/metagpt/memory/brain_memory.py
@@ -119,7 +119,7 @@ class BrainMemory(BaseModel):
     def to_int(v, default_value):
         try:
             return int(v)
-        except:
+        except Exception:
             return default_value
 
     def pop_last_talk(self):

--- a/metagpt/provider/openai_api.py
+++ b/metagpt/provider/openai_api.py
@@ -323,5 +323,5 @@ class OpenAILLM(BaseLLM):
     def count_tokens(self, messages: list[dict]) -> int:
         try:
             return count_message_tokens(messages, self.model)
-        except:
+        except Exception:
             return super().count_tokens(messages)

--- a/tests/metagpt/ext/stanford_town/memory/test_agent_memory.py
+++ b/tests/metagpt/ext/stanford_town/memory/test_agent_memory.py
@@ -52,7 +52,7 @@ class TestAgentMemory:
         try:
             agent_memory.save(memory_save_chat_test_path)
             logger.info("成功存储")
-        except:
+        except Exception:
             pass
 
     def test_summary_function(self, agent_memory):

--- a/tests/metagpt/strategy/examples/test_creative_writing.py
+++ b/tests/metagpt/strategy/examples/test_creative_writing.py
@@ -50,7 +50,7 @@ class TextGenEvaluator(BaseEvaluator):
                 print(vote)
                 if vote == int(node_id):
                     value = 1
-        except:
+        except Exception:
             value = 0
         return value
 

--- a/tests/metagpt/strategy/examples/test_game24.py
+++ b/tests/metagpt/strategy/examples/test_game24.py
@@ -39,7 +39,7 @@ class Game24Evaluator(BaseEvaluator):
         try:
             matches = re.findall(r"\b(impossible|sure|likely)\b", evaluation)
             value = self.value_map[matches[0]]
-        except:
+        except Exception:
             value = 0.001
         return value
 


### PR DESCRIPTION
## What
Replace 15 bare `except:` clauses with `except Exception:` across multiple files.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can:
- Prevent clean process shutdown (Ctrl+C ignored)
- Mask critical system errors
- Make debugging harder by silently swallowing unexpected exceptions

Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.