### PR TITLE
Fix nested triple-backtick parsing in code block extractors

### DIFF
--- a/metagpt/utils/common.py
+++ b/metagpt/utils/common.py
@@ -94,12 +94,20 @@ class OutputParser:
 
     @classmethod
     def parse_code(cls, text: str, lang: str = "") -> str:
-        pattern = rf"```{lang}.*?\s+(.*?)```"
-        match = re.search(pattern, text, re.DOTALL)
-        if match:
-            code = match.group(1)
-        else:
+        # Split by the opening tag and use rsplit to find the *last* closing
+        # ```, which avoids matching nested triple-backticks inside content
+        # (e.g., markdown that contains ```shell ... ``` blocks).
+        start_tag = f"```{lang}"
+        if start_tag not in text:
             raise Exception
+        after_start = text.split(start_tag, 1)[1]
+        if "```" not in after_start:
+            raise Exception
+        # rsplit by ``` to find the outermost closing fence
+        code = after_start.rsplit("```", 1)[0]
+        # Strip the leading optional language suffix and whitespace
+        # (e.g., after ```python there may be a newline)
+        code = code.split("\n", 1)[-1] if "\n" in code else code.lstrip()
         return code
 
     @classmethod
@@ -283,15 +291,24 @@ class CodeParser:
     def parse_code(cls, text: str, lang: str = "", block: Optional[str] = None) -> str:
         if block:
             text = cls.parse_block(block, text)
-        pattern = rf"```{lang}.*?\s+(.*?)\n```"
-        match = re.search(pattern, text, re.DOTALL)
-        if match:
-            code = match.group(1)
-        else:
-            logger.error(f"{pattern} not match following text:")
+        # Split by the opening tag and use rsplit to find the *last* closing
+        # ```, which avoids matching nested triple-backticks inside content
+        # (e.g., markdown that contains ```shell ... ``` blocks).
+        start_tag = f"```{lang}"
+        if start_tag not in text:
+            logger.error(f"```{lang} not found in following text:")
             logger.error(text)
-            # raise Exception
             return text  # just assume original text is code
+        after_start = text.split(start_tag, 1)[1]
+        if "```" not in after_start:
+            logger.error(f"Closing ``` not found after ```{lang} in following text:")
+            logger.error(text)
+            return text  # just assume original text is code
+        # rsplit by ``` to find the outermost closing fence
+        code = after_start.rsplit("```", 1)[0]
+        # Strip the leading optional language suffix and whitespace
+        # (e.g., after ```python there may be a newline)
+        code = code.split("\n", 1)[-1] if "\n" in code else code.lstrip()
         return code
 
     @classmethod
@@ -776,11 +793,21 @@ def list_files(root: str | Path) -> List[Path]:
 
 
 def parse_json_code_block(markdown_text: str) -> List[str]:
-    json_blocks = (
-        re.findall(r"```json(.*?)```", markdown_text, re.DOTALL) if "```json" in markdown_text else [markdown_text]
-    )
+    if "```json" not in markdown_text:
+        return [markdown_text.strip()]
 
-    return [v.strip() for v in json_blocks]
+    # Split by the opening ```json tag and process each segment.
+    # For each segment, use rsplit to find the *last* closing ``` so that
+    # nested triple-backticks inside JSON string values (e.g., markdown
+    # content containing ```shell ... ```) do not prematurely end the block.
+    blocks = []
+    parts = markdown_text.split("```json")
+    for part in parts[1:]:
+        if "```" in part:
+            content = part.rsplit("```", 1)[0]
+            blocks.append(content.strip())
+
+    return blocks if blocks else [markdown_text.strip()]
 
 
 def remove_white_spaces(v: str) -> str:


### PR DESCRIPTION
## Summary

- Fix `OutputParser.parse_code`, `CodeParser.parse_code`, and `parse_json_code_block` in `metagpt/utils/common.py` to correctly handle nested triple-backticks inside code block content
- Replace non-greedy regex matching (`.*?`) with a `split`/`rsplit` approach: split by the opening fence (e.g., `` ```json ``), then `rsplit` by `` ``` `` to find the *last* (outermost) closing fence
- This prevents LLM responses containing markdown with nested code blocks (e.g., `` ```shell ... ``` `` inside a JSON string value) from being truncated at the first inner `` ``` ``

**Before (broken):**
```python
# Non-greedy regex stops at the first ``` it finds, even if nested
pattern = rf"```{lang}.*?\s+(.*?)```"
match = re.search(pattern, text, re.DOTALL)
```

**After (fixed):**
```python
# split by opening tag, rsplit by ``` to find the outermost closing fence
after_start = text.split(start_tag, 1)[1]
code = after_start.rsplit("```", 1)[0]
```

Addresses #1923

## Test plan

- [x] Verify `OutputParser.parse_code` correctly extracts code blocks that contain nested triple-backticks (e.g., Python code with embedded markdown containing `` ```shell `` blocks)
- [x] Verify `CodeParser.parse_code` handles nested backticks in block-based parsing
- [x] Verify `parse_json_code_block` returns valid JSON when JSON string values contain triple-backtick sequences
- [x] Verify all three functions still work correctly for simple (non-nested) code blocks
- [x] Verify `OutputParser.parse_code` still raises `Exception` when no matching code block is found
- [x] Verify `parse_json_code_block` returns original text when no `` ```json `` marker is present
- [x] Verify `parse_json_code_block` correctly handles multiple JSON blocks in one response