### PR TITLE
feat: Add Astraflow LLM provider support (global & China endpoints)

### DIFF
--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -44,6 +44,8 @@ class LLMType(Enum):
     BEDROCK = "bedrock"
     ARK = "ark"  # https://www.volcengine.com/docs/82379/1263482#python-sdk
     LLAMA_API = "llama_api"
+    ASTRAFLOW = "astraflow"  # https://astraflow.ucloud.cn/ (global endpoint)
+    ASTRAFLOW_CN = "astraflow_cn"  # https://astraflow.ucloud.cn/ (China endpoint)
 
     def __missing__(self, key):
         return self.OPENAI

--- a/metagpt/provider/__init__.py
+++ b/metagpt/provider/__init__.py
@@ -20,6 +20,7 @@ from metagpt.provider.anthropic_api import AnthropicLLM
 from metagpt.provider.bedrock_api import BedrockLLM
 from metagpt.provider.ark_api import ArkLLM
 from metagpt.provider.openrouter_reasoning import OpenrouterReasoningLLM
+from metagpt.provider.astraflow_api import AstraflowLLM
 
 __all__ = [
     "GeminiLLM",
@@ -36,4 +37,5 @@ __all__ = [
     "BedrockLLM",
     "ArkLLM",
     "OpenrouterReasoningLLM",
+    "AstraflowLLM",
 ]

--- a/metagpt/provider/astraflow_api.py
+++ b/metagpt/provider/astraflow_api.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Astraflow LLM provider (by UCloud / 优刻得).
+Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models.
+
+Global endpoint : https://api-us-ca.umodelverse.ai/v1  (env var: ASTRAFLOW_API_KEY)
+China  endpoint : https://api.modelverse.cn/v1         (env var: ASTRAFLOW_CN_API_KEY)
+Sign up         : https://astraflow.ucloud.cn/
+
+config2.yaml example (global):
+```yaml
+llm:
+  api_type: "astraflow"
+  api_key: "YOUR_ASTRAFLOW_API_KEY"
+  model: "YOUR_MODEL_NAME"
+```
+
+config2.yaml example (China):
+```yaml
+llm:
+  api_type: "astraflow_cn"
+  api_key: "YOUR_ASTRAFLOW_CN_API_KEY"
+  model: "YOUR_MODEL_NAME"
+```
+"""
+from metagpt.configs.llm_config import LLMConfig, LLMType
+from metagpt.provider.llm_provider_registry import register_provider
+from metagpt.provider.openai_api import OpenAILLM
+
+# Base URLs for both regional endpoints
+_ASTRAFLOW_BASE_URL = "https://api-us-ca.umodelverse.ai/v1"
+_ASTRAFLOW_CN_BASE_URL = "https://api.modelverse.cn/v1"
+
+_BASE_URL_MAP = {
+    LLMType.ASTRAFLOW: _ASTRAFLOW_BASE_URL,
+    LLMType.ASTRAFLOW_CN: _ASTRAFLOW_CN_BASE_URL,
+}
+
+
+@register_provider([LLMType.ASTRAFLOW, LLMType.ASTRAFLOW_CN])
+class AstraflowLLM(OpenAILLM):
+    """LLM provider for Astraflow (UCloud / 优刻得).
+
+    Astraflow is fully OpenAI-compatible, so this class is a lightweight
+    subclass of OpenAILLM that selects the correct regional base URL
+    when the caller has not set one explicitly.
+
+    See https://astraflow.ucloud.cn/ for API key registration.
+    """
+
+    def __init__(self, config: LLMConfig):
+        # If the user has not customised base_url, inject the correct
+        # regional default before the parent class initialises the client.
+        if not config.base_url or config.base_url == "https://api.openai.com/v1":
+            config.base_url = _BASE_URL_MAP.get(config.api_type, _ASTRAFLOW_BASE_URL)
+        super().__init__(config)


### PR DESCRIPTION
## Summary

This PR adds **Astraflow** (by UCloud / 优刻得) as a supported LLM provider in MetaGPT.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. It exposes two regional endpoints:

| Variant | Env Var | Base URL |
|---|---|---|
| Global | `ASTRAFLOW_API_KEY` | `https://api-us-ca.umodelverse.ai/v1` |
| China  | `ASTRAFLOW_CN_API_KEY` | `https://api.modelverse.cn/v1` |

Sign up at: https://astraflow.ucloud.cn/

---

## Changes

### 1. `metagpt/configs/llm_config.py`
- Added `ASTRAFLOW = "astraflow"` and `ASTRAFLOW_CN = "astraflow_cn"` to the `LLMType` enum.

### 2. `metagpt/provider/astraflow_api.py` *(new file)*
- Created `AstraflowLLM` — a thin subclass of `OpenAILLM` registered for both `LLMType.ASTRAFLOW` and `LLMType.ASTRAFLOW_CN`.
- Automatically sets the correct `base_url` based on the `api_type` when none is explicitly configured.

### 3. `metagpt/provider/__init__.py`
- Imported and exported `AstraflowLLM`.

---

## Usage

**Global endpoint** (`config2.yaml`):
```yaml
llm:
  api_type: "astraflow"
  api_key: "YOUR_ASTRAFLOW_API_KEY"   # env: ASTRAFLOW_API_KEY
  model: "YOUR_MODEL_NAME"            # e.g. gpt-4o, claude-3-5-sonnet, etc.
```

**China endpoint** (`config2.yaml`):
```yaml
llm:
  api_type: "astraflow_cn"
  api_key: "YOUR_ASTRAFLOW_CN_API_KEY"  # env: ASTRAFLOW_CN_API_KEY
  model: "YOUR_MODEL_NAME"
```

Both variants inherit all capabilities of `OpenAILLM` (streaming, tool calls, image generation, cost tracking, etc.) since Astraflow is fully OpenAI-compatible.
