### PR TITLE
fix(CodeParser): strip LLM-injected filename headers from extracted c…

### DIFF
--- a/metagpt/utils/common.py
+++ b/metagpt/utils/common.py
@@ -292,6 +292,9 @@ class CodeParser:
             logger.error(text)
             # raise Exception
             return text  # just assume original text is code
+        # Strip LLM-injected filename header (e.g., "## quickSort.js") from code blocks.
+        # The LLM sometimes echoes the filename marker inside the code block instead of outside.
+        code = re.sub(r'^##\s+\S+\.\w+[ \t]*\n+', '', code)
         return code
 
     @classmethod

--- a/tests/metagpt/utils/test_code_parser.py
+++ b/tests/metagpt/utils/test_code_parser.py
@@ -133,6 +133,20 @@ class TestCodeParser:
         print(result)
         assert "game.py" in result
 
+    def test_parse_code_strips_filename_header(self, parser):
+        """LLM sometimes echoes the filename marker inside the code block instead of outside it."""
+        text = "```python\n## sort.py\n\ndef sort(arr):\n    return sorted(arr)\n```"
+        result = parser.parse_code(block="", text=text, lang="python")
+        assert not result.startswith("##"), "filename header should be stripped from extracted code"
+        assert "def sort" in result
+
+    def test_parse_code_strips_filename_header_no_blank_line(self, parser):
+        """Filename header immediately followed by code with no blank line."""
+        text = "```javascript\n## quickSort.js\nfunction quickSort(arr) { return arr; }\n```"
+        result = parser.parse_code(block="", text=text, lang="javascript")
+        assert not result.startswith("##"), "filename header should be stripped"
+        assert "function quickSort" in result
+
 
 if __name__ == "__main__":
     t = TestCodeParser()


### PR DESCRIPTION
When Engineer generates code, the LLM sometimes echoes the filename marker (e.g., '## quickSort.js') inside the code block instead of outside it. CodeParser.parse_code() then captures this marker as part of the code, producing invalid syntax in the output files.

**Features**
- Add a post-extraction strip to remove any leading '## filename.ext' line from the captured code
- Add regression tests covering both cases (with and without blank line after the header).