### PR TITLE
fix: prevent shell injection in AndroidExtEnv.execute_adb_with_cmd (CWE-78)

### DIFF
--- a/metagpt/environment/android/android_ext_env.py
+++ b/metagpt/environment/android/android_ext_env.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # @Desc   : The Android external environment to integrate with Android apps
+import shlex
 import subprocess
 import time
 from pathlib import Path
@@ -136,7 +137,9 @@ class AndroidExtEnv(ExtEnv):
 
     def execute_adb_with_cmd(self, adb_cmd: str) -> str:
         adb_cmd = adb_cmd.replace("\\", "/")
-        res = subprocess.run(adb_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        res = subprocess.run(
+            shlex.split(adb_cmd), shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
         exec_res = ADB_EXEC_FAIL
         if not res.returncode:
             exec_res = res.stdout.strip()

--- a/tests/security/test_cwe78_android_ext_env.py
+++ b/tests/security/test_cwe78_android_ext_env.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Regression tests for CWE-78 in AndroidExtEnv adb execution."""
+
+import ast
+from pathlib import Path
+
+ANDROID_EXT_ENV_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "metagpt" / "environment" / "android" / "android_ext_env.py"
+)
+
+
+def _android_ext_env_ast() -> ast.Module:
+    return ast.parse(ANDROID_EXT_ENV_PATH.read_text())
+
+
+def _find_android_method(method_name: str) -> ast.FunctionDef:
+    for node in ast.walk(_android_ext_env_ast()):
+        if isinstance(node, ast.ClassDef) and node.name == "AndroidExtEnv":
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == method_name:
+                    return item
+    raise AssertionError(f"Could not find AndroidExtEnv.{method_name}")
+
+
+def _is_subprocess_run(call: ast.Call) -> bool:
+    return (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr == "run"
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "subprocess"
+    )
+
+
+def test_execute_adb_with_cmd_does_not_invoke_a_shell():
+    """ADB commands must not be executed through a host shell."""
+    method = _find_android_method("execute_adb_with_cmd")
+    run_calls = [node for node in ast.walk(method) if isinstance(node, ast.Call) and _is_subprocess_run(node)]
+
+    assert run_calls, "execute_adb_with_cmd must call subprocess.run"
+    for call in run_calls:
+        shell_keywords = [kw for kw in call.keywords if kw.arg == "shell"]
+        assert shell_keywords, "subprocess.run must set shell explicitly for this security-sensitive call"
+        for keyword in shell_keywords:
+            assert isinstance(keyword.value, ast.Constant)
+            assert keyword.value.value is False, "subprocess.run must use shell=False to prevent CWE-78"
+
+
+def test_execute_adb_with_cmd_passes_tokenized_argv():
+    """The subprocess command must be argv tokens, not a shell command string."""
+    method = _find_android_method("execute_adb_with_cmd")
+    run_calls = [node for node in ast.walk(method) if isinstance(node, ast.Call) and _is_subprocess_run(node)]
+
+    assert run_calls, "execute_adb_with_cmd must call subprocess.run"
+    for call in run_calls:
+        assert call.args, "subprocess.run must receive the command as its first positional argument"
+        command_arg = call.args[0]
+        assert (
+            isinstance(command_arg, ast.Call)
+            and isinstance(command_arg.func, ast.Attribute)
+            and command_arg.func.attr == "split"
+            and isinstance(command_arg.func.value, ast.Name)
+            and command_arg.func.value.id == "shlex"
+        ), "subprocess.run must receive shlex.split(adb_cmd) so shell metacharacters stay literal"
+
+
+def test_agent_user_input_reaches_adb_execution_sink():
+    """Document the external action path: agent input -> user_input -> execute_adb_with_cmd."""
+    execute_action = _find_android_method("_execute_env_action")
+    user_input = _find_android_method("user_input")
+
+    assert any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "user_input"
+        and any(kw.arg == "input_txt" for kw in node.keywords)
+        for node in ast.walk(execute_action)
+    ), "_execute_env_action must route EnvAction.USER_INPUT input text into user_input"
+
+    assert any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "execute_adb_with_cmd"
+        for node in ast.walk(user_input)
+    ), "user_input must pass the assembled adb command to execute_adb_with_cmd"


### PR DESCRIPTION
## Summary

Fixes a shell command injection vulnerability (CWE-78) in `AndroidExtEnv.execute_adb_with_cmd`. This method is the single chokepoint through which all 20+ `adb` invocations in the Android environment flow, and it currently runs an attacker-influenceable command string through the host shell.

## Vulnerability

- **File:** `metagpt/environment/android/android_ext_env.py`
- **Function:** `AndroidExtEnv.execute_adb_with_cmd`
- **CWE:** [CWE-78 — OS Command Injection](https://cwe.mitre.org/data/definitions/78.html)
- **Severity:** High (RCE on the operator host running the Android environment)

The vulnerable line:

```python
res = subprocess.run(adb_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
```

`adb_cmd` is built via f-strings from agent-/LLM-supplied data throughout the file. For example, the `user_input` path:

```
EnvAction.USER_INPUT.input_txt
  -> AndroidExtEnv._execute_env_action
  -> AndroidExtEnv.user_input(input_txt=...)
  -> f"adb -s {self.device_id} shell input text {input_txt}"
  -> execute_adb_with_cmd(...)
  -> subprocess.run(..., shell=True)
```

The only sanitization on `input_txt` strips spaces and quotes — shell metacharacters such as `;`, `&`, `|`, `` ` ``, `$()`, and newlines pass through untouched. An adversary that can influence the agent's task text (a realistic threat in multi-agent / tool-use deployments and any flow where task descriptions, page content, or tool outputs are fed back into the agent) can therefore execute arbitrary commands on the host.

## Fix

Tokenize the command with `shlex.split` and disable the shell:

```python
import shlex
...
res = subprocess.run(
    shlex.split(adb_cmd), shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
)
```

Rationale:

- Patching at the single sink removes the vulnerability for every caller without having to audit and sanitize each of the ~20 f-string command builders individually.
- `shlex.split` preserves the existing quoting semantics callers already rely on (e.g. `adb shell "am start ..."`), so behavior for legitimate adb commands is unchanged.
- `shell=False` ensures shell metacharacters in any embedded user/agent text remain literal arguments to `adb` rather than being interpreted by `/bin/sh`.

The diff is intentionally minimal — one import and one call site:

```
metagpt/environment/android/android_ext_env.py |  5 +-
tests/security/test_cwe78_android_ext_env.py   | 85 ++++++++++++++++++++++++++
2 files changed, 89 insertions(+), 1 deletion(-)
```

## Tests

Added `tests/security/test_cwe78_android_ext_env.py` with three regression checks (all passing locally):

1. `test_execute_adb_with_cmd_does_not_invoke_a_shell` — AST-asserts `subprocess.run` is invoked with `shell=False`.
2. `test_execute_adb_with_cmd_passes_tokenized_argv` — AST-asserts the first positional argument is `shlex.split(adb_cmd)` (not a raw string).
3. `test_agent_user_input_reaches_adb_execution_sink` — Documents and pins the data-flow path `EnvAction.USER_INPUT → user_input → execute_adb_with_cmd`, so future refactors can't silently re-introduce a shell-string sink without tripping the test.

```
3 passed in 3.56s
```

We also constructed a runtime PoC against the pre-fix code using a payload like `hello; touch /tmp/pwned` routed through `user_input`; the file was created on the unpatched build and is no longer created after the patch.

## Security analysis

- **Exploitability:** The reachable path requires only that an attacker influence agent-consumed text (task description, retrieved content, or any field that lands in `EnvAction.USER_INPUT.input_txt` or another adb command builder) on a deployment that actually runs the Android environment with `adb` available. The existing input scrubbing only removes whitespace and quotes, which does not block command separators or substitutions.
- **Mitigations after fix:** Shell metacharacters are no longer interpreted; the worst case for a malicious `input_txt` is now a malformed `adb shell input text` argument list that `adb` rejects.
- **Scope:** The fix is at the single sink, so all other adb command builders (install, pull, push, getevent, screencap, etc.) inherit the protection without code changes elsewhere.

### Adversarial review

Before submitting we tried to disprove this. We checked whether the upstream `user_input` sanitizer or any wrapper neutralized shell metacharacters — it only strips spaces and quotes, leaving `;`, `|`, `&`, `` ` ``, `$()`, and newlines intact. We considered whether the Android environment is gated behind operator-only configuration that would make agent input non-attacker-controlled — it isn't; in normal multi-agent/tool-use flows the LLM-produced text reaches this sink. We considered whether `shell=True` with a fixed `adb` prefix limits damage — it doesn't, because the shell evaluates the whole string and command separators escape the `adb` prefix entirely. The preconditions to exploit (LLM-influenced text + Android env enabled on a host with `adb`) do not already grant the attacker shell access on the operator's machine, so this fix provides genuine defense rather than restating an existing capability.

cc @lewiswigmore
