### PR TITLE
Add optional paper-research routing to Team workflow with fallback and robustness fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_stages: [ commit ]
 # 2. pre-commit install
 # 3. pre-commit run --all-files  # make sure all files are clean
 repos:
-  - repo: git@github.com:pycqa/isort.git
+  - repo: https://github.com/pycqa/isort.git
     rev: 5.11.5
     hooks:
       - id: isort
@@ -15,14 +15,14 @@ repos:
             .*__init__\.py$
             )
 
-  - repo: git@github.com:astral-sh/ruff-pre-commit.git
+  - repo: https://github.com/astral-sh/ruff-pre-commit.git
     # Ruff version.
     rev: v0.0.284
     hooks:
       - id: ruff
         args: [ --fix ]
 
-  - repo: git@github.com:psf/black.git
+  - repo: https://github.com/psf/black.git
     rev: 23.3.0
     hooks:
       - id: black

--- a/metagpt/actions/intent_classification.py
+++ b/metagpt/actions/intent_classification.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from metagpt.actions import Action
+from metagpt.logs import logger
+
+INTENT_CLASSIFIER_PROMPT = """
+You are an intent classifier for MetaGPT startup requests.
+Classify whether the user input is mainly asking for academic paper/literature research or software building tasks.
+
+Return ONLY a JSON object with this schema:
+{
+  "collaboration_mode": "paper" | "software",
+  "topic": "string",
+  "confidence": 0.0-1.0,
+  "reason": "short reason"
+}
+
+Rules:
+- Use "paper" when the input asks for papers, essays, literature review, survey, citations, arXiv, scholarly analysis.
+- Use "software" for coding/product/system-building tasks.
+- topic should be concise; for software mode, topic can be the original request.
+- Do not include markdown code fences.
+""".strip()
+
+
+def _extract_first_json_payload(text: str) -> str:
+    source = (text or "").strip()
+    if not source:
+        return source
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(source):
+        if char not in "[{":
+            continue
+        candidate = source[index:]
+        try:
+            _, end = decoder.raw_decode(candidate)
+            return candidate[:end]
+        except json.JSONDecodeError:
+            continue
+    return source
+
+
+class IntentClassificationAction(Action):
+    """Classify startup idea into paper/software collaboration mode."""
+
+    name: str = "IntentClassificationAction"
+
+    async def run(self, user_input: str) -> dict[str, Any]:
+        prompt = f"{INTENT_CLASSIFIER_PROMPT}\n\nUser input:\n{user_input}"
+        rsp = await self._aask(prompt)
+        data = self._parse_response(rsp)
+
+        mode = str(data.get("collaboration_mode", "software")).strip().lower()
+        if mode not in {"paper", "software"}:
+            mode = "software"
+
+        topic = str(data.get("topic") or user_input).strip() or user_input
+        reason = str(data.get("reason", "")).strip()
+        confidence = self._safe_confidence(data.get("confidence"))
+        return {
+            "collaboration_mode": mode,
+            "topic": topic,
+            "confidence": confidence,
+            "reason": reason,
+        }
+
+    @staticmethod
+    def _safe_confidence(raw: Any) -> float:
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return 0.0
+        return max(0.0, min(1.0, value))
+
+    @staticmethod
+    def _parse_response(rsp: str) -> dict[str, Any]:
+        payload = _extract_first_json_payload(rsp)
+        try:
+            data = json.loads(payload)
+            if isinstance(data, dict):
+                return data
+        except json.JSONDecodeError:
+            logger.warning("Intent classifier JSON parse failed; fallback will be used.")
+        return {}

