### PR TITLE
fix: make optional dependencies safe and enforce on-disk workspace outputs in DI flow

### DIFF
--- a/metagpt/environment/mgx/mgx_env.py
+++ b/metagpt/environment/mgx/mgx_env.py
@@ -26,6 +26,10 @@ class MGXEnv(Environment, SerializationMixin):
         message = self.attach_images(message)  # for multi-modal message
 
         tl = self.get_role(TEAMLEADER_NAME)  # TeamLeader's name is Mike
+        if tl is None:
+            self._publish_message(message)
+            self.history.add(message)
+            return True
 
         if user_defined_recipient:
             # human user's direct chat message to a certain role

--- a/metagpt/prompts/di/engineer2.py
+++ b/metagpt/prompts/di/engineer2.py
@@ -58,6 +58,8 @@ Note:
 27. Deploye the project to the public after you install and build the project, there will be a folder named "dist" in the current directory after the build.
 28. Use Engineer2.write_new_code to rewrite the whole file when you fail to use Editor.edit_file_by_replace more than three times.
 29. Just continue the work, if the template path does not exits.
+30. If the requirement provides a project root path, you must keep all coding output under that path and persist files on disk. Do not only return code snippets in messages.
+31. Treat a coding task as unfinished until required files are created or updated under the target project root.
 """.format(
     vue_template_path=VUE_TEMPLATE_PATH.resolve().absolute(),
     react_template_path=REACT_TEMPLATE_PATH.resolve().absolute(),

--- a/metagpt/prompts/di/team_leader.py
+++ b/metagpt/prompts/di/team_leader.py
@@ -37,6 +37,8 @@ Note:
 14. Default technology stack is Vite, React, MUI, Tailwind CSS. Web app is the default option when developing software. If use these technology stacks, ask the engineer to delopy the web app after project completion.
 15. You are the only one who decides the programming language for the software, so the instruction must contain the programming language.
 16. Data collection and web/software development are two separate tasks. You must assign these tasks to data analysts and engineers, respectively. Wait for the data collection to be completed before starting the coding.
+17. If the requirement or upstream message includes a project root path, you MUST include the exact absolute path when assigning software tasks.
+18. For software development, a task is complete only when files are actually written under the project root path, not when code is only described in messages.
 """
 TL_THOUGHT_GUIDANCE = (
     THOUGHT_GUIDANCE

--- a/metagpt/provider/__init__.py
+++ b/metagpt/provider/__init__.py
@@ -6,20 +6,32 @@
 @File    : __init__.py
 """
 
-from metagpt.provider.google_gemini_api import GeminiLLM
-from metagpt.provider.ollama_api import OllamaLLM
+from importlib import import_module
+
 from metagpt.provider.openai_api import OpenAILLM
-from metagpt.provider.zhipuai_api import ZhiPuAILLM
 from metagpt.provider.azure_openai_api import AzureOpenAILLM
-from metagpt.provider.metagpt_api import MetaGPTLLM
 from metagpt.provider.human_provider import HumanProvider
-from metagpt.provider.spark_api import SparkLLM
-from metagpt.provider.qianfan_api import QianFanLLM
-from metagpt.provider.dashscope_api import DashScopeLLM
-from metagpt.provider.anthropic_api import AnthropicLLM
-from metagpt.provider.bedrock_api import BedrockLLM
-from metagpt.provider.ark_api import ArkLLM
-from metagpt.provider.openrouter_reasoning import OpenrouterReasoningLLM
+
+
+def _safe_import(module_path: str, attr_name: str):
+    try:
+        module = import_module(module_path)
+        return getattr(module, attr_name)
+    except (ImportError, ModuleNotFoundError):
+        return None
+
+
+GeminiLLM = _safe_import("metagpt.provider.google_gemini_api", "GeminiLLM")
+OllamaLLM = _safe_import("metagpt.provider.ollama_api", "OllamaLLM")
+ZhiPuAILLM = _safe_import("metagpt.provider.zhipuai_api", "ZhiPuAILLM")
+MetaGPTLLM = _safe_import("metagpt.provider.metagpt_api", "MetaGPTLLM")
+SparkLLM = _safe_import("metagpt.provider.spark_api", "SparkLLM")
+QianFanLLM = _safe_import("metagpt.provider.qianfan_api", "QianFanLLM")
+DashScopeLLM = _safe_import("metagpt.provider.dashscope_api", "DashScopeLLM")
+AnthropicLLM = _safe_import("metagpt.provider.anthropic_api", "AnthropicLLM")
+BedrockLLM = _safe_import("metagpt.provider.bedrock_api", "BedrockLLM")
+ArkLLM = _safe_import("metagpt.provider.ark_api", "ArkLLM")
+OpenrouterReasoningLLM = _safe_import("metagpt.provider.openrouter_reasoning", "OpenrouterReasoningLLM")
 
 __all__ = [
     "GeminiLLM",

--- a/metagpt/schema.py
+++ b/metagpt/schema.py
@@ -69,6 +69,15 @@ from metagpt.utils.serialize import (
 )
 
 
+def _new_message_queue() -> Queue:
+    """Create an asyncio queue even when no event loop is set on the current thread."""
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+    return Queue()
+
+
 class SerializationMixin(BaseSerialization):
     @handle_exception
     def serialize(self, file_path: str = None) -> str:
@@ -715,7 +724,7 @@ class MessageQueue(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    _queue: Queue = PrivateAttr(default_factory=Queue)
+    _queue: Queue = PrivateAttr(default_factory=_new_message_queue)
 
     def pop(self) -> Message | None:
         """Pop one message from the queue."""

--- a/metagpt/software_company.py
+++ b/metagpt/software_company.py
@@ -6,9 +6,35 @@ from pathlib import Path
 
 import typer
 
-from metagpt.const import CONFIG_ROOT
+from metagpt.const import CONFIG_ROOT, TEAMLEADER_NAME
 
 app = typer.Typer(add_completion=False, pretty_exceptions_show_locals=False)
+
+
+def _build_workspace_constrained_requirement(idea: str, project_root: Path) -> str:
+    """Add runtime constraints to force file persistence under the workspace path."""
+    return (
+        f"{idea}\n\n"
+        "[Runtime Constraints]\n"
+        f"- Project root path (absolute): {project_root}\n"
+        "- All implementation outputs must be persisted as files under this project root.\n"
+        "- Do not only print code or plans in chat/console; write real files.\n"
+        "- Keep all actions inside this project root unless user explicitly asks otherwise.\n"
+    )
+
+
+def _collect_materialized_files(project_root: Path) -> list[Path]:
+    """Collect generated files, excluding git internals and bootstrap-only file."""
+    files: list[Path] = []
+    for file in project_root.rglob("*"):
+        if not file.is_file():
+            continue
+        if ".git" in file.parts:
+            continue
+        if file.name == ".gitignore":
+            continue
+        files.append(file)
+    return files
 
 
 def generate_repo(
@@ -36,11 +62,23 @@ def generate_repo(
         TeamLeader,
     )
     from metagpt.team import Team
+    from metagpt.utils.file_repository import FileRepository
+    from metagpt.utils.project_repo import ProjectRepo
 
     config.update_via_cli(project_path, project_name, inc, reqa_file, max_auto_summarize_code)
     ctx = Context(config=config)
+    repo = None
 
     if not recover_path:
+        if config.project_path:
+            project_root = Path(config.project_path).expanduser().resolve()
+        else:
+            name = config.project_name or FileRepository.new_filename()
+            project_root = (Path(config.workspace.path) / name).expanduser().resolve()
+        repo = ProjectRepo(project_root)
+        ctx.kwargs.project_path = str(repo.workdir)
+        runtime_idea = _build_workspace_constrained_requirement(idea=idea, project_root=repo.workdir)
+
         company = Team(context=ctx)
         company.hire(
             [
@@ -66,12 +104,24 @@ def generate_repo(
             raise FileNotFoundError(f"{recover_path} not exists or not endswith `team`")
 
         company = Team.deserialize(stg_path=stg_path, context=ctx)
-        idea = company.idea
+        runtime_idea = company.idea
 
     company.invest(investment)
-    asyncio.run(company.run(n_round=n_round, idea=idea))
+    asyncio.run(company.run(n_round=n_round, idea=runtime_idea, send_to=TEAMLEADER_NAME))
 
-    return ctx.kwargs.get("project_path")
+    project_path = ctx.kwargs.get("project_path")
+    if not project_path:
+        raise RuntimeError("Project path is missing after generation. The repository was not initialized.")
+    repo = repo or ProjectRepo(project_path)
+    if implement:
+        files = _collect_materialized_files(repo.workdir)
+        if not files:
+            raise RuntimeError(
+                f"Generation finished without persisted files under {repo.workdir}. "
+                "The workflow only produced console/chat output."
+            )
+
+    return repo
 
 
 @app.command("", help="Start a new project.")

--- a/metagpt/team.py
+++ b/metagpt/team.py
@@ -104,7 +104,7 @@ class Team(BaseModel):
         self.idea = idea
 
         # Human requirement.
-        self.env.publish_message(Message(content=idea))
+        self.env.publish_message(Message(content=idea, send_to=send_to))
 
     def start_project(self, idea, send_to: str = ""):
         """

--- a/metagpt/tools/libs/__init__.py
+++ b/metagpt/tools/libs/__init__.py
@@ -4,33 +4,33 @@
 # @Author  : lidanyang
 # @File    : __init__.py
 # @Desc    :
-from metagpt.tools.libs import (
-    data_preprocess,
-    feature_engineering,
-    sd_engine,
-    gpt_v_generator,
-    web_scraping,
-    # email_login,
-    terminal,
-    editor,
-    browser,
-    deployer,
-    git,
-)
+from importlib import import_module
+
+from metagpt.logs import logger
 from metagpt.tools.libs.env import get_env, set_get_env_entry, default_get_env, get_env_description, get_env_default
 
+_REGISTER_MODULES = [
+    "data_preprocess",
+    "feature_engineering",
+    "sd_engine",
+    "gpt_v_generator",
+    "web_scraping",
+    "terminal",
+    "editor",
+    "browser",
+    "deployer",
+    "git",
+]
+
+_loaded_modules = []
+for _name in _REGISTER_MODULES:
+    try:
+        _loaded_modules.append(import_module(f"metagpt.tools.libs.{_name}"))
+    except (ImportError, ModuleNotFoundError) as err:
+        logger.warning(f"Skip loading tools module `{_name}` due to missing dependency: {err}")
+
 _ = (
-    data_preprocess,
-    feature_engineering,
-    sd_engine,
-    gpt_v_generator,
-    web_scraping,
-    # email_login,
-    terminal,
-    editor,
-    browser,
-    deployer,
-    git,
+    _loaded_modules,
     get_env,
     get_env_default,
     get_env_description,

--- a/metagpt/utils/git_repository.py
+++ b/metagpt/utils/git_repository.py
@@ -19,13 +19,6 @@ from urllib.parse import quote
 
 from git.repo import Repo
 from git.repo.fun import is_git_dir
-from github import Auth, BadCredentialsException, Github
-from github.GithubObject import NotSet
-from github.Issue import Issue
-from github.Label import Label
-from github.Milestone import Milestone
-from github.NamedUser import NamedUser
-from github.PullRequest import PullRequest
 from gitignore_parser import parse_gitignore
 from pydantic import BaseModel
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -34,6 +27,35 @@ from metagpt.logs import logger
 from metagpt.tools.libs.shell import shell_execute
 from metagpt.utils.dependency_file import DependencyFile
 from metagpt.utils.file_repository import FileRepository
+
+try:
+    from github import Auth, BadCredentialsException, Github
+    from github.GithubObject import NotSet
+    from github.Issue import Issue
+    from github.Label import Label
+    from github.Milestone import Milestone
+    from github.NamedUser import NamedUser
+    from github.PullRequest import PullRequest
+
+    HAS_GITHUB = True
+except (ImportError, ModuleNotFoundError):
+    Auth = None
+    Github = None
+    NotSet = object()
+    Issue = Label = Milestone = NamedUser = PullRequest = object
+    HAS_GITHUB = False
+
+    class BadCredentialsException(Exception):
+        """Fallback exception when PyGithub is not installed."""
+
+        def __init__(self, *args, **kwargs):
+            message = kwargs.get("message") or (args[0] if args else "PyGithub is required")
+            super().__init__(message)
+
+
+def _require_github_dependency():
+    if not HAS_GITHUB:
+        raise ModuleNotFoundError("PyGithub is required for GitHub operations. Install with `pip install PyGithub`.")
 
 
 class ChangeType(Enum):
@@ -481,6 +503,7 @@ class GitRepository:
         Returns:
             PullRequest: The created pull request object.
         """
+        _require_github_dependency()
         title = title or NotSet
         body = body or NotSet
         maintainer_can_modify = maintainer_can_modify or NotSet
@@ -546,6 +569,7 @@ class GitRepository:
         Returns:
             Issue: The created issue object.
         """
+        _require_github_dependency()
         body = body or NotSet
         assignee = assignee or NotSet
         milestone = milestone or NotSet
@@ -588,6 +612,7 @@ class GitRepository:
         Returns:
             List[str]: A list of full names of the public repositories belonging to the user.
         """
+        _require_github_dependency()
         auth = auth or Auth.Token(access_token)
         git = Github(auth=auth)
         user = git.get_user()

--- a/tests/metagpt/test_software_company.py
+++ b/tests/metagpt/test_software_company.py
@@ -5,12 +5,16 @@
 @Author  : alexanderwu
 @File    : test_software_company.py
 """
+from pathlib import Path
+
 import pytest
 from typer.testing import CliRunner
 
+from metagpt.const import TEAMLEADER_NAME
 from metagpt.logs import logger
-from metagpt.software_company import app
+from metagpt.software_company import app, generate_repo
 from metagpt.team import Team
+from metagpt.utils.project_repo import ProjectRepo
 
 runner = CliRunner()
 
@@ -23,18 +27,56 @@ async def test_empty_team(new_filename):
     logger.info(history)
 
 
-def test_software_company(new_filename):
-    args = ["Make a cli snake game"]
+def test_software_company(new_filename, tmp_path, mocker):
+    project_root = tmp_path / "snake_game"
+    captured = {}
+
+    async def fake_run(self, n_round=3, idea="", send_to="", auto_archive=True):
+        captured["idea"] = idea
+        captured["send_to"] = send_to
+        root = Path(self.env.context.kwargs.project_path)
+        (root / "src").mkdir(parents=True, exist_ok=True)
+        (root / "src" / "main.py").write_text("print('hello')\n", encoding="utf-8")
+        return self.env.history
+
+    mocker.patch("metagpt.team.Team.run", new=fake_run)
+
+    args = ["Make a cli snake game", "--project-path", str(project_root)]
     result = runner.invoke(app, args)
-    logger.info(result)
-    logger.info(result.output)
+    assert result.exit_code == 0
+    assert (project_root / "src" / "main.py").exists()
+    assert captured["send_to"] == TEAMLEADER_NAME
+    assert str(project_root) in captured["idea"]
+    assert "must be persisted as files" in captured["idea"]
 
 
-def test_software_company_with_run_tests():
-    args = ["Make a cli snake game", "--run-tests", "--n-round=8"]
-    result = runner.invoke(app, args)
-    logger.info(result.output)
-    # assert "unittest" in result.output.lower() or "pytest" in result.output.lower()
+def test_generate_repo_returns_project_repo(tmp_path, mocker):
+    project_root = tmp_path / "repo_return_case"
+
+    async def fake_run(self, n_round=3, idea="", send_to="", auto_archive=True):
+        root = Path(self.env.context.kwargs.project_path)
+        (root / "app").mkdir(parents=True, exist_ok=True)
+        (root / "app" / "server.py").write_text("print('ok')\n", encoding="utf-8")
+        return self.env.history
+
+    mocker.patch("metagpt.team.Team.run", new=fake_run)
+
+    repo = generate_repo("Build a tiny API", project_path=str(project_root))
+    assert isinstance(repo, ProjectRepo)
+    assert repo.workdir == project_root
+    assert (project_root / "app" / "server.py").exists()
+
+
+def test_generate_repo_fails_when_no_files_persisted(tmp_path, mocker):
+    project_root = tmp_path / "empty_case"
+
+    async def fake_run(self, n_round=3, idea="", send_to="", auto_archive=True):
+        return self.env.history
+
+    mocker.patch("metagpt.team.Team.run", new=fake_run)
+
+    with pytest.raises(RuntimeError, match="without persisted files"):
+        generate_repo("Make a cli snake game", project_path=str(project_root), implement=True)
 
 
 if __name__ == "__main__":

--- a/tests/metagpt/test_team.py
+++ b/tests/metagpt/test_team.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 # @Desc   : unittest of team
 
+from metagpt.const import TEAMLEADER_NAME
 from metagpt.roles.project_manager import ProjectManager
 from metagpt.team import Team
 
@@ -11,3 +12,13 @@ def test_team():
     company.hire([ProjectManager()])
 
     assert len(company.env.roles) == 1
+
+
+def test_run_project_with_send_to():
+    company = Team()
+    company.hire([ProjectManager()])
+
+    company.run_project("Build a todo app", send_to=TEAMLEADER_NAME)
+    published = company.env.history.get()[-1]
+
+    assert TEAMLEADER_NAME in published.send_to


### PR DESCRIPTION
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

- Fix hard-import behavior for optional integrations in `metagpt.provider`, `metagpt.tools.libs`, and GitHub-related utilities, so missing optional packages do not fail module import or pytest collection prematurely.
- Enforce DI/software generation tasks to persist outputs under the target project root instead of only returning code snippets or chat-only results.
- Pass the target project path through the runtime requirement and route the generated task message to `TeamLeader` explicitly.
- Add runtime validation that generation must leave materialized files on disk, otherwise fail fast with a clear error.
- Update related tests to cover the new generation and routing behavior.

**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->

N/A

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->

- Affects DI/software generation flow by making "task completed" mean real files are created under the workspace/project root.
- Reduces failure risk in clean CI/local environments where optional integrations such as Spark- or GitHub-related dependencies are not installed.
- Improves robustness of test collection and module import behavior.

**Result**
<!-- The screenshot/log of unittest/running result -->

- Before this change, optional integrations could fail during import/collection when related packages were not installed.
- Before this change, DI generation could appear finished even when no actual files were written under the target workspace.
- After this change, optional integrations degrade gracefully, and the generation flow explicitly validates that files are persisted on disk.

**Other**
<!-- Something else about this PR. -->

- This PR is not only a prompt tweak. It also changes runtime validation, message routing, and optional dependency loading behavior.
- Actual Spark/GitHub-related functionality still requires installing the corresponding optional dependencies when those integrations are used.