### PR TITLE
fix: extract 2 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/fulltest.yaml
+++ b/.github/workflows/fulltest.yaml
@@ -55,9 +55,12 @@ jobs:
     - name: Test with pytest
       run: |
         export ALLOW_OPENAI_API_CALL=0
-        echo "${{ secrets.METAGPT_KEY_YAML }}" | base64 -d > config/key.yaml
-        mkdir -p ~/.metagpt && echo "${{ secrets.METAGPT_CONFIG2_YAML }}" | base64 -d > ~/.metagpt/config2.yaml
+        echo "${METAGPT_KEY_YAML}" | base64 -d > config/key.yaml
+        mkdir -p ~/.metagpt && echo "${METAGPT_CONFIG2_YAML}" | base64 -d > ~/.metagpt/config2.yaml
         pytest tests/ --doctest-modules --cov=./metagpt/ --cov-report=xml:cov.xml --cov-report=html:htmlcov --durations=20 | tee unittest.txt
+      env:
+        METAGPT_KEY_YAML: ${{ secrets.METAGPT_KEY_YAML }}
+        METAGPT_CONFIG2_YAML: ${{ secrets.METAGPT_CONFIG2_YAML }}
     - name: Show coverage report
       run: |
         coverage report -m


### PR DESCRIPTION
> This is a re-submission of #1987, which was closed due to a branch issue on my end. Same fixes, apologies for the noise.

## Security: Harden GitHub Actions workflows

Hey, I found some CI/CD security issues in this repo's GitHub Actions workflows. These are the same vulnerability classes that were exploited in the tj-actions/changed-files supply chain attack. I've been reviewing repos that are affected and submitting fixes where I can.

This PR applies mechanical fixes and flags anything else that needs a manual look. Happy to answer any questions.

### Fixes applied

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-002 | high | `.github/workflows/fulltest.yaml` | Extracted 2 unsafe expression(s) to env vars |


### Additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-001 | critical | `.github/workflows/fulltest.yaml` | pull_request_target with Fork Code Checkout |
| RGS-009 | critical | `.github/workflows/fulltest.yaml` | Direct Execution of Fork Code in Privileged Context |
| RGS-001 | critical | `.github/workflows/unittest.yaml` | pull_request_target with Fork Code Checkout |
| RGS-009 | critical | `.github/workflows/unittest.yaml` | Direct Execution of Fork Code in Privileged Context |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks or reference unpinned third-party actions are vulnerable to code injection and supply chain attacks. These are the same vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-attack-and-its-impact) which compromised CI secrets across thousands of repositories.

### How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **Expression extraction**: Moves `${{ }}` expressions from `run:` blocks into `env:` mappings, preventing shell injection


---

If this PR is not welcome, just close it and I won't send another.