--- a/metagpt/actions/literature_review.py
+++ b/metagpt/actions/literature_review.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Any
+
+from metagpt.actions import Action
+from metagpt.logs import logger
+
+ARXIV_API_ENDPOINT = "http://export.arxiv.org/api/query"
+
+
+@dataclass
+class ArxivPaper:
+    title: str
+    summary: str
+    url: str
+    published_year: str
+    venue: str = "arXiv"
+
+
+class LiteratureReviewAction(Action):
+    """
+    Prepare lightweight literature context for software/paper collaboration.
+
+    This action intentionally keeps output compact and deterministic, because the
+    result is injected into Team prompts and also written to a fixed markdown file.
+    """
+
+    name: str = "LiteratureReviewAction"
+
+    async def run(self, topic: str, max_results: int = 5) -> dict[str, Any]:
+        topic = (topic or "").strip()
+        if not topic:
+            return {
+                "topic": "",
+                "summary": "No topic provided; skipped literature pre-review.",
+                "papers": [],
+            }
+
+        try:
+            papers = self._search_arxiv(topic=topic, max_results=max_results)
+        except Exception as exc:  # pragma: no cover
+            logger.warning(f"Literature search failed for topic '{topic}': {exc}")
+            papers = []
+
+        return {
+            "topic": topic,
+            "summary": self._build_summary(topic, papers),
+            "papers": [self._paper_to_dict(paper) for paper in papers],
+        }
+
+    @staticmethod
+    def _paper_to_dict(paper: ArxivPaper) -> dict[str, str]:
+        return {
+            "title": paper.title,
+            "abstract": paper.summary,
+            "url": paper.url,
+            "year": paper.published_year,
+            "venue": paper.venue,
+        }
+
+    def _search_arxiv(self, topic: str, max_results: int) -> list[ArxivPaper]:
+        query = urllib.parse.urlencode(
+            {
+                "search_query": f"all:{topic}",
+                "start": 0,
+                "max_results": max_results,
+                "sortBy": "relevance",
+                "sortOrder": "descending",
+            }
+        )
+        url = f"{ARXIV_API_ENDPOINT}?{query}"
+        with urllib.request.urlopen(url, timeout=15) as response:
+            xml_text = response.read().decode("utf-8", errors="replace")
+        return self._parse_arxiv_feed(xml_text)
+
+    def _parse_arxiv_feed(self, xml_text: str) -> list[ArxivPaper]:
+        namespace = {"atom": "http://www.w3.org/2005/Atom"}
+        root = ET.fromstring(xml_text)
+        papers: list[ArxivPaper] = []
+
+        for entry in root.findall("atom:entry", namespace):
+            title = self._safe_text(entry.find("atom:title", namespace))
+            summary = self._safe_text(entry.find("atom:summary", namespace))
+            published = self._safe_text(entry.find("atom:published", namespace))
+            published_year = published[:4] if len(published) >= 4 else "N/A"
+
+            url = ""
+            for link in entry.findall("atom:link", namespace):
+                href = link.attrib.get("href")
+                rel = link.attrib.get("rel", "")
+                if href and rel in ("alternate", ""):
+                    url = href
+                    break
+
+            papers.append(
+                ArxivPaper(
+                    title=title or "Untitled",
+                    summary=summary or "",
+                    url=url,
+                    published_year=published_year,
+                )
+            )
+        return papers
+
+    @staticmethod
+    def _safe_text(node: ET.Element | None) -> str:
+        if node is None or node.text is None:
+            return ""
+        return " ".join(node.text.split())
+
+    @staticmethod
+    def _build_summary(topic: str, papers: list[ArxivPaper]) -> str:
+        if not papers:
+            return (
+                f"Collected 0 papers for '{topic}'. "
+                "Continue with domain reasoning and explicitly state limited evidence."
+            )
+
+        years = [paper.published_year for paper in papers if paper.published_year.isdigit()]
+        if years:
+            earliest, latest = min(years), max(years)
+            year_span = f"{earliest}-{latest}"
+        else:
+            year_span = "N/A"
+
+        return (
+            f"Collected {len(papers)} arXiv papers for '{topic}'. "
+            f"Coverage year span: {year_span}. "
+            "Use these as evidence seeds, then synthesize themes, methods, strengths, and limitations."
+        )

--- a/metagpt/intent_router.py
+++ b/metagpt/intent_router.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import re
+
+# Common multilingual hints for paper/literature requests.
+PAPER_INTENT_KEYWORDS = (
+    "paper",
+    "papers",
+    "essay",
+    "survey",
+    "literature",
+    "literature review",
+    "academic",
+    "arxiv",
+    "scholar",
+    "citation",
+    "论文",
+    "文献",
+    "综述",
+    "学术",
+    "检索",
+)
+
+# Trigger words used when literature pre-review mode is set to "keyword".
+LITERATURE_REVIEW_HINTS = (
+    "research",
+    "analysis",
+    "survey",
+    "state of the art",
+    "sota",
+    "benchmark",
+    "compare methods",
+    "论文",
+    "文献",
+    "综述",
+    "调研",
+    "对比",
+)
+
+# Patterns to extract the probable topical phrase from natural language requests.
+TOPIC_EXTRACTION_PATTERNS = (
+    r"(?:topic|subject|field)\s*(?:is|:)\s*(?P<topic>[^.?!]+)",
+    r"(?:about|on|regarding|related to)\s+(?P<topic>[^.?!]+)",
+    r"(?:find|search|look for|retrieve)\s+(?:me\s+)?(?:papers?|essays?)\s+(?:about|on)\s+(?P<topic>[^.?!]+)",
+    r"(?:论文|文献|综述)\s*(?:主题|方向)?\s*(?:是|为|关于)?\s*(?P<topic>[^。！？]+)",
+)
+
+# Prefix phrases that should be removed if they appear at the beginning of
+# extracted topics.
+FILLER_PREFIX_PATTERNS = (
+    r"^(?:i want to|please|can you|could you|would you|help me|let me)\s+",
+    r"^(?:find|search|look for|get|retrieve)\s+",
+    r"^(?:me\s+)?(?:the\s+)?(?:papers?|essays?)\s+(?:of|about|on)\s+",
+    r"^(?:请|帮我|我想|我需要)\s*",
+    r"^(?:请)?帮我(?:找|搜索|检索)?(?:一些|有关|关于)?\s*",
+    r"^(?:找|检索|搜索)\s*(?:一些|有关|关于)?\s*",
+)
+
+TOPIC_SUFFIX_PATTERNS = (
+    r"\s*(?:for me|please)\s*$",
+    r"\s*(?:thanks|thank you)\s*$",
+)
+
+# Lightweight typo/term normalization for common user inputs.
+TOPIC_NORMALIZATION_MAP = {
+    "software engining": "software engineering",
+    "reinforcment learning": "reinforcement learning",
+    "machine learnning": "machine learning",
+}
+
+
+def _normalize_whitespace(text: str) -> str:
+    return re.sub(r"\s+", " ", (text or "")).strip()
+
+
+def _clean_extracted_topic(topic: str) -> str:
+    cleaned = _normalize_whitespace(topic).strip(" '\"“”‘’`")
+    if not cleaned:
+        return cleaned
+
+    lowered = cleaned.lower()
+    for pattern in FILLER_PREFIX_PATTERNS:
+        lowered = re.sub(pattern, "", lowered, flags=re.IGNORECASE).strip()
+    for pattern in TOPIC_SUFFIX_PATTERNS:
+        lowered = re.sub(pattern, "", lowered, flags=re.IGNORECASE).strip()
+
+    # Remove trailing intent tokens left by loose extraction/fallback.
+    lowered = re.sub(r"\b(?:paper|papers|essay|essays|literature|survey)\b\s*$", "", lowered).strip()
+    lowered = re.sub(r"(?:论文|文献|综述)\s*$", "", lowered).strip()
+
+    lowered = lowered.strip(" '\"“”‘’`")
+    if lowered in TOPIC_NORMALIZATION_MAP:
+        lowered = TOPIC_NORMALIZATION_MAP[lowered]
+
+    return lowered
+
+
+def looks_like_paper_research_topic(text: str) -> bool:
+    """Return True if user input looks like an academic paper request."""
+    content = (text or "").lower()
+    if not content.strip():
+        return False
+    return any(keyword in content for keyword in PAPER_INTENT_KEYWORDS)
+
+
+def should_trigger_literature_review(text: str) -> bool:
+    """Return True when input is likely to benefit from literature pre-review."""
+    content = (text or "").lower()
+    if not content.strip():
+        return False
+    return any(hint in content for hint in LITERATURE_REVIEW_HINTS)
+
+
+def extract_paper_research_topic(text: str) -> str:
+    """Extract a concise topic phrase from natural language paper requests."""
+    source = _normalize_whitespace(text)
+    if not source:
+        return ""
+
+    for pattern in TOPIC_EXTRACTION_PATTERNS:
+        match = re.search(pattern, source, flags=re.IGNORECASE)
+        if not match:
+            continue
+        topic = _clean_extracted_topic(match.group("topic"))
+        if topic:
+            return topic
+
+    # Fallback: clean the whole input and remove obvious intent tokens.
+    fallback = source.lower()
+    for keyword in PAPER_INTENT_KEYWORDS:
+        fallback = fallback.replace(keyword, " ")
+    fallback = _clean_extracted_topic(fallback)
+    return fallback or source.lower()

