### PR TITLE
fix: handle empty OCR results in _ocr() to prevent IndexError

### DIFF
--- a/metagpt/actions/invoice_ocr.py
+++ b/metagpt/actions/invoice_ocr.py
@@ -85,6 +85,8 @@ class InvoiceOCR(Action):
     async def _ocr(invoice_file_path: Path):
         ocr = PaddleOCR(use_angle_cls=True, lang="ch", page_num=1)
         ocr_result = ocr.ocr(str(invoice_file_path), cls=True)
+        if not ocr_result or not ocr_result[0]:
+            return ocr_result
         for result in ocr_result[0]:
             result[1] = (result[1][0], round(result[1][1], 2))  # round long confidence scores to reduce token costs
         return ocr_result


### PR DESCRIPTION
## Summary

`_ocr()` in `invoice_ocr.py` crashes with `IndexError` when PaddleOCR returns an empty result for blank, corrupted, or unsupported image files.

**Features**
- Add a guard check before accessing `ocr_result[0]` to handle empty/None OCR results
- Returns early with the empty result instead of crashing

**Bug**
PaddleOCR's `ocr.ocr()` may return `[]` or `[None]` for certain inputs (blank images, corrupted files). The current code unconditionally accesses `ocr_result[0]` on line 88, which raises `IndexError` in these edge cases.

**Fix**
Added `if not ocr_result or not ocr_result[0]: return ocr_result` before the loop that processes OCR results.

**Feature Docs**
N/A - bug fix only

**Influence**
This change only affects the `_ocr()` static method in `InvoiceOCR`. No other code paths are modified.