### PR TITLE
fix: initialize user_assistant_msgs to prevent UnboundLocalError in compress_messages

### DIFF
--- a/metagpt/provider/base_llm.py
+++ b/metagpt/provider/base_llm.py
@@ -362,14 +362,13 @@ class BaseLLM(ABC):
         # NOTE: Assume they do not exceed token limit
         system_msg_val = self._system_msg("")["role"]
         system_msgs = []
+        user_assistant_msgs = []
         for i, msg in enumerate(messages):
             if msg["role"] == system_msg_val:
                 system_msgs.append(msg)
             else:
                 user_assistant_msgs = messages[i:]
                 break
-        # system_msgs = [msg for msg in messages if msg["role"] == system_msg_val]
-        # user_assistant_msgs = [msg for msg in messages if msg["role"] != system_msg_val]
         compressed.extend(system_msgs)
         current_token_count = self.count_tokens(system_msgs)
 


### PR DESCRIPTION
## Summary
- `BaseLLM.compress_messages()` raises `UnboundLocalError` when all messages are system messages or the message list is empty (with compression enabled).

## Root Cause
- In `compress_messages()`, the variable `user_assistant_msgs` is only assigned inside the `else` branch of a for-loop (line 369). If all messages have `role == "system"`, the `else` branch never executes, and `user_assistant_msgs` remains undefined. The subsequent code on lines 378 and 396 references this variable unconditionally, causing an `UnboundLocalError`.

## Fix
- Initialize `user_assistant_msgs = []` before the loop so the variable always has a valid default value. This makes the compression logic safely handle edge cases (all-system messages, empty lists) by producing an empty compressed result instead of crashing.

## Test
```python
from metagpt.provider.base_llm import BaseLLM

# Before fix: raises UnboundLocalError
# After fix: returns the system messages without crashing
messages = [{"role": "system", "content": "You are helpful."}]
# compress_messages with any compress_type != NO_COMPRESS
```