--- a/metagpt/roles/__init__.py
+++ b/metagpt/roles/__init__.py
@@ -6,12 +6,12 @@
 @File    : __init__.py
 """
 
+from metagpt.roles.role import Role
 from metagpt.roles.architect import Architect
 from metagpt.roles.project_manager import ProjectManager
 from metagpt.roles.product_manager import ProductManager
 from metagpt.roles.engineer import Engineer
 from metagpt.roles.qa_engineer import QaEngineer
-from metagpt.roles.role import Role
 from metagpt.roles.sales import Sales
 from metagpt.roles.searcher import Searcher
 from metagpt.roles.di.data_analyst import DataAnalyst

--- a/metagpt/roles/__init__.py
+++ b/metagpt/roles/__init__.py
@@ -6,14 +6,14 @@
 @File    : __init__.py
 """
 
-from metagpt.roles.role import Role
 from metagpt.roles.architect import Architect
 from metagpt.roles.project_manager import ProjectManager
 from metagpt.roles.product_manager import ProductManager
 from metagpt.roles.engineer import Engineer
 from metagpt.roles.qa_engineer import QaEngineer
-from metagpt.roles.searcher import Searcher
+from metagpt.roles.role import Role
 from metagpt.roles.sales import Sales
+from metagpt.roles.searcher import Searcher
 from metagpt.roles.di.data_analyst import DataAnalyst
 from metagpt.roles.di.team_leader import TeamLeader
 from metagpt.roles.di.engineer2 import Engineer2

--- a/metagpt/roles/di/role_zero.py
+++ b/metagpt/roles/di/role_zero.py
@@ -30,7 +30,7 @@ from metagpt.prompts.di.role_zero import (
     SUMMARY_PROMPT,
     SYSTEM_PROMPT,
 )
-from metagpt.roles import Role
+from metagpt.roles.role import Role
 from metagpt.schema import AIMessage, Message, UserMessage
 from metagpt.strategy.experience_retriever import DummyExpRetriever, ExpRetriever
 from metagpt.strategy.planner import Planner

--- a/metagpt/software_company.py
+++ b/metagpt/software_company.py
@@ -9,12 +9,12 @@ from typing import Optional
 import typer
 
 from metagpt.const import CONFIG_ROOT
-from metagpt.logs import logger
 from metagpt.intent_router import (
     extract_paper_research_topic,
     looks_like_paper_research_topic,
     should_trigger_literature_review,
 )
+from metagpt.logs import logger
 
 app = typer.Typer(add_completion=False, pretty_exceptions_show_locals=False, invoke_without_command=True)
 
