### PR TITLE
Fix Context.deserialize() discarding deserialized cost_manager

### DIFF
--- a/metagpt/context.py
+++ b/metagpt/context.py
@@ -124,4 +124,4 @@ class Context(BaseModel):
                 self.kwargs.set(k, v)
         cost_manager = serialized_data.get("cost_manager")
         if cost_manager:
-            self.cost_manager.model_validate_json(cost_manager)
+            self.cost_manager = CostManager.model_validate_json(cost_manager)


### PR DESCRIPTION
## Problem

`Context.deserialize()` in `metagpt/context.py` line 127 calls:

```python
self.cost_manager.model_validate_json(cost_manager)
```

`model_validate_json()` is a Pydantic **classmethod** that creates and returns a new model instance from JSON. Since the return value is discarded, the deserialized cost manager data is silently lost — `self.cost_manager` retains its original (default) values.

## Fix

Assign the returned instance:

```python
self.cost_manager = CostManager.model_validate_json(cost_manager)
```

This means that when a Team is recovered from serialized state, the cost tracking (total_cost, max_budget, etc.) is correctly restored instead of being reset to defaults.