### PR TITLE
Fix command injection in get_mime_type() via shell=True

### DIFF
--- a/metagpt/utils/common.py
+++ b/metagpt/utils/common.py
@@ -917,7 +917,7 @@ async def get_mime_type(filename: str | Path, force_read: bool = False) -> str:
     }
 
     try:
-        stdout, stderr, _ = await shell_execute(f"file --mime-type '{str(filename)}'")
+        stdout, stderr, _ = await shell_execute(["file", "--mime-type", str(filename)])
         if stderr:
             logger.debug(f"file:{filename}, error:{stderr}")
             return guess_mime_type


### PR DESCRIPTION
## Summary

- Fix command injection vulnerability in `get_mime_type()` (`metagpt/utils/common.py`) by passing the command as a list to `shell_execute()` instead of an f-string
- When `shell_execute` receives a list, it sets `shell=False`, preventing shell metacharacters in filenames from being interpreted as shell commands
- This prevents arbitrary command execution when processing files with maliciously crafted filenames (e.g., from untrusted repositories via `repo_to_markdown`)

**Before (vulnerable):**
```python
stdout, stderr, _ = await shell_execute(f"file --mime-type '{str(filename)}'")
```

**After (safe):**
```python
stdout, stderr, _ = await shell_execute(["file", "--mime-type", str(filename)])
```

Addresses #1930

## Test plan

- [ ] Verify `get_mime_type()` returns correct MIME types for standard files (e.g., `.py`, `.json`, `.txt`)
- [ ] Verify filenames with shell metacharacters (e.g., `'; id; '`) do not trigger command injection
- [ ] Verify `repo_to_markdown()` continues to work correctly with the fix applied