@@ -89,7 +89,13 @@ def generate_repo(
     """Run the startup logic. Can be called from CLI or other Python scripts."""
     from metagpt.config2 import config
     from metagpt.context import Context
-    from metagpt.roles import Architect, DataAnalyst, Engineer2, ProductManager, TeamLeader
+    from metagpt.roles import (
+        Architect,
+        DataAnalyst,
+        Engineer2,
+        ProductManager,
+        TeamLeader,
+    )
     from metagpt.team import Team
 
     config.update_via_cli(project_path, project_name, inc, reqa_file, max_auto_summarize_code)

--- a/metagpt/software_company.py
+++ b/metagpt/software_company.py
@@ -8,10 +8,8 @@ from typing import Optional
 
 import typer
 
-from metagpt.actions.literature_review import LiteratureReviewAction
-from metagpt.config2 import config as metagpt_config
 from metagpt.const import CONFIG_ROOT
-from metagpt.context import Context
+from metagpt.logs import logger
 from metagpt.intent_router import (
     extract_paper_research_topic,
     looks_like_paper_research_topic,
@@ -187,6 +185,10 @@ def _run_literature_review_for_software(idea: str, max_results: int = 5) -> Opti
     """Run optional literature review action and return context text."""
 
     async def run_review():
+        from metagpt.actions.literature_review import LiteratureReviewAction
+        from metagpt.config2 import config as metagpt_config
+        from metagpt.context import Context
+
         action = LiteratureReviewAction()
         action.set_context(Context(config=metagpt_config))
         result = await action.run(topic=idea, max_results=max_results)
@@ -197,6 +199,51 @@ def _run_literature_review_for_software(idea: str, max_results: int = 5) -> Opti
     result = asyncio.run(run_review())
     _ensure_main_event_loop()
     return result
+
+
+def _resolve_intent_with_fallback(
+    idea: str,
+    agent_result: Optional[dict] = None,
+    confidence_threshold: float = 0.65,
+) -> tuple[bool, str]:
+    """Resolve paper/software intent using agent result first, regex as fallback."""
+    if agent_result:
+        mode = str(agent_result.get("collaboration_mode", "")).strip().lower()
+        confidence = float(agent_result.get("confidence") or 0.0)
+        topic = str(agent_result.get("topic") or "").strip()
+        if mode in {"paper", "software"} and confidence >= confidence_threshold:
+            if mode == "paper":
+                return True, topic or extract_paper_research_topic(idea)
+            return False, idea
+
+    # Deterministic fallback to keep behavior stable.
+    is_paper_request = looks_like_paper_research_topic(idea)
+    topic = extract_paper_research_topic(idea) if is_paper_request else idea
+    return is_paper_request, topic
+
+
+def _classify_intent_via_agent(idea: str) -> Optional[dict]:
+    """Use a lightweight Action to classify user intent. Return None on failure."""
+
+    async def run_classify() -> dict:
+        from metagpt.actions.intent_classification import IntentClassificationAction
+        from metagpt.config2 import config as metagpt_config
+        from metagpt.context import Context
+
+        action = IntentClassificationAction()
+        action.set_context(Context(config=metagpt_config))
+        return await action.run(user_input=idea)
+
+    try:
+        if platform.system() == "Windows":
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        result = asyncio.run(run_classify())
+        _ensure_main_event_loop()
+        return result
+    except Exception as exc:
+        logger.warning(f"Intent classification action failed, fallback to regex router: {exc}")
+        _ensure_main_event_loop()
+        return None
 
 
 @app.callback(invoke_without_command=True)
@@ -242,10 +289,17 @@ def startup(
         typer.echo("Missing argument 'IDEA'. Run 'metagpt --help' for more information.")
         raise typer.Exit()
 
-    is_paper_request = looks_like_paper_research_topic(idea)
+    agent_intent = _classify_intent_via_agent(idea)
+    is_paper_request, topic = _resolve_intent_with_fallback(idea=idea, agent_result=agent_intent)
+    if agent_intent:
+        logger.info(
+            "Intent classifier result: "
+            f"mode={agent_intent.get('collaboration_mode')} "
+            f"confidence={float(agent_intent.get('confidence') or 0.0):.2f} "
+            f"topic={agent_intent.get('topic')}"
+        )
 
     normalized_mode = literature_review_mode.strip().lower()
-    topic = extract_paper_research_topic(idea) if is_paper_request else idea
     should_review = (
         is_paper_request
         or normalized_mode == "always"

--- a/metagpt/software_company.py
+++ b/metagpt/software_company.py
@@ -2,13 +2,74 @@
 # -*- coding: utf-8 -*-
 
 import asyncio
+import platform
 from pathlib import Path
+from typing import Optional
 
 import typer
 
+from metagpt.actions.literature_review import LiteratureReviewAction
+from metagpt.config2 import config as metagpt_config
 from metagpt.const import CONFIG_ROOT
+from metagpt.context import Context
+from metagpt.intent_router import (
+    extract_paper_research_topic,
+    looks_like_paper_research_topic,
+    should_trigger_literature_review,
+)
 
-app = typer.Typer(add_completion=False, pretty_exceptions_show_locals=False)
+app = typer.Typer(add_completion=False, pretty_exceptions_show_locals=False, invoke_without_command=True)
+
+PAPER_MODE_COMMAND_CONSTRAINT = """
+You are in paper-mode collaboration.
+Return ONLY a strict JSON array of commands. Do not output narrative text before or after JSON.
+Do not call SearchEnhancedQA.run.
+Focus on literature synthesis outputs, not software implementation artifacts.
+""".strip()
+
+PAPER_MODE_PM_INSTRUCTION = """
+You are the ProductManager for an academic literature synthesis task.
+Your output must define:
+1) Research objectives and scope
+2) Research questions and inclusion/exclusion criteria
+3) Report outline for literature review (not market competitor analysis)
+4) Evidence table template and expected citation style
+Use Editor tools to produce markdown documents.
+""".strip()
+
+PAPER_MODE_ARCHITECT_INSTRUCTION = """
+You are the Architect for an academic literature synthesis workflow.
+Design an analysis framework for evidence synthesis, including:
+1) Thematic dimensions
+2) Comparison matrix structure
+3) Claim-to-evidence mapping
+4) Quality/risk assessment rubric
+Output markdown structure and mermaid diagrams only when helpful for analysis flow.
+Do not design software implementation architecture.
+""".strip()
+
+
+def _ensure_main_event_loop():
+    """Ensure there is a current event loop in main thread."""
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+
+def _build_hire_roles(collaboration_mode: str, team_leader, product_manager, architect, engineer2, data_analyst):
+    """Build role lineup for a collaboration mode within one Team workflow."""
+    if collaboration_mode == "paper":
+        pm = product_manager(
+            instruction=f"{PAPER_MODE_COMMAND_CONSTRAINT}\n\n{PAPER_MODE_PM_INSTRUCTION}",
+            tools=["RoleZero", "Browser", "Editor"],
+        )
+        arch = architect(
+            instruction=f"{PAPER_MODE_COMMAND_CONSTRAINT}\n\n{PAPER_MODE_ARCHITECT_INSTRUCTION}",
+        )
+        return [team_leader(), pm, arch, data_analyst()]
+    return [team_leader(), product_manager(), architect(), engineer2(), data_analyst()]
 
 
 def generate_repo(
@@ -24,42 +85,30 @@ def generate_repo(
     reqa_file="",
     max_auto_summarize_code=0,
     recover_path=None,
+    literature_context: Optional[str] = None,
+    collaboration_mode: str = "software",
 ):
     """Run the startup logic. Can be called from CLI or other Python scripts."""
     from metagpt.config2 import config
     from metagpt.context import Context
-    from metagpt.roles import (
-        Architect,
-        DataAnalyst,
-        Engineer2,
-        ProductManager,
-        TeamLeader,
-    )
+    from metagpt.roles import Architect, DataAnalyst, Engineer2, ProductManager, TeamLeader
     from metagpt.team import Team
 
     config.update_via_cli(project_path, project_name, inc, reqa_file, max_auto_summarize_code)
     ctx = Context(config=config)
+    _ensure_main_event_loop()
 
     if not recover_path:
         company = Team(context=ctx)
-        company.hire(
-            [
-                TeamLeader(),
-                ProductManager(),
-                Architect(),
-                Engineer2(),
-                # ProjectManager(),
-                DataAnalyst(),
-            ]
+        hire_roles = _build_hire_roles(
+            collaboration_mode=collaboration_mode,
+            team_leader=TeamLeader,
+            product_manager=ProductManager,
+            architect=Architect,
+            engineer2=Engineer2,
+            data_analyst=DataAnalyst,
         )
-
-        # if implement or code_review:
-        #     company.hire([Engineer(n_borg=5, use_code_review=code_review)])
-        #
-        # if run_tests:
-        #     company.hire([QaEngineer()])
-        #     if n_round < 8:
-        #         n_round = 8  # If `--run-tests` is enabled, at least 8 rounds are required to run all QA actions.
+        company.hire(hire_roles)
     else:
         stg_path = Path(recover_path)
         if not stg_path.exists() or not str(stg_path).endswith("team"):
@@ -69,13 +118,90 @@ def generate_repo(
         idea = company.idea
 
     company.invest(investment)
-    asyncio.run(company.run(n_round=n_round, idea=idea))
+    effective_idea = _compose_idea_with_literature_context(idea, literature_context)
+    asyncio.run(company.run(n_round=n_round, idea=effective_idea))
 
     return ctx.kwargs.get("project_path")
 
 
-@app.command("", help="Start a new project.")
+def _compose_idea_with_literature_context(idea: str, literature_context: Optional[str]) -> str:
+    """Inject literature context into requirement for PM/Architect traceability."""
+    if not literature_context:
+        return idea
+    return (
+        f"{idea}\n\n"
+        "## Literature Review Context (for ProductManager and Architect)\n"
+        f"{literature_context}\n"
+        "## End Literature Review Context\n"
+    )
+
+
+def _compose_paper_collaboration_idea(topic: str, literature_context: Optional[str]) -> str:
+    """Build a paper-oriented collaborative requirement for the common Team workflow."""
+    base_idea = (
+        "Deliver a collaborative academic research report instead of software implementation. "
+        f"Research topic: {topic}. "
+        "ProductManager should define research objectives and report outline. "
+        "Architect should design a clear analysis framework and evidence structure. "
+        "DataAnalyst should summarize trends, key methods, strengths/limitations, and practical suggestions. "
+        "Output should be in markdown and focused on literature synthesis."
+    )
+    return _compose_idea_with_literature_context(base_idea, literature_context)
+
+
+def _render_literature_context(review_result: dict) -> str:
+    """Render reusable literature context in a deterministic format."""
+    lines = [
+        f"- Topic: {review_result.get('topic', '')}",
+        "- Summary:",
+        review_result.get("summary", ""),
+        "",
+        "- Key Papers:",
+    ]
+    papers = review_result.get("papers", [])
+    if not papers:
+        lines.append("  - No papers extracted.")
+        return "\n".join(lines)
+    for idx, paper in enumerate(papers, 1):
+        lines.append(
+            f"  {idx}. {paper.get('title', 'Untitled')} ({paper.get('year', 'N/A')}, {paper.get('venue', 'N/A')})"
+        )
+        if paper.get("url"):
+            lines.append(f"     URL: {paper['url']}")
+        if paper.get("abstract"):
+            lines.append(f"     Abstract: {paper['abstract']}")
+    return "\n".join(lines)
+
+
+def _save_literature_context_to_fixed_file(context_text: str) -> Optional[Path]:
+    """Persist pre-review context to a deterministic file for easy retrieval."""
+    if not context_text:
+        return None
+    output_path = Path.cwd() / "workspace" / "paper_search_result.md"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(context_text, encoding="utf-8")
+    return output_path
+
+
+def _run_literature_review_for_software(idea: str, max_results: int = 5) -> Optional[str]:
+    """Run optional literature review action and return context text."""
+
+    async def run_review():
+        action = LiteratureReviewAction()
+        action.set_context(Context(config=metagpt_config))
+        result = await action.run(topic=idea, max_results=max_results)
+        return _render_literature_context(result)
+
+    if platform.system() == "Windows":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    result = asyncio.run(run_review())
+    _ensure_main_event_loop()
+    return result
+
+
+@app.callback(invoke_without_command=True)
 def startup(
+    ctx: typer.Context,
     idea: str = typer.Argument(None, help="Your innovative idea, such as 'Create a 2048 game.'"),
     investment: float = typer.Option(default=3.0, help="Dollar amount to invest in the AI company."),
     n_round: int = typer.Option(default=5, help="Number of rounds for the simulation."),
@@ -98,8 +224,16 @@ def startup(
     ),
     recover_path: str = typer.Option(default=None, help="recover the project from existing serialized storage"),
     init_config: bool = typer.Option(default=False, help="Initialize the configuration file for MetaGPT."),
+    literature_review_mode: str = typer.Option(
+        default="off",
+        help="Optional literature pre-review mode: off, keyword, always.",
+    ),
+    literature_top_k: int = typer.Option(default=5, help="Top papers used in pre-review context."),
 ):
     """Run a startup. Be a boss."""
+    if ctx.invoked_subcommand:
+        return
+
     if init_config:
         copy_config_to()
         return
@@ -108,8 +242,33 @@ def startup(
         typer.echo("Missing argument 'IDEA'. Run 'metagpt --help' for more information.")
         raise typer.Exit()
 
+    is_paper_request = looks_like_paper_research_topic(idea)
+
+    normalized_mode = literature_review_mode.strip().lower()
+    topic = extract_paper_research_topic(idea) if is_paper_request else idea
+    should_review = (
+        is_paper_request
+        or normalized_mode == "always"
+        or (normalized_mode == "keyword" and should_trigger_literature_review(idea))
+    )
+    literature_context = None
+    if should_review:
+        typer.echo("\nRunning optional literature pre-review for software collaboration...")
+        literature_context = _run_literature_review_for_software(topic, max_results=literature_top_k)
+        typer.echo("Literature pre-review context injected into ProductManager/Architect inputs.\n")
+        saved_path = _save_literature_context_to_fixed_file(literature_context or "")
+        if saved_path:
+            typer.echo(f"Pre-review paper result saved to: {saved_path}")
+
+    collaboration_mode = "paper" if is_paper_request else "software"
+    effective_idea = idea
+    if is_paper_request:
+        typer.echo(f"Detected paper request topic: {topic}")
+        effective_idea = _compose_paper_collaboration_idea(topic, literature_context)
+        literature_context = None
+
     return generate_repo(
-        idea,
+        effective_idea,
         investment,
         n_round,
         code_review,
@@ -121,6 +280,8 @@ def startup(
         reqa_file,
         max_auto_summarize_code,
         recover_path,
+        literature_context,
+        collaboration_mode,
     )
 
 
@@ -139,16 +300,13 @@ def copy_config_to():
     """Initialize the configuration file for MetaGPT."""
     target_path = CONFIG_ROOT / "config2.yaml"
 
-    # 创建目标目录（如果不存在）
     target_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # 如果目标文件已经存在，则重命名为 .bak
     if target_path.exists():
         backup_path = target_path.with_suffix(".bak")
         target_path.rename(backup_path)
         print(f"Existing configuration file backed up at {backup_path}")
 
-    # 复制文件
     target_path.write_text(DEFAULT_CONFIG, encoding="utf-8")
     print(f"Configuration file initialized at {target_path}")
 

--- a/metagpt/tools/libs/editor.py
+++ b/metagpt/tools/libs/editor.py
@@ -113,8 +113,12 @@ class Editor(BaseModel):
     enable_auto_lint: bool = False
     working_dir: Path = DEFAULT_WORKSPACE_ROOT
 
-    def write(self, path: str, content: str):
-        """Write the whole content to a file. When used, make sure content arg contains the full content of the file."""
+    def write(self, path: str, content: str, description: str = "", **kwargs):
+        """Write full content to a file.
+
+        The `description` and extra kwargs are accepted for compatibility with
+        LLM-generated tool arguments and are ignored.
+        """
 
         path = self._try_fix_path(path)
 

--- a/metagpt/utils/common.py
+++ b/metagpt/utils/common.py
@@ -288,8 +288,8 @@ class CodeParser:
         if match:
             code = match.group(1)
         else:
-            logger.error(f"{pattern} not match following text:")
-            logger.error(text)
+            logger.warning(f"{pattern} not matched; fallback to raw text.")
+            logger.debug(text)
             # raise Exception
             return text  # just assume original text is code
         return code

--- a/metagpt/utils/repo_to_markdown.py
+++ b/metagpt/utils/repo_to_markdown.py
@@ -140,6 +140,8 @@ async def is_text_file(filename: Union[str, Path]) -> Tuple[bool, str]:
         "video/mp4",
     }
     mime_type = await get_mime_type(Path(filename), force_read=True)
+    if not mime_type:
+        return False, ""
     v = "text/" in mime_type or mime_type in pass_set
     if v:
         return True, mime_type

--- a/metagpt/utils/role_zero_utils.py
+++ b/metagpt/utils/role_zero_utils.py
@@ -16,7 +16,7 @@ from metagpt.prompts.di.role_zero import (
     SUMMARY_PROBLEM_WHEN_DUPLICATE,
 )
 from metagpt.schema import Message, UserMessage
-from metagpt.utils.common import CodeParser, extract_and_encode_images
+from metagpt.utils.common import extract_and_encode_images
 from metagpt.utils.repair_llm_raw_output import (
     RepairType,
     repair_escape_error,

--- a/metagpt/utils/role_zero_utils.py
+++ b/metagpt/utils/role_zero_utils.py
@@ -16,12 +16,31 @@ from metagpt.prompts.di.role_zero import (
     SUMMARY_PROBLEM_WHEN_DUPLICATE,
 )
 from metagpt.schema import Message, UserMessage
-from metagpt.utils.common import extract_and_encode_images
+from metagpt.utils.common import CodeParser, extract_and_encode_images
 from metagpt.utils.repair_llm_raw_output import (
     RepairType,
     repair_escape_error,
     repair_llm_raw_output,
 )
+
+
+def _extract_first_json_payload(text: str) -> str:
+    """Extract the first decodable JSON object/array from mixed LLM output."""
+    source = (text or "").strip()
+    if not source:
+        return source
+
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(source):
+        if char not in "[{":
+            continue
+        candidate = source[index:]
+        try:
+            _, end = decoder.raw_decode(candidate)
+            return candidate[:end]
+        except json.JSONDecodeError:
+            continue
+    return source
 
 
 async def parse_browser_actions(memory: list[Message], browser) -> list[Message]:
@@ -107,7 +126,7 @@ async def parse_commands(command_rsp: str, llm, exclusive_tool_commands: list[st
             - A boolean flag indicating success (True) or failure (False).
     """
     try:
-        commands = CodeParser.parse_code(block=None, lang="json", text=command_rsp)
+        commands = _extract_first_json_payload(command_rsp)
         if commands.endswith("]") and not commands.startswith("["):
             commands = "[" + commands
         commands = json.loads(repair_llm_raw_output(output=commands, req_keys=[None], repair_type=RepairType.JSON))
@@ -115,10 +134,10 @@ async def parse_commands(command_rsp: str, llm, exclusive_tool_commands: list[st
         logger.warning(f"Failed to parse JSON for: {command_rsp}. Trying to repair...")
         commands = await llm.aask(msg=JSON_REPAIR_PROMPT.format(json_data=command_rsp, json_decode_error=str(e)))
         try:
-            commands = json.loads(CodeParser.parse_code(block=None, lang="json", text=commands))
+            commands = json.loads(_extract_first_json_payload(commands))
         except json.JSONDecodeError:
             # repair escape error of code and math
-            commands = CodeParser.parse_code(block=None, lang="json", text=command_rsp)
+            commands = _extract_first_json_payload(command_rsp)
             new_command = repair_escape_error(commands)
             commands = json.loads(
                 repair_llm_raw_output(output=new_command, req_keys=[None], repair_type=RepairType.JSON)

--- a/tests/metagpt/test_intent_router.py
+++ b/tests/metagpt/test_intent_router.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from metagpt.intent_router import (
+    extract_paper_research_topic,
+    looks_like_paper_research_topic,
+    should_trigger_literature_review,
+)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("find papers about reinforcement learning", True),
+        ("please search essay on software engineering", True),
+        ("我想检索关于多智能体系统的论文", True),
+        ("Summarize this sprint plan", False),
+        ("build me a todo app", False),
+    ],
+)
+def test_looks_like_paper_research_topic(text, expected):
+    assert looks_like_paper_research_topic(text) is expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("Please do a survey on retrieval augmented generation", True),
+        ("Need benchmark comparison for image segmentation", True),
+        ("我想做文献综述", True),
+        ("Create API specs for payment service", False),
+        ("Add redis cache and unit tests", False),
+    ],
+)
+def test_should_trigger_literature_review(text, expected):
+    assert should_trigger_literature_review(text) is expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (
+            "I want to search for essay whose topic is machine learning",
+            "machine learning",
+        ),
+        (
+            "Please find papers about software engining",
+            "software engineering",
+        ),
+        (
+            "Search papers on Reinforcment Learning please",
+            "reinforcement learning",
+        ),
+        (
+            "Can you retrieve papers regarding graph neural networks",
+            "graph neural networks",
+        ),
+        (
+            "请帮我找关于大模型推理优化的论文",
+            "大模型推理优化的",
+        ),
+    ],
+)
+def test_extract_paper_research_topic_patterns(text, expected):
+    assert extract_paper_research_topic(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("", ""),
+        ("  ", ""),
+        ("Create a 2048 game", "create a 2048 game"),
+    ],
+)
+def test_extract_topic_edge_inputs(text, expected):
+    assert extract_paper_research_topic(text) == expected
+
+
+def test_extract_topic_fallback_strips_intent_tokens():
+    text = "paper paper literature about federated learning paper"
+    topic = extract_paper_research_topic(text)
+    assert "paper" not in topic
+    assert "literature" not in topic
+    assert "federated learning" in topic
+
+
+def test_extract_topic_handles_quotes_and_whitespace():
+    text = "Please find papers about   '   Agentic Workflow   '   "
+    assert extract_paper_research_topic(text) == "agentic workflow"

--- a/tests/metagpt/test_software_company_paper_mode.py
+++ b/tests/metagpt/test_software_company_paper_mode.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+from metagpt.software_company import (
+    _compose_idea_with_literature_context,
+    _compose_paper_collaboration_idea,
+    _render_literature_context,
+    _resolve_intent_with_fallback,
+    _save_literature_context_to_fixed_file,
+)
+
+
+def test_compose_idea_with_empty_context():
+    idea = "Build a simple app"
+    assert _compose_idea_with_literature_context(idea, None) == idea
+    assert _compose_idea_with_literature_context(idea, "") == idea
+
+
+def test_compose_idea_with_literature_context():
+    idea = "Build a simple app"
+    context = "- Topic: RL\n- Summary: ...\n- Key Papers:"
+    merged = _compose_idea_with_literature_context(idea, context)
+    assert "Build a simple app" in merged
+    assert "Literature Review Context" in merged
+    assert context in merged
+
+
+def test_compose_paper_collaboration_idea():
+    idea = _compose_paper_collaboration_idea(
+        topic="reinforcement learning",
+        literature_context="- Topic: reinforcement learning",
+    )
+    assert "Research topic: reinforcement learning." in idea
+    assert "ProductManager should define research objectives" in idea
+    assert "DataAnalyst should summarize trends" in idea
+    assert "Literature Review Context" in idea
+
+
+def test_render_literature_context_no_papers():
+    payload = {"topic": "agents", "summary": "S", "papers": []}
+    rendered = _render_literature_context(payload)
+    assert "- Topic: agents" in rendered
+    assert "- Summary:" in rendered
+    assert "No papers extracted." in rendered
+
+
+def test_render_literature_context_with_papers():
+    payload = {
+        "topic": "agents",
+        "summary": "S",
+        "papers": [
+            {
+                "title": "Paper A",
+                "year": "2024",
+                "venue": "arXiv",
+                "url": "https://arxiv.org/abs/1234.5678",
+                "abstract": "A short abstract",
+            }
+        ],
+    }
+    rendered = _render_literature_context(payload)
+    assert "Paper A (2024, arXiv)" in rendered
+    assert "URL: https://arxiv.org/abs/1234.5678" in rendered
+    assert "Abstract: A short abstract" in rendered
+
+
+def test_save_literature_context_to_fixed_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    out = _save_literature_context_to_fixed_file("content")
+    assert out == tmp_path / "workspace" / "paper_search_result.md"
+    assert out.exists()
+    assert out.read_text(encoding="utf-8") == "content"
+
+
+def test_save_literature_context_skips_empty(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    out = _save_literature_context_to_fixed_file("")
+    assert out is None
+    assert not (tmp_path / "workspace" / "paper_search_result.md").exists()
+
+
+def test_save_path_is_relative_to_cwd(tmp_path, monkeypatch):
+    nested = tmp_path / "nested"
+    nested.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(nested)
+    out = _save_literature_context_to_fixed_file("abc")
+    assert out == Path.cwd() / "workspace" / "paper_search_result.md"
+
+
+def test_resolve_intent_prefers_agent_high_confidence_paper():
+    idea = "Build a web dashboard"
+    agent_result = {
+        "collaboration_mode": "paper",
+        "topic": "software architecture",
+        "confidence": 0.92,
+    }
+    is_paper, topic = _resolve_intent_with_fallback(idea=idea, agent_result=agent_result)
+    assert is_paper is True
+    assert topic == "software architecture"
+
+
+def test_resolve_intent_prefers_agent_high_confidence_software():
+    idea = "please find papers about reinforcement learning"
+    agent_result = {
+        "collaboration_mode": "software",
+        "topic": "ignore this",
+        "confidence": 0.91,
+    }
+    is_paper, topic = _resolve_intent_with_fallback(idea=idea, agent_result=agent_result)
+    assert is_paper is False
+    assert topic == idea
+
+
+def test_resolve_intent_falls_back_when_agent_low_confidence():
+    idea = "please find papers about reinforcement learning"
+    agent_result = {
+        "collaboration_mode": "software",
+        "topic": "ignore this",
+        "confidence": 0.20,
+    }
+    is_paper, topic = _resolve_intent_with_fallback(idea=idea, agent_result=agent_result)
+    assert is_paper is True
+    assert topic == "reinforcement learning"


### PR DESCRIPTION
**Features**
1. Add optional paper-research capability to startup routing while preserving the original software workflow as default.
2. Introduce IntentClassificationAction for paper/software intent prediction with topic and confidence output.
3. Keep deterministic regex router as fallback when classifier fails or confidence is low.
4. Add lightweight LiteratureReviewAction (arXiv-based) to prepare pre-review context for collaboration.
5. Integrate paper-oriented collaboration mode into software_company without breaking existing Team software flow.
6. Improve runtime robustness:
    · handle mime_type=None safely in text-file detection (repo_to_markdown),
    · accept extra LLM-generated kwargs (e.g., description) in Editor.write.
7. Improve command parsing robustness in role_zero_utils by extracting first valid JSON payload from mixed LLM output.
8. Add focused tests for intent routing and fallback behavior.
9. Update .pre-commit-config.yaml to use HTTPS repos for CI compatibility.

**Feature Docs**

Main use case:
    `metagpt "please find me some essay about machine learning"`
Expected artifacts (example run):
    workspace/paper_search_result.md
    paper-collaboration planning/analysis markdown files generated by Team roles.

**Influence**

1. Default software-company path is preserved (no breaking change to normal software tasks).
2. New paper capability is optional and guarded by fallback logic.
3. Startup routing and role collaboration behavior are the main impacted areas.
4. Tool execution stability is improved for file reading/writing edge cases.

**Result**

Local focused tests passed:
```
python -m pytest -q -o addopts="" --confcutdir=tests/metagpt tests/metagpt/test_intent_router.py tests/metagpt/test_software_company_paper_mode.py
python -m pytest -q -o addopts="" --confcutdir=tests/metagpt tests/metagpt/roles/di/test_role_zero.py
pre-commit run --all-files executed locally, auto-fixes applied, and follow-up style commit pushed.

```
**Other**

This PR includes an extension beyond pure software generation.
If maintainers prefer narrower scope for main, I can split this into two PRs:

- core robustness improvements aligned with existing software workflow,
- optional paper-research extension for separate review (Draft PR / feature branch).