### PR TITLE
feat: Add Astraflow (UCloud) LLM provider support

### DIFF
--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -44,6 +44,8 @@ class LLMType(Enum):
     BEDROCK = "bedrock"
     ARK = "ark"  # https://www.volcengine.com/docs/82379/1263482#python-sdk
     LLAMA_API = "llama_api"
+    ASTRAFLOW = "astraflow"  # UCloud Astraflow global endpoint
+    ASTRAFLOW_CN = "astraflow_cn"  # UCloud Astraflow China endpoint
 
     def __missing__(self, key):
         return self.OPENAI

--- a/metagpt/provider/__init__.py
+++ b/metagpt/provider/__init__.py
@@ -20,6 +20,7 @@ from metagpt.provider.anthropic_api import AnthropicLLM
 from metagpt.provider.bedrock_api import BedrockLLM
 from metagpt.provider.ark_api import ArkLLM
 from metagpt.provider.openrouter_reasoning import OpenrouterReasoningLLM
+from metagpt.provider.astraflow_api import AstraflowLLM, AstraflowCNLLM
 
 __all__ = [
     "GeminiLLM",
@@ -36,4 +37,6 @@ __all__ = [
     "BedrockLLM",
     "ArkLLM",
     "OpenrouterReasoningLLM",
+    "AstraflowLLM",
+    "AstraflowCNLLM",
 ]

--- a/metagpt/provider/astraflow_api.py
+++ b/metagpt/provider/astraflow_api.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Astraflow LLM provider (by UCloud / 优刻得).
+
+Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models.
+
+Endpoints:
+  Global : https://api-us-ca.umodelverse.ai/v1   (env var: ASTRAFLOW_API_KEY)
+  China  : https://api.modelverse.cn/v1          (env var: ASTRAFLOW_CN_API_KEY)
+
+Sign-up / docs: https://astraflow.ucloud.cn/
+
+config2.yaml example (global endpoint):
+```yaml
+llm:
+  api_type: "astraflow"
+  api_key: "YOUR_ASTRAFLOW_API_KEY"
+  model: "deepseek-ai/DeepSeek-V3"
+```
+
+config2.yaml example (China endpoint):
+```yaml
+llm:
+  api_type: "astraflow_cn"
+  api_key: "YOUR_ASTRAFLOW_CN_API_KEY"
+  model: "deepseek-ai/DeepSeek-V3"
+```
+"""
+
+from metagpt.configs.llm_config import LLMConfig, LLMType
+from metagpt.provider.llm_provider_registry import register_provider
+from metagpt.provider.openai_api import OpenAILLM
+
+ASTRAFLOW_GLOBAL_BASE_URL = "https://api-us-ca.umodelverse.ai/v1"
+ASTRAFLOW_CN_BASE_URL = "https://api.modelverse.cn/v1"
+
+
+@register_provider(LLMType.ASTRAFLOW)
+class AstraflowLLM(OpenAILLM):
+    """LLM provider for Astraflow global endpoint (https://api-us-ca.umodelverse.ai/v1).
+
+    Astraflow is an OpenAI-compatible platform by UCloud that aggregates 200+ AI models.
+    Use this class when your API key targets the international / global region.
+    """
+
+    def _init_client(self):
+        """Override base URL to point at the Astraflow global endpoint unless the
+        user has explicitly set a custom base_url in their config."""
+        if not self.config.base_url or self.config.base_url == "https://api.openai.com/v1":
+            self.config.base_url = ASTRAFLOW_GLOBAL_BASE_URL
+        super()._init_client()
+
+
+@register_provider(LLMType.ASTRAFLOW_CN)
+class AstraflowCNLLM(OpenAILLM):
+    """LLM provider for Astraflow China endpoint (https://api.modelverse.cn/v1).
+
+    Astraflow is an OpenAI-compatible platform by UCloud that aggregates 200+ AI models.
+    Use this class when your API key targets the China / mainland region.
+    """
+
+    def _init_client(self):
+        """Override base URL to point at the Astraflow China endpoint unless the
+        user has explicitly set a custom base_url in their config."""
+        if not self.config.base_url or self.config.base_url == "https://api.openai.com/v1":
+            self.config.base_url = ASTRAFLOW_CN_BASE_URL
+        super()._init_client()


### PR DESCRIPTION
## Summary

This PR adds support for **Astraflow** (by UCloud / 优刻得) as an LLM provider in MetaGPT.

Astraflow is an OpenAI-compatible AI model aggregation platform that supports 200+ models across both a global endpoint and a China-region endpoint.

### What's changed

| File | Change |
|---|---|
| `metagpt/configs/llm_config.py` | Add `ASTRAFLOW` and `ASTRAFLOW_CN` entries to `LLMType` enum |
| `metagpt/provider/astraflow_api.py` | New provider file implementing both endpoints |
| `metagpt/provider/__init__.py` | Export `AstraflowLLM` and `AstraflowCNLLM` |

### Endpoints

| Variant | Base URL | API Key env var |
|---|---|---|
| Global | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| China  | `https://api.modelverse.cn/v1`         | `ASTRAFLOW_CN_API_KEY` |

### Usage (config2.yaml)

**Global endpoint:**
```yaml
llm:
  api_type: "astraflow"
  api_key: "YOUR_ASTRAFLOW_API_KEY"
  model: "YOUR_MODEL_NAME"   # e.g. deepseek-ai/DeepSeek-V3
```

**China endpoint:**
```yaml
llm:
  api_type: "astraflow_cn"
  api_key: "YOUR_ASTRAFLOW_CN_API_KEY"
  model: "YOUR_MODEL_NAME"
```

### Sign-up / docs
- https://astraflow.ucloud.cn/
