### PR TITLE
fix: handle multimodal content correctly in count_message_tokens

### DIFF
--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -494,13 +494,13 @@ def count_message_tokens(messages, model="gpt-3.5-turbo-0125"):
     for message in messages:
         num_tokens += tokens_per_message
         for key, value in message.items():
-            content = value
             if isinstance(value, list):
-                # for gpt-4v
+                # for gpt-4v: sum tokens from all text parts in multimodal content
                 for item in value:
                     if isinstance(item, dict) and item.get("type") in ["text"]:
-                        content = item.get("text", "")
-            num_tokens += len(encoding.encode(content))
+                        num_tokens += len(encoding.encode(item.get("text", "")))
+            else:
+                num_tokens += len(encoding.encode(value))
             if key == "name":
                 num_tokens += tokens_per_name
     num_tokens += 3  # every reply is primed with <|start|>assistant<|message|>


### PR DESCRIPTION
## Summary
- `count_message_tokens()` crashes with `TypeError` on multimodal messages (e.g., gpt-4v image inputs) and silently undercounts tokens when multiple text parts exist.

## Root Cause
- In `count_message_tokens()`, when a message value is a list (multimodal content), the code assigns `content = value` (the list itself) and then only overwrites `content` inside a loop if a text item is found. Two problems result:
  1. If no text items exist in the list (e.g., image-only content), `encoding.encode(content)` receives a list object instead of a string, raising `TypeError`.
  2. If multiple text items exist, only the last one's tokens are counted because `content` is overwritten each iteration, and `encoding.encode()` is called only once after the loop.

## Fix
- Restructure the logic to properly branch on `isinstance(value, list)`:
  - For list values: iterate through items and sum tokens from all text parts directly.
  - For string values: encode directly as before.
- This correctly handles image-only content (0 text tokens) and multi-text content (sum of all text tokens).

## Test
```python
from metagpt.utils.token_counter import count_message_tokens

# Before fix: TypeError (encoding.encode receives a list)
messages = [{"role": "user", "content": [
    {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}
]}]
count_message_tokens(messages, "gpt-4o")

# Before fix: only counts last text item's tokens
messages = [{"role": "user", "content": [
    {"type": "text", "text": "What is in this image?"},
    {"type": "text", "text": "Please describe in detail."},
    {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}}
]}]
count_message_tokens(messages, "gpt-4o")
```