### PR TITLE
feat: Add ModelsLab text-to-image tool

### DIFF
--- a/metagpt/learn/text_to_image.py
+++ b/metagpt/learn/text_to_image.py
@@ -9,10 +9,13 @@
 import base64
 from typing import Optional
 
+import os
+
 from metagpt.config2 import Config
 from metagpt.const import BASE64_FORMAT
 from metagpt.llm import LLM
 from metagpt.tools.metagpt_text_to_image import oas3_metagpt_text_to_image
+from metagpt.tools.modelslab_text_to_image import oas3_modelslab_text_to_image
 from metagpt.tools.openai_text_to_image import oas3_openai_text_to_image
 from metagpt.utils.s3 import S3
 
@@ -29,8 +32,11 @@ async def text_to_image(text, size_type: str = "512x512", config: Optional[Confi
     image_declaration = "data:image/png;base64,"
 
     model_url = config.metagpt_tti_url
+    modelslab_api_key = os.environ.get("MODELSLAB_API_KEY", "")
     if model_url:
         binary_data = await oas3_metagpt_text_to_image(text, size_type, model_url)
+    elif modelslab_api_key:
+        binary_data = await oas3_modelslab_text_to_image(text, size_type, api_key=modelslab_api_key)
     elif config.get_openai_llm():
         llm = LLM(llm_config=config.get_openai_llm())
         binary_data = await oas3_openai_text_to_image(text, size_type, llm=llm)

--- a/metagpt/tools/modelslab_text_to_image.py
+++ b/metagpt/tools/modelslab_text_to_image.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+@Time    : 2026/3/1
+@File    : modelslab_text_to_image.py
+@Desc    : ModelsLab Text-to-Image OAS3 api, which provides text-to-image functionality.
+           ModelsLab supports Flux, SDXL, Stable Diffusion 3.5, and 100+ community models.
+           API docs: https://docs.modelslab.com
+"""
+import asyncio
+import os
+
+import aiohttp
+
+from metagpt.logs import logger
+
+_MODELSLAB_TEXT2IMG_URL = "https://modelslab.com/api/v6/images/text2img"
+_MODELSLAB_FETCH_URL = "https://modelslab.com/api/v6/images/fetch/{request_id}"
+_POLL_INTERVAL = 5  # seconds
+_POLL_TIMEOUT = 300  # seconds
+
+
+class ModelsLabText2Image:
+    def __init__(self, api_key: str, model_id: str = "flux"):
+        """Initialize ModelsLab text-to-image client.
+
+        :param api_key: ModelsLab API key (see https://modelslab.com/account/api-key)
+        :param model_id: Model to use. Recommended: 'flux' (default), 'fluxpro',
+                         'sdxl', 'sd3.5', 'realistic-vision-v6'.
+        """
+        self.api_key = api_key
+        self.model_id = model_id
+
+    async def text_2_image(self, text: str, size_type: str = "1024x1024") -> bytes:
+        """Generate an image from text using ModelsLab API.
+
+        ModelsLab uses key-in-body authentication and an asynchronous pattern:
+        the API may return ``status: processing`` with a request_id, requiring
+        polling of the fetch endpoint until ``status: success``.
+
+        :param text: The text prompt used for image generation.
+        :param size_type: Image dimensions as 'WxH'. Supported: '512x512',
+                          '1024x1024', '1344x768', '768x1344'.
+        :return: Raw image bytes (PNG).
+        """
+        dims = size_type.split("x")
+        width = int(dims[0]) if len(dims) == 2 else 1024
+        height = int(dims[1]) if len(dims) == 2 else 1024
+
+        payload = {
+            "key": self.api_key,
+            "model_id": self.model_id,
+            "prompt": text,
+            "negative_prompt": "blurry, low quality, watermark, distorted",
+            "width": width,
+            "height": height,
+            "samples": 1,
+            "num_inference_steps": 30,
+            "safety_checker": "no",
+            "enhance_prompt": "yes",
+        }
+
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.post(
+                    _MODELSLAB_TEXT2IMG_URL,
+                    json=payload,
+                    headers={"Content-Type": "application/json"},
+                ) as response:
+                    response.raise_for_status()
+                    data = await response.json()
+            except Exception as e:
+                logger.error(f"ModelsLab API request failed: {e}")
+                return b""
+
+        if data.get("status") == "error":
+            logger.error(f"ModelsLab error: {data.get('message', 'Unknown error')}")
+            return b""
+
+        if data.get("status") == "processing":
+            request_id = str(data.get("id", ""))
+            if not request_id:
+                logger.error("ModelsLab returned processing status without request ID")
+                return b""
+            data = await self._poll_until_ready(request_id)
+            if not data:
+                return b""
+
+        output = data.get("output", [])
+        if not output:
+            logger.error("ModelsLab returned no image output")
+            return b""
+
+        return await self._download_image(output[0])
+
+    async def _poll_until_ready(self, request_id: str) -> dict:
+        """Poll ModelsLab fetch endpoint until image is ready or timeout."""
+        fetch_url = _MODELSLAB_FETCH_URL.format(request_id=request_id)
+        fetch_payload = {"key": self.api_key}
+        deadline = asyncio.get_event_loop().time() + _POLL_TIMEOUT
+
+        async with aiohttp.ClientSession() as session:
+            while asyncio.get_event_loop().time() < deadline:
+                await asyncio.sleep(_POLL_INTERVAL)
+                try:
+                    async with session.post(
+                        fetch_url,
+                        json=fetch_payload,
+                        headers={"Content-Type": "application/json"},
+                    ) as response:
+                        response.raise_for_status()
+                        data = await response.json()
+                except Exception as e:
+                    logger.warning(f"ModelsLab poll error: {e}")
+                    continue
+
+                if data.get("status") == "error":
+                    logger.error(f"ModelsLab generation failed: {data.get('message')}")
+                    return {}
+                if data.get("status") == "success":
+                    return data
+
+        logger.error(f"ModelsLab timed out after {_POLL_TIMEOUT}s (id={request_id})")
+        return {}
+
+    async def _download_image(self, url: str) -> bytes:
+        """Download image from URL and return raw bytes."""
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.get(url) as response:
+                    response.raise_for_status()
+                    return await response.read()
+            except Exception as e:
+                logger.error(f"Failed to download image from {url}: {e}")
+                return b""
+
+
+async def oas3_modelslab_text_to_image(
+    text: str,
+    size_type: str = "1024x1024",
+    model_id: str = "flux",
+    api_key: str = "",
+) -> bytes:
+    """Text to image using ModelsLab API.
+
+    Supports Flux, SDXL, Stable Diffusion 3.5, and 100+ community models.
+
+    :param text: The text used for image conversion.
+    :param size_type: Image size. Options: '512x512', '1024x1024',
+                      '1344x768', '768x1344'. Default: '1024x1024'.
+    :param model_id: ModelsLab model ID. Default: 'flux'. See
+                     https://docs.modelslab.com for available models.
+    :param api_key: ModelsLab API key (or set MODELSLAB_API_KEY env var).
+    :return: Raw image bytes (PNG), or empty bytes on failure.
+    """
+    if not text:
+        return b""
+    if not api_key:
+        api_key = os.environ.get("MODELSLAB_API_KEY", "")
+    if not api_key:
+        logger.error("ModelsLab API key not provided. Set MODELSLAB_API_KEY env var.")
+        return b""
+    return await ModelsLabText2Image(api_key=api_key, model_id=model_id).text_2_image(
+        text, size_type=size_type
+    )

--- a/tests/metagpt/tools/test_modelslab_text_to_image.py
+++ b/tests/metagpt/tools/test_modelslab_text_to_image.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+@Time    : 2026/3/1
+@File    : test_modelslab_text_to_image.py
+"""
+import pytest
+
+from metagpt.tools.modelslab_text_to_image import (
+    ModelsLabText2Image,
+    oas3_modelslab_text_to_image,
+)
+
+
+@pytest.mark.asyncio
+async def test_text_2_image_success(mocker):
+    """Test successful image generation (immediate success response)."""
+    mock_post = mocker.patch("aiohttp.ClientSession.post")
+    mock_get = mocker.patch("aiohttp.ClientSession.get")
+
+    # Mock API response: immediate success
+    mock_api_response = mocker.AsyncMock()
+    mock_api_response.status = 200
+    mock_api_response.json.return_value = {
+        "status": "success",
+        "output": ["https://modelslab.com/output/test.png"],
+    }
+    mock_post.return_value.__aenter__.return_value = mock_api_response
+
+    # Mock image download
+    mock_img_response = mocker.AsyncMock()
+    mock_img_response.status = 200
+    mock_img_response.read.return_value = b"fake_image_bytes"
+    mock_get.return_value.__aenter__.return_value = mock_img_response
+
+    client = ModelsLabText2Image(api_key="test_key", model_id="flux")
+    result = await client.text_2_image("A futuristic city at night")
+
+    assert result == b"fake_image_bytes"
+    mock_post.assert_called_once()
+    call_kwargs = mock_post.call_args
+    assert "modelslab.com/api/v6/images/text2img" in str(call_kwargs)
+
+
+@pytest.mark.asyncio
+async def test_text_2_image_processing(mocker):
+    """Test async polling when API returns status: processing."""
+    call_count = 0
+
+    async def mock_json():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First call: processing
+            return {"status": "processing", "id": "req_123", "eta": 10}
+        else:
+            # Second call: success
+            return {"status": "success", "output": ["https://modelslab.com/output/test.png"]}
+
+    mock_post = mocker.patch("aiohttp.ClientSession.post")
+    mock_get = mocker.patch("aiohttp.ClientSession.get")
+    mocker.patch("asyncio.sleep", return_value=None)
+
+    mock_response = mocker.AsyncMock()
+    mock_response.status = 200
+    mock_response.json.side_effect = mock_json
+    mock_post.return_value.__aenter__.return_value = mock_response
+
+    mock_img_response = mocker.AsyncMock()
+    mock_img_response.status = 200
+    mock_img_response.read.return_value = b"polled_image_bytes"
+    mock_get.return_value.__aenter__.return_value = mock_img_response
+
+    client = ModelsLabText2Image(api_key="test_key")
+    result = await client.text_2_image("A sunset over mountains")
+
+    assert result == b"polled_image_bytes"
+    assert call_count >= 2  # initial call + at least one poll
+
+
+@pytest.mark.asyncio
+async def test_text_2_image_error(mocker):
+    """Test error response from API returns empty bytes."""
+    mock_post = mocker.patch("aiohttp.ClientSession.post")
+
+    mock_response = mocker.AsyncMock()
+    mock_response.status = 200
+    mock_response.json.return_value = {
+        "status": "error",
+        "message": "Invalid API key",
+    }
+    mock_post.return_value.__aenter__.return_value = mock_response
+
+    client = ModelsLabText2Image(api_key="bad_key")
+    result = await client.text_2_image("Test prompt")
+
+    assert result == b""
+
+
+@pytest.mark.asyncio
+async def test_oas3_modelslab_text_to_image_no_key(mocker):
+    """Test that missing API key returns empty bytes."""
+    mocker.patch.dict("os.environ", {}, clear=True)
+    result = await oas3_modelslab_text_to_image("Test", api_key="")
+    assert result == b""
+
+
+@pytest.mark.asyncio
+async def test_oas3_modelslab_text_to_image_env_key(mocker):
+    """Test that MODELSLAB_API_KEY env var is used when api_key not provided."""
+    mocker.patch.dict("os.environ", {"MODELSLAB_API_KEY": "env_key_123"})
+    mock_post = mocker.patch("aiohttp.ClientSession.post")
+    mock_get = mocker.patch("aiohttp.ClientSession.get")
+
+    mock_response = mocker.AsyncMock()
+    mock_response.status = 200
+    mock_response.json.return_value = {
+        "status": "success",
+        "output": ["https://modelslab.com/output/test.png"],
+    }
+    mock_post.return_value.__aenter__.return_value = mock_response
+
+    mock_img = mocker.AsyncMock()
+    mock_img.status = 200
+    mock_img.read.return_value = b"env_key_image"
+    mock_get.return_value.__aenter__.return_value = mock_img
+
+    result = await oas3_modelslab_text_to_image("Test prompt")
+    assert result == b"env_key_image"
+
+    # Verify the API key from env was used
+    call_json = mock_post.call_args.kwargs.get("json", {})
+    assert call_json.get("key") == "env_key_123"
+
+
+@pytest.mark.asyncio
+async def test_size_parsing(mocker):
+    """Test that size_type is correctly parsed into width/height."""
+    mock_post = mocker.patch("aiohttp.ClientSession.post")
+    mock_get = mocker.patch("aiohttp.ClientSession.get")
+
+    mock_response = mocker.AsyncMock()
+    mock_response.status = 200
+    mock_response.json.return_value = {
+        "status": "success",
+        "output": ["https://modelslab.com/output/test.png"],
+    }
+    mock_post.return_value.__aenter__.return_value = mock_response
+
+    mock_img = mocker.AsyncMock()
+    mock_img.status = 200
+    mock_img.read.return_value = b"size_test"
+    mock_get.return_value.__aenter__.return_value = mock_img
+
+    client = ModelsLabText2Image(api_key="test_key")
+    await client.text_2_image("Test", size_type="1344x768")
+
+    call_json = mock_post.call_args.kwargs.get("json", {})
+    assert call_json["width"] == 1344
+    assert call_json["height"] == 768


### PR DESCRIPTION
Adds ModelsLabText2Image and oas3_modelslab_text_to_image() following the openai_text_to_image.py pattern, and integrates it into the text_to_image() skill.

ModelsLab (https://modelslab.com) provides access to Flux, SDXL, SD 3.5, and 100+ community models.

## Files Changed

- metagpt/tools/modelslab_text_to_image.py: standalone tool (follows openai pattern)
- metagpt/learn/text_to_image.py: adds ModelsLab between metagpt_tti_url and OpenAI checks
- tests/metagpt/tools/test_modelslab_text_to_image.py: 6 mocked tests

## Key details

- Auth: key-in-body (MODELSLAB_API_KEY env var)
- Async polling: status=processing -> poll /images/fetch/{id} every 5s (up to 300s)
- No new dependencies (uses existing aiohttp)
- Models: flux (default), fluxpro, sdxl, sd3.5, realistic-vision-v6, +100 more

## Usage

export MODELSLAB_API_KEY=your_key

Automatically used when MODELSLAB_API_KEY is set and no metagpt_tti_url is configured.

API docs: https://docs.modelslab.com