### PR TITLE
feat: add [ LiteLLM as AI gateway ] provider

### DIFF
--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -44,6 +44,7 @@ class LLMType(Enum):
     BEDROCK = "bedrock"
     ARK = "ark"  # https://www.volcengine.com/docs/82379/1263482#python-sdk
     LLAMA_API = "llama_api"
+    LITELLM = "litellm"  # LiteLLM AI gateway — unified interface to 100+ providers
 
     def __missing__(self, key):
         return self.OPENAI

--- a/metagpt/provider/__init__.py
+++ b/metagpt/provider/__init__.py
@@ -20,6 +20,7 @@ from metagpt.provider.anthropic_api import AnthropicLLM
 from metagpt.provider.bedrock_api import BedrockLLM
 from metagpt.provider.ark_api import ArkLLM
 from metagpt.provider.openrouter_reasoning import OpenrouterReasoningLLM
+from metagpt.provider.litellm_api import LiteLLM
 
 __all__ = [
     "GeminiLLM",
@@ -36,4 +37,5 @@ __all__ = [
     "BedrockLLM",
     "ArkLLM",
     "OpenrouterReasoningLLM",
+    "LiteLLM",
 ]

--- a/metagpt/provider/litellm_api.py
+++ b/metagpt/provider/litellm_api.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+@Time    : 2026/04/21
+@Author  : aarish
+@File    : litellm_api.py
+@Desc    : LiteLLM provider — unified access to 100+ LLM providers via the LiteLLM AI gateway.
+           https://docs.litellm.ai/docs/providers
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import litellm
+from litellm import CustomStreamWrapper, ModelResponse
+from litellm.exceptions import APIConnectionError
+from tenacity import after_log, retry, retry_if_exception_type, stop_after_attempt, wait_random_exponential
+
+from metagpt.configs.llm_config import LLMConfig, LLMType
+from metagpt.const import USE_CONFIG_TIMEOUT
+from metagpt.logs import log_llm_stream, logger
+from metagpt.provider.base_llm import BaseLLM
+from metagpt.provider.llm_provider_registry import register_provider
+from metagpt.utils.common import log_and_reraise
+from metagpt.utils.cost_manager import CostManager
+
+
+@register_provider(LLMType.LITELLM)
+class LiteLLM(BaseLLM):
+    """LiteLLM AI gateway provider.
+
+    Routes chat completions through litellm.acompletion(), which supports 100+ providers
+    (OpenAI, Anthropic, Bedrock, Vertex, Ollama, OpenRouter, Groq, DeepSeek, etc.).
+
+    Set `api_type: litellm` and a litellm-style model name (e.g. `anthropic/claude-3-5-sonnet-20241022`)
+    in config2.yaml. See https://docs.litellm.ai/docs/providers for the full list.
+    """
+
+    def __init__(self, config: LLMConfig):
+        self.config = config
+        self.model = config.model
+        self.pricing_plan = config.pricing_plan or self.model
+        self.cost_manager: Optional[CostManager] = None
+
+    def _cons_kwargs(self, messages: list[dict], timeout=USE_CONFIG_TIMEOUT, **extra_kwargs) -> dict:
+        kwargs = {
+            "model": self.model,
+            "messages": messages,
+            "max_tokens": self.config.max_token,
+            "temperature": self.config.temperature,
+            "timeout": self.get_timeout(timeout),
+        }
+        # Only forward api_key/api_base when the user has explicitly set them; otherwise
+        # LiteLLM will pick up provider-specific env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, ...).
+        if self.config.api_key and self.config.api_key != "sk-":
+            kwargs["api_key"] = self.config.api_key
+        if self.config.base_url and self.config.base_url != "https://api.openai.com/v1":
+            kwargs["api_base"] = self.config.base_url
+        if self.config.proxy:
+            kwargs["proxy"] = self.config.proxy
+        if self.config.reasoning:
+            kwargs["thinking"] = {"type": "enabled", "budget_tokens": self.config.reasoning_max_token}
+        if extra_kwargs:
+            kwargs.update(extra_kwargs)
+        return kwargs
+
+    async def _achat_completion(self, messages: list[dict], timeout=USE_CONFIG_TIMEOUT) -> ModelResponse:
+        rsp: ModelResponse = await litellm.acompletion(**self._cons_kwargs(messages, timeout=timeout))
+        self._update_costs(rsp.usage)
+        return rsp
+
+    async def acompletion(self, messages: list[dict], timeout=USE_CONFIG_TIMEOUT) -> ModelResponse:
+        return await self._achat_completion(messages, timeout=timeout)
+
+    async def _achat_completion_stream(self, messages: list[dict], timeout=USE_CONFIG_TIMEOUT) -> str:
+        stream: CustomStreamWrapper = await litellm.acompletion(
+            **self._cons_kwargs(messages, timeout=timeout), stream=True
+        )
+        collected_messages = []
+        usage = None
+        async for chunk in stream:
+            if not chunk.choices:
+                continue
+            delta = chunk.choices[0].delta
+            content = getattr(delta, "content", None) or ""
+            if content:
+                log_llm_stream(content)
+                collected_messages.append(content)
+            if hasattr(chunk, "usage") and chunk.usage:
+                usage = chunk.usage
+
+        log_llm_stream("\n")
+        full_reply_content = "".join(collected_messages)
+        if usage is not None:
+            self._update_costs(usage)
+        return full_reply_content
+
+    @retry(
+        wait=wait_random_exponential(min=1, max=60),
+        stop=stop_after_attempt(6),
+        after=after_log(logger, logger.level("WARNING").name),
+        retry=retry_if_exception_type(APIConnectionError),
+        retry_error_callback=log_and_reraise,
+    )
+    async def acompletion_text(self, messages: list[dict], stream: bool = False, timeout=USE_CONFIG_TIMEOUT) -> str:
+        """Async completion returning plain text. Supports stream-print."""
+        if stream:
+            return await self._achat_completion_stream(messages, timeout=timeout)
+        rsp = await self._achat_completion(messages, timeout=timeout)
+        return self.get_choice_text(rsp)
+
+    def get_choice_text(self, rsp: ModelResponse) -> str:
+        return rsp.choices[0].message.content if rsp.choices else ""
+
+    def _update_costs(self, usage, model: str = None, local_calc_usage: bool = True):
+        # LiteLLM returns an OpenAI-shaped pydantic usage object; convert to dict for BaseLLM._update_costs.
+        if usage is not None and hasattr(usage, "model_dump"):
+            usage = usage.model_dump()
+        super()._update_costs(usage, model, local_calc_usage)

--- a/metagpt/provider/litellm_api.py
+++ b/metagpt/provider/litellm_api.py
@@ -9,6 +9,8 @@
 """
 from __future__ import annotations
 
+import json
+import re
 from typing import Optional
 
 import litellm
@@ -20,8 +22,9 @@ from metagpt.configs.llm_config import LLMConfig, LLMType
 from metagpt.const import USE_CONFIG_TIMEOUT
 from metagpt.logs import log_llm_stream, logger
 from metagpt.provider.base_llm import BaseLLM
+from metagpt.provider.constant import GENERAL_FUNCTION_SCHEMA
 from metagpt.provider.llm_provider_registry import register_provider
-from metagpt.utils.common import log_and_reraise
+from metagpt.utils.common import CodeParser, log_and_reraise
 from metagpt.utils.cost_manager import CostManager
 
 
@@ -111,6 +114,90 @@ class LiteLLM(BaseLLM):
 
     def get_choice_text(self, rsp: ModelResponse) -> str:
         return rsp.choices[0].message.content if rsp.choices else ""
+
+    async def _achat_completion_function(
+        self, messages: list[dict], timeout: int = USE_CONFIG_TIMEOUT, **chat_configs
+    ) -> ModelResponse:
+        messages = self.format_msg(messages)
+        kwargs = self._cons_kwargs(messages=messages, timeout=self.get_timeout(timeout), **chat_configs)
+        rsp: ModelResponse = await litellm.acompletion(**kwargs)
+        self._update_costs(rsp.usage)
+        return rsp
+
+    async def aask_code(self, messages: list[dict], timeout: int = USE_CONFIG_TIMEOUT, **kwargs) -> dict:
+        """Use function-calling to ask for code. Mirrors OpenAILLM.aask_code.
+
+        LiteLLM passes ``tools=[...]`` through to every provider that supports native
+        function calling (OpenAI, Anthropic, Gemini, Bedrock, Groq, DeepSeek, ...) and
+        returns the response in OpenAI-shape ``tool_calls`` format regardless of
+        backend, so the OpenAI parsing logic transfers directly.
+
+        Examples:
+            >>> llm = LiteLLM(cfg)
+            >>> msg = [{'role': 'user', 'content': "Write a python hello world code."}]
+            >>> rsp = await llm.aask_code(msg)
+            # -> {'language': 'python', 'code': "print('Hello, World!')"}
+        """
+        if "tools" not in kwargs:
+            kwargs["tools"] = [{"type": "function", "function": GENERAL_FUNCTION_SCHEMA}]
+        rsp = await self._achat_completion_function(messages, **kwargs)
+        return self.get_choice_function_arguments(rsp)
+
+    def _parse_arguments(self, arguments: str) -> dict:
+        """Parse ``arguments`` JSON from a function-call response.
+
+        Fallback when the JSON is malformed: regex out ``language`` and ``code`` keys.
+        Mirrors OpenAILLM._parse_arguments for identical behaviour across providers.
+        """
+        if "language" not in arguments and "code" not in arguments:
+            logger.warning(f"Not found `code`, `language`, We assume it is pure code:\n {arguments}\n. ")
+            return {"language": "python", "code": arguments}
+
+        language_pattern = re.compile(r'[\"\']?language[\"\']?\s*:\s*["\']([^"\']+?)["\']', re.DOTALL)
+        language_match = language_pattern.search(arguments)
+        language_value = language_match.group(1) if language_match else "python"
+
+        code_pattern = r'(["\'`]{3}|["\'`])([\s\S]*?)\1'
+        try:
+            code_value = re.findall(code_pattern, arguments)[-1][-1]
+        except Exception as e:
+            logger.error(f"{e}, when re.findall({code_pattern}, {arguments})")
+            code_value = None
+
+        if code_value is None:
+            raise ValueError(f"Parse code error for {arguments}")
+        return {"language": language_value, "code": code_value}
+
+    def get_choice_function_arguments(self, rsp: ModelResponse) -> dict:
+        """Parse the first tool_call's function arguments.
+
+        LiteLLM's ``ModelResponse`` mirrors OpenAI's ``ChatCompletion`` shape, so the
+        same attribute access path works across providers.
+        """
+        message = rsp.choices[0].message
+        if (
+            message.tool_calls is not None
+            and message.tool_calls[0].function is not None
+            and message.tool_calls[0].function.arguments is not None
+        ):
+            try:
+                return json.loads(message.tool_calls[0].function.arguments, strict=False)
+            except json.decoder.JSONDecodeError as e:
+                error_msg = (
+                    f"Got JSONDecodeError for \n{'--' * 40} \n{message.tool_calls[0].function.arguments}, {str(e)}"
+                )
+                logger.error(error_msg)
+                return self._parse_arguments(message.tool_calls[0].function.arguments)
+        elif message.tool_calls is None and message.content is not None:
+            # Some providers return the code block in content instead of tool_calls.
+            code_formats = "```"
+            if message.content.startswith(code_formats) and message.content.endswith(code_formats):
+                code = CodeParser.parse_code(text=message.content)
+                return {"language": "python", "code": code}
+            return {"language": "markdown", "code": self.get_choice_text(rsp)}
+        else:
+            logger.error(f"Failed to parse \n {rsp}\n")
+            raise Exception(f"Failed to parse \n {rsp}\n")
 
     def _update_costs(self, usage, model: str = None, local_calc_usage: bool = True):
         # LiteLLM returns an OpenAI-shaped pydantic usage object; convert to dict for BaseLLM._update_costs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ tqdm==4.66.2
 # selenium>4
 # webdriver_manager<3.9
 anthropic==0.47.2
+litellm~=1.83.0
 typing-inspect==0.8.0
 libcst==1.0.1
 qdrant-client==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,9 @@ tqdm==4.66.2
 # selenium>4
 # webdriver_manager<3.9
 anthropic==0.47.2
-litellm~=1.83.0
+# LiteLLM: range chosen to stay compatible with MetaGPT's openai~=1.64 pin.
+# Newer litellm (>=1.65) requires openai>=1.66; pre-1.55 lacks recent provider coverage.
+litellm>=1.55,<1.65
 typing-inspect==0.8.0
 libcst==1.0.1
 qdrant-client==1.7.0

--- a/tests/metagpt/provider/mock_llm_config.py
+++ b/tests/metagpt/provider/mock_llm_config.py
@@ -62,6 +62,12 @@ mock_llm_config_anthropic = LLMConfig(
     api_type="anthropic", api_key="xxx", base_url="https://api.anthropic.com", model="claude-3-opus-20240229"
 )
 
+mock_llm_config_litellm = LLMConfig(
+    api_type="litellm",
+    api_key="sk-test",
+    model="anthropic/claude-3-5-sonnet-20241022",
+)
+
 mock_llm_config_bedrock = LLMConfig(
     api_type="bedrock",
     model="gpt-100",

--- a/tests/metagpt/provider/test_litellm_api.py
+++ b/tests/metagpt/provider/test_litellm_api.py
@@ -2,6 +2,9 @@
 # -*- coding: utf-8 -*-
 # @Desc   : the unittest of LiteLLM provider
 
+import json
+from types import SimpleNamespace
+
 import pytest
 
 from metagpt.provider.litellm_api import LiteLLM
@@ -68,3 +71,60 @@ def test_cons_kwargs_forwards_custom_base_url():
     llm = LiteLLM(cfg)
     kwargs = llm._cons_kwargs(messages)
     assert kwargs["api_base"] == "https://my-proxy.example.com/v1"
+
+
+def _fake_tool_call_response(arguments: dict) -> SimpleNamespace:
+    """LiteLLM's ModelResponse mirrors OpenAI's ChatCompletion, so we can build a
+    duck-typed stand-in for tool_call responses using SimpleNamespace."""
+    function = SimpleNamespace(name="execute", arguments=json.dumps(arguments))
+    tool_call = SimpleNamespace(type="function", function=function, id="call_1")
+    message = SimpleNamespace(role="assistant", content=None, tool_calls=[tool_call])
+    choice = SimpleNamespace(message=message, finish_reason="tool_calls", index=0)
+    return SimpleNamespace(choices=[choice], usage=None)
+
+
+@pytest.mark.asyncio
+async def test_aask_code_forwards_tools_and_parses_arguments(mocker):
+    """LiteLLM's aask_code must (1) inject the default ``tools=[...]`` schema,
+    (2) forward it to ``litellm.acompletion``, (3) parse the returned tool_call
+    arguments into a dict. This is the path used by Engineer / QAEngineer /
+    DataAnalyst roles when LLM is configured with ``api_type: litellm``."""
+
+    captured = {}
+
+    async def _capturing_acompletion(**kwargs):
+        captured.update(kwargs)
+        return _fake_tool_call_response({"language": "python", "code": "print('hi')"})
+
+    mocker.patch("litellm.acompletion", _capturing_acompletion)
+
+    llm = LiteLLM(mock_llm_config_litellm)
+    result = await llm.aask_code([{"role": "user", "content": "Write a hello world"}])
+
+    # Default function schema was injected
+    assert "tools" in captured, "aask_code should inject a default tools schema"
+    assert captured["tools"][0]["type"] == "function"
+    assert captured["tools"][0]["function"]["name"] == "execute"
+
+    # Parsed arguments dict is returned
+    assert result == {"language": "python", "code": "print('hi')"}
+
+
+@pytest.mark.asyncio
+async def test_aask_code_respects_user_supplied_tools(mocker):
+    """When the caller passes their own ``tools=[...]``, the default schema must
+    not overwrite it."""
+
+    captured = {}
+
+    async def _capturing_acompletion(**kwargs):
+        captured.update(kwargs)
+        return _fake_tool_call_response({"lang": "go", "code": "fmt.Println(1)"})
+
+    mocker.patch("litellm.acompletion", _capturing_acompletion)
+
+    custom_tools = [{"type": "function", "function": {"name": "go_tool", "parameters": {}}}]
+    llm = LiteLLM(mock_llm_config_litellm)
+    await llm.aask_code([{"role": "user", "content": "print 1 in Go"}], tools=custom_tools)
+
+    assert captured["tools"] == custom_tools

--- a/tests/metagpt/provider/test_litellm_api.py
+++ b/tests/metagpt/provider/test_litellm_api.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# @Desc   : the unittest of LiteLLM provider
+
+import pytest
+
+from metagpt.provider.litellm_api import LiteLLM
+from tests.metagpt.provider.mock_llm_config import mock_llm_config_litellm
+from tests.metagpt.provider.req_resp_const import (
+    get_openai_chat_completion,
+    get_openai_chat_completion_chunk,
+    llm_general_chat_funcs_test,
+    messages,
+    prompt,
+    resp_cont_tmpl,
+)
+
+name = "LiteLLM-Claude"
+resp_cont = resp_cont_tmpl.format(name=name)
+default_resp = get_openai_chat_completion(name)
+default_resp_chunk = get_openai_chat_completion_chunk(name, usage_as_dict=True)
+
+
+async def mock_litellm_acompletion(**kwargs):
+    """LiteLLM's module-level async completion — returns an OpenAI-shaped ModelResponse
+    (or an async iterator of chunks when stream=True)."""
+    if kwargs.get("stream"):
+
+        class Iterator:
+            async def __aiter__(self):
+                yield default_resp_chunk
+
+        return Iterator()
+    return default_resp
+
+
+@pytest.mark.asyncio
+async def test_litellm_acompletion(mocker):
+    mocker.patch("litellm.acompletion", mock_litellm_acompletion)
+
+    llm = LiteLLM(mock_llm_config_litellm)
+
+    resp = await llm.acompletion(messages)
+    assert resp.choices[0].message.content == resp_cont
+
+    await llm_general_chat_funcs_test(llm, prompt, messages, resp_cont)
+
+
+def test_cons_kwargs_maps_config():
+    llm = LiteLLM(mock_llm_config_litellm)
+    kwargs = llm._cons_kwargs(messages)
+    assert kwargs["model"] == "anthropic/claude-3-5-sonnet-20241022"
+    assert kwargs["api_key"] == "sk-test"
+    assert kwargs["messages"] == messages
+    # Default base_url (openai) is NOT forwarded — LiteLLM routes by model prefix.
+    assert "api_base" not in kwargs
+
+
+def test_cons_kwargs_forwards_custom_base_url():
+    from metagpt.configs.llm_config import LLMConfig
+
+    cfg = LLMConfig(
+        api_type="litellm",
+        api_key="sk-test",
+        base_url="https://my-proxy.example.com/v1",
+        model="openrouter/meta-llama/llama-3-70b-instruct",
+    )
+    llm = LiteLLM(cfg)
+    kwargs = llm._cons_kwargs(messages)
+    assert kwargs["api_base"] == "https://my-proxy.example.com/v1"


### PR DESCRIPTION
  Features
                                                                                                                                                                                                                     
  - Add LiteLLM provider in metagpt/provider/litellm_api.py implementing BaseLLM against the litellm.acompletion() API                                                                                             
  - Add LLMType.LITELLM = "litellm" to metagpt/configs/llm_config.py and register in metagpt/provider/__init__.py                                                                                                    
  - Add tests/metagpt/provider/test_litellm_api.py covering completion, streaming, and config kwarg mapping                                                                                                          
  -  Add litellm>=1.55,<1.65 to requirements.txt (version range chosen to resolve cleanly against MetaGPT's openai~=1.64 pin).
  - Add aask_code / _achat_completion_function / get_choice_function_arguments so Engineer / QAEngineer / DataAnalyst roles work on LiteLLM-routed models.
                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                     
  Feature Docs                                                                                                                                                                                                       
                                                                                                                                                                                                                   
  Users set api_type: litellm in config2.yaml and route to 100+ providers (OpenAI, Anthropic, Bedrock, Vertex, Ollama, OpenRouter, Groq, DeepSeek, etc.) via a single interface:                                     
  
  llm:                                                                                                                                                                                                               
    api_type: "litellm"                                                                                                                                                                                            
    model: "anthropic/claude-3-5-sonnet-20241022"                                                                                                                                                                    
    api_key: "sk-..."
                                                                                                                                                                                                                     
  LiteLLM routes based on the model-name prefix. Full provider list: https://docs.litellm.ai/docs/providers                                                                                                          
  
  Influence                                                                                                                                                                                                          
                                                                                                                                                                                                                   
  - Unblocks MetaGPT on any LiteLLM-supported provider without writing a new provider class per provider, reduces maintenance burden of per-provider files going forward                                            
  - Additive only existing providers (OpenAI, Anthropic, Bedrock, etc.) are untouched
  - One new required dependency (litellm>=1.55,<1.65). Range pinned to stay compatible with MetaGPT's base install (newer litellm requires openai>=1.66; MetaGPT pins openai~=1.64)
  - Matches existing provider conventions (header block, @register_provider decorator, async-first)                                                                                                                
  - Reuses OpenAI-shaped response parsing since litellm.ModelResponse follows OpenAI format                                                                                                                          
  - Thinking/reasoning-mode passthrough matches anthropic_api.py                                                                                                                                                     
                                                                                                                                
                                                                                                                                
                                                                                                                                                                                                                     
  Result                                                                                                                                                                                                             
                                                                                                                                                                                                                   
  $ pytest tests/metagpt/provider/test_litellm_api.py -v
  tests/metagpt/provider/test_litellm_api.py::test_litellm_acompletion PASSED                                                                                                                                                                                                                                                                                             
  tests/metagpt/provider/test_litellm_api.py::test_cons_kwargs_maps_config PASSED                                                                                                                                                                                                                                                                                         
  tests/metagpt/provider/test_litellm_api.py::test_cons_kwargs_forwards_custom_base_url PASSED                                                                                                                                                                                                                                                                            
  tests/metagpt/provider/test_litellm_api.py::test_aask_code_forwards_tools_and_parses_arguments PASSED                                                                                                                                                                                                                                                                   
  tests/metagpt/provider/test_litellm_api.py::test_aask_code_respects_user_supplied_tools PASSED                                                                                                                                                                                                                                                                          
  ======================== 5 passed in 5.32s =========================                                                                                                                                                  
                                                                                                                                                                                                                     
  Existing provider tests (test_openai.py) also pass, no regressions.   
  
  ## E2E smoke test against Azure OpenAI (azure/gpt-4o):     
  
  ```
  → Model: azure/gpt-4o
  → Endpoint: https://<redacted>.cognitiveservices.azure.com                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                          
  [Test 1] acompletion, prompt 'What is 2+2?'                                                                                                                                                                                                                                                                                                                             
    response: '4'                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                          
  [Test 2] aask with system message, prompt 'What is 10 - 3?'                                                                                                                                                                                                                                                                                                             
    response: '7'
                                                                                                                                                                                                                                                                                                                                                                          
  MetaGPT LiteLLM live test PASSED.                                                                                                                                        
  ```                
  
  Exercised the full call path: LLMConfig(api_type=LITELLM) to LLM_REGISTRY[LITELLM] to LiteLLM._cons_kwargs to litellm.acompletion (real Azure endpoint) to response parsing. 
  
  Other                                                                                                                                                                                                              
                  
  - Forwards api_key / base_url / proxy / reasoning config fields through to litellm.acompletion
  - Default OpenAI base_url is intentionally not forwarded so LiteLLM can route by model-name prefix
  - Cost tracking via _update_costs  LiteLLM returns an OpenAI-shaped usage object
  - aask_code / tool-use support lets MetaGPT's code-generating roles (Engineer, QAEngineer, DataAnalyst) work unchanged on LiteLLM-routed models. LiteLLM forwards tools=[...] to all providers that support native function calling and returns OpenAI-shape tool_calls regardless of backend, so the same parsing logic from openai_api.py applies.