### PR TITLE
fix: initialize srcs path before get_codes in incremental mode

### DIFF
--- a/metagpt/actions/write_code.py
+++ b/metagpt/actions/write_code.py
@@ -27,7 +27,7 @@ from metagpt.actions.project_management_an import REFINED_TASK_LIST, TASK_LIST
 from metagpt.actions.write_code_plan_and_change_an import REFINED_TEMPLATE
 from metagpt.logs import logger
 from metagpt.schema import CodingContext, Document, RunCodeResult
-from metagpt.utils.common import CodeParser, get_markdown_code_block_type
+from metagpt.utils.common import CodeParser, get_markdown_code_block_type, get_project_srcs_path
 from metagpt.utils.project_repo import ProjectRepo
 from metagpt.utils.report import EditorReporter
 
@@ -117,6 +117,8 @@ class WriteCode(Action):
             logs = test_detail.stderr
 
         if self.config.inc or bug_feedback:
+            if self.repo and self.repo.src_relative_path is None:
+                self.repo.with_src_path(get_project_srcs_path(self.repo.workdir))
             code_context = await self.get_codes(
                 coding_context.task_doc, exclude=self.i_context.filename, project_repo=self.repo, use_inc=True
             )


### PR DESCRIPTION
Fixes #2007

## Problem

In incremental mode (`config.inc = True`), `WriteCode.run()` calls `get_codes()` which internally accesses `project_repo.srcs`. The `srcs` property raises `ValueError: Call with_srcs first.` when `_srcs_path` has not been initialized on the `ProjectRepo` object.

This occurs when the project's source directory does not yet exist at the start of incremental development — `ProjectRepo.__init__` calls `code_files_exists()`, which returns early without calling `with_src_path()` if the source directory is absent. The `Engineer._think()` fallback that calls `with_src_path()` covers most cases, but there are scenarios (e.g., fresh incremental projects or `WriteCode` used outside the `Engineer` role) where `_srcs_path` can remain `None` when `WriteCode.run()` is called.

## Solution

Add a defensive guard in `WriteCode.run()` that initializes `_srcs_path` via `get_project_srcs_path()` when `src_relative_path` is `None`, before calling `get_codes()` in the incremental branch. This mirrors the existing initialization in `Engineer._think()` and `QaEngineer._think()`.

## Testing

The fix is a targeted guard that only fires when `_srcs_path` is not already set, so it does not affect the normal code path. The existing test suite (`test_write_refined_code`, `test_get_codes`) continues to cover incremental mode behavior.