### PR TITLE
feat: add MiniMax LLM provider support (M3 default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ llm:
 ```yaml
 llm:
   api_type: "minimax"
-  model: "MiniMax-M2.7"  # or MiniMax-M2.5 / MiniMax-M2.5-highspeed
+  model: "MiniMax-M3"  # or MiniMax-M2.7 / MiniMax-M2.7-highspeed
   base_url: "https://api.minimax.io/v1"
   api_key: "YOUR_MINIMAX_API_KEY"
   temperature: 0.5  # MiniMax requires temperature in (0.0, 1.0]

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ llm:
 ```yaml
 llm:
   api_type: "minimax"
-  model: "MiniMax-M2.5"
+  model: "MiniMax-M2.7"  # or MiniMax-M2.5 / MiniMax-M2.5-highspeed
   base_url: "https://api.minimax.io/v1"
   api_key: "YOUR_MINIMAX_API_KEY"
   temperature: 0.5  # MiniMax requires temperature in (0.0, 1.0]

--- a/README.md
+++ b/README.md
@@ -77,11 +77,24 @@ You can configure `~/.metagpt/config2.yaml` according to the [example](https://g
 
 ```yaml
 llm:
-  api_type: "openai"  # or azure / ollama / groq etc. Check LLMType for more options
+  api_type: "openai"  # or azure / ollama / minimax / groq etc. Check LLMType for more options
   model: "gpt-4-turbo"  # or gpt-3.5-turbo
   base_url: "https://api.openai.com/v1"  # or forward url / other llm url
   api_key: "YOUR_API_KEY"
 ```
+
+<details>
+<summary>Example: Using MiniMax</summary>
+
+```yaml
+llm:
+  api_type: "minimax"
+  model: "MiniMax-M2.5"
+  base_url: "https://api.minimax.io/v1"
+  api_key: "YOUR_MINIMAX_API_KEY"
+  temperature: 0.5  # MiniMax requires temperature in (0.0, 1.0]
+```
+</details>
 
 ### Usage
 

--- a/config/config2.example.yaml
+++ b/config/config2.example.yaml
@@ -127,7 +127,7 @@ models:
 #    # timeout: 600 # Optional. If set to 0, default value is 300.
 #    # Details: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
 #    pricing_plan: "" # Optional. Use for Azure LLM when its model name is not the same as OpenAI's
-#  "MiniMax-M2.5":  # MiniMax (OpenAI-compatible)
+#  "MiniMax-M2.7":  # MiniMax (OpenAI-compatible) — default recommended model
 #    api_type: "minimax"
 #    base_url: "https://api.minimax.io/v1"
 #    api_key: "YOUR_MINIMAX_API_KEY"

--- a/config/config2.example.yaml
+++ b/config/config2.example.yaml
@@ -127,7 +127,7 @@ models:
 #    # timeout: 600 # Optional. If set to 0, default value is 300.
 #    # Details: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
 #    pricing_plan: "" # Optional. Use for Azure LLM when its model name is not the same as OpenAI's
-#  "MiniMax-M2.7":  # MiniMax (OpenAI-compatible) — default recommended model
+#  "MiniMax-M3":  # MiniMax (OpenAI-compatible) — default recommended model
 #    api_type: "minimax"
 #    base_url: "https://api.minimax.io/v1"
 #    api_key: "YOUR_MINIMAX_API_KEY"

--- a/config/config2.example.yaml
+++ b/config/config2.example.yaml
@@ -127,3 +127,8 @@ models:
 #    # timeout: 600 # Optional. If set to 0, default value is 300.
 #    # Details: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
 #    pricing_plan: "" # Optional. Use for Azure LLM when its model name is not the same as OpenAI's
+#  "MiniMax-M2.5":  # MiniMax (OpenAI-compatible)
+#    api_type: "minimax"
+#    base_url: "https://api.minimax.io/v1"
+#    api_key: "YOUR_MINIMAX_API_KEY"
+#    temperature: 0.5  # MiniMax requires temperature in (0.0, 1.0]

--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -44,6 +44,7 @@ class LLMType(Enum):
     BEDROCK = "bedrock"
     ARK = "ark"  # https://www.volcengine.com/docs/82379/1263482#python-sdk
     LLAMA_API = "llama_api"
+    MINIMAX = "minimax"
 
     def __missing__(self, key):
         return self.OPENAI

--- a/metagpt/provider/openai_api.py
+++ b/metagpt/provider/openai_api.py
@@ -53,6 +53,7 @@ from metagpt.utils.token_counter import (
         LLMType.SILICONFLOW,
         LLMType.OPENROUTER,
         LLMType.LLAMA_API,
+        LLMType.MINIMAX,
     ]
 )
 class OpenAILLM(BaseLLM):
@@ -149,6 +150,9 @@ class OpenAILLM(BaseLLM):
             # compatible to openai o1-series
             kwargs["temperature"] = 1
             kwargs.pop("max_tokens")
+        if self.config.api_type == LLMType.MINIMAX and kwargs.get("temperature", 0) <= 0:
+            # MiniMax requires temperature in (0.0, 1.0]
+            kwargs["temperature"] = 0.01
         if extra_kwargs:
             kwargs.update(extra_kwargs)
         return kwargs

--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -117,10 +117,9 @@ TOKEN_COSTS = {
     "llama-4-Maverick-17B-128E-Instruct-FP8": {"prompt": 0.0, "completion": 0.0},
     "llama-3.3-8B-Instruct": {"prompt": 0.0, "completion": 0.0},
     "llama-3.3-70B-Instruct": {"prompt": 0.0, "completion": 0.0},  # end, for Llama API
-    "MiniMax-M1": {"prompt": 0.0014, "completion": 0.007},  # start, for MiniMax
-    "MiniMax-M2.5": {"prompt": 0.0014, "completion": 0.007},
-    "MiniMax-M2.5-highspeed": {"prompt": 0.0014, "completion": 0.007},
-    "MiniMax-M2.7": {"prompt": 0.0014, "completion": 0.007},  # end, for MiniMax
+    "MiniMax-M3": {"prompt": 0.0006, "completion": 0.0024},  # start, for MiniMax
+    "MiniMax-M2.7": {"prompt": 0.0014, "completion": 0.007},
+    "MiniMax-M2.7-highspeed": {"prompt": 0.0014, "completion": 0.007},  # end, for MiniMax
 }
 
 
@@ -354,10 +353,9 @@ TOKEN_MAX = {
     "qwen-7b-chat": 32000,
     "qwen-1.8b-longcontext-chat": 32000,
     "qwen-1.8b-chat": 8000,
-    "MiniMax-M1": 1000000,  # start, for MiniMax
-    "MiniMax-M2.5": 204000,
-    "MiniMax-M2.5-highspeed": 204000,
-    "MiniMax-M2.7": 204000,  # end, for MiniMax
+    "MiniMax-M3": 512000,  # start, for MiniMax
+    "MiniMax-M2.7": 204000,
+    "MiniMax-M2.7-highspeed": 204000,  # end, for MiniMax
 }
 
 # For Amazon Bedrock US region

--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -119,7 +119,8 @@ TOKEN_COSTS = {
     "llama-3.3-70B-Instruct": {"prompt": 0.0, "completion": 0.0},  # end, for Llama API
     "MiniMax-M1": {"prompt": 0.0014, "completion": 0.007},  # start, for MiniMax
     "MiniMax-M2.5": {"prompt": 0.0014, "completion": 0.007},
-    "MiniMax-M2.5-highspeed": {"prompt": 0.0014, "completion": 0.007},  # end, for MiniMax
+    "MiniMax-M2.5-highspeed": {"prompt": 0.0014, "completion": 0.007},
+    "MiniMax-M2.7": {"prompt": 0.0014, "completion": 0.007},  # end, for MiniMax
 }
 
 
@@ -355,7 +356,8 @@ TOKEN_MAX = {
     "qwen-1.8b-chat": 8000,
     "MiniMax-M1": 1000000,  # start, for MiniMax
     "MiniMax-M2.5": 204000,
-    "MiniMax-M2.5-highspeed": 204000,  # end, for MiniMax
+    "MiniMax-M2.5-highspeed": 204000,
+    "MiniMax-M2.7": 204000,  # end, for MiniMax
 }
 
 # For Amazon Bedrock US region

--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -117,6 +117,9 @@ TOKEN_COSTS = {
     "llama-4-Maverick-17B-128E-Instruct-FP8": {"prompt": 0.0, "completion": 0.0},
     "llama-3.3-8B-Instruct": {"prompt": 0.0, "completion": 0.0},
     "llama-3.3-70B-Instruct": {"prompt": 0.0, "completion": 0.0},  # end, for Llama API
+    "MiniMax-M1": {"prompt": 0.0014, "completion": 0.007},  # start, for MiniMax
+    "MiniMax-M2.5": {"prompt": 0.0014, "completion": 0.007},
+    "MiniMax-M2.5-highspeed": {"prompt": 0.0014, "completion": 0.007},  # end, for MiniMax
 }
 
 
@@ -350,6 +353,9 @@ TOKEN_MAX = {
     "qwen-7b-chat": 32000,
     "qwen-1.8b-longcontext-chat": 32000,
     "qwen-1.8b-chat": 8000,
+    "MiniMax-M1": 1000000,  # start, for MiniMax
+    "MiniMax-M2.5": 204000,
+    "MiniMax-M2.5-highspeed": 204000,  # end, for MiniMax
 }
 
 # For Amazon Bedrock US region


### PR DESCRIPTION
## Summary

Add MiniMax as a first-class LLM provider for MetaGPT via its OpenAI-compatible API, with **MiniMax-M3** set as the default recommended model.

### Changes
- Add `LLMType.MINIMAX` enum value in `llm_config.py`
- Register `MINIMAX` in `OpenAILLM` provider routing in `openai_api.py`
- Add temperature clamping for MiniMax (requires > 0)
- Add token costs and context window limits for **MiniMax-M3** (default), MiniMax-M2.7, and MiniMax-M2.7-highspeed
- Add MiniMax config example in `config2.example.yaml`
- Add MiniMax usage example in README

### Models Supported
| Model | Context Window | Pricing (Input / Output per 1M tokens) | Notes |
|-------|---------------|----------------------------------------|-------|
| MiniMax-M3 | 512K | $0.6 / $2.4 | **Default recommended** — latest model, 128K max output, image input support |
| MiniMax-M2.7 | 204K | $1.4 / $7.0 | Previous generation |
| MiniMax-M2.7-highspeed | 204K | $1.4 / $7.0 | Low-latency variant of M2.7 |

### Configuration

```yaml
llm:
  api_type: "minimax"
  model: "MiniMax-M3"
  base_url: "https://api.minimax.io/v1"
  api_key: "YOUR_MINIMAX_API_KEY"
  temperature: 0.5  # MiniMax requires temperature in (0.0, 1.0]
```

### Testing
- Verified MiniMax-M3 model responds correctly via API
- Token counter and context window values validated programmatically
- LLMType enum verified