### PR TITLE
security: prevent path traversal in aflow_inference dynamic workflow loading

### DIFF
--- a/metagpt/ext/aflow/scripts/interface.py
+++ b/metagpt/ext/aflow/scripts/interface.py
@@ -14,8 +14,24 @@ from metagpt.ext.aflow.scripts.evaluator import DatasetType
 from metagpt.ext.aflow.scripts.optimizer_utils.data_utils import DataUtils
 from metagpt.logs import logger
 
+DEFAULT_OPTIMIZED_PATH = "metagpt/ext/aflow/scripts/optimized"
 
-def load_best_round(dataset: str, optimized_path: str = "metagpt/ext/aflow/scripts/optimized") -> int:
+
+def _resolve_graph_path(dataset: str, round: int, optimized_path: str) -> Path:
+    """Build and validate the optimized workflow path before dynamic loading."""
+    base_dir = Path(optimized_path).resolve()
+    graph_path = (base_dir / dataset / "workflows" / f"round_{round}" / "graph.py").resolve()
+
+    if not graph_path.is_relative_to(base_dir):
+        raise ValueError(f"Workflow path {graph_path} is outside the allowed base directory {base_dir}")
+
+    if graph_path.name != "graph.py":
+        raise ValueError(f"Unexpected workflow filename: {graph_path.name} (expected 'graph.py')")
+
+    return graph_path
+
+
+def load_best_round(dataset: str, optimized_path: str = DEFAULT_OPTIMIZED_PATH) -> int:
     """加载最佳表现的轮次"""
     data_utils = DataUtils(f"{optimized_path}/{dataset}")
 
@@ -42,7 +58,7 @@ async def aflow_inference(
     entry_point: Optional[str] = None,
     round: Optional[int] = None,
     llm_name: str = "gpt-4o-mini",
-    optimized_path: str = "metagpt/ext/aflow/scripts/optimized",
+    optimized_path: str = DEFAULT_OPTIMIZED_PATH,
 ) -> Tuple[str, float]:
     """AFLOW推理接口
 
@@ -63,7 +79,7 @@ async def aflow_inference(
     logger.info(f"Using round {round} for inference")
 
     # 构建工作流路径并加载
-    graph_path = Path(optimized_path) / dataset / "workflows" / f"round_{round}" / "graph.py"
+    graph_path = _resolve_graph_path(dataset, round, optimized_path)
     if not graph_path.exists():
         raise FileNotFoundError(f"Workflow file not found: {graph_path}")
 


### PR DESCRIPTION
## Summary

Harden `aflow_inference` against path-traversal-driven dynamic code execution when constructing the `graph.py` workflow path that is passed to `importlib.util.spec_from_file_location` + `exec_module`.

- **File:** `metagpt/ext/aflow/scripts/interface.py`
- **Function:** `aflow_inference` (and the new helper `_resolve_graph_path`)
- **Weakness:** CWE-94 (Improper Control of Generation of Code) via CWE-22 (Path Traversal)

## Vulnerability details

`aflow_inference` builds a filesystem path from three caller-controlled values and then dynamically executes whatever Python file lives at that path:

```python
graph_path = Path(optimized_path) / dataset / "workflows" / f"round_{round}" / "graph.py"
...
spec = importlib.util.spec_from_file_location("workflow_module", graph_path)
workflow_module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(workflow_module)
```

`dataset`, `round`, and `optimized_path` are concatenated into the path with no validation. Values like `dataset="../../../tmp"` (or an absolute `optimized_path`) escape the intended `optimized/` directory, so a `graph.py` placed anywhere readable on disk can be executed in-process. Because the load uses `exec_module`, top-level statements in the chosen file run immediately — this is arbitrary code execution, not just file disclosure.

## Fix

Introduce `_resolve_graph_path` which:

1. Resolves `optimized_path` and the constructed `graph_path` to absolute paths.
2. Uses `Path.is_relative_to` to ensure the resolved `graph_path` stays inside the resolved base directory, blocking `..` segments and absolute-path injection through `dataset` / `round`.
3. Asserts the final filename is exactly `graph.py`, preventing any tail-component shenanigans.

The default path string was extracted into `DEFAULT_OPTIMIZED_PATH` to keep the two call sites consistent. The change is a 19-line addition with no behavioural change for legitimate inputs — the existing `FileNotFoundError` path is preserved.

## What we tested

- Legitimate inputs (`dataset="HumanEval"`, `round=1`, default `optimized_path`) resolve to the same path as before and load normally.
- `dataset="../../etc"` and similarly crafted values now raise `ValueError` from `_resolve_graph_path` before any import machinery runs.
- An absolute `dataset` value (`/tmp/evil`) is also rejected because the resolved path escapes `base_dir`.
- Filename guard: a hypothetical `round` value engineered to land on a non-`graph.py` file is rejected.
- `git diff main..HEAD --stat` confirms the change is limited to a single file (+19/−3).

## Why this is worth fixing

The dynamic `exec_module` sink is reachable from a public function signature with `str` parameters and no documented trust boundary. Any downstream integration that wires `aflow_inference` to a config file, CLI flag, agent tool definition, or HTTP endpoint inherits an RCE primitive. Fixing it at the library boundary is the right layer — individual integrators are unlikely to remember to canonicalise the path themselves.

Before submitting, we tried to disprove this. We checked whether MetaGPT itself currently feeds untrusted input into these parameters (it doesn't — the only in-tree caller is the `__main__` demo with hardcoded values), and whether existing framework code performed any path canonicalisation (it doesn't). So the practical risk today is that downstream users of `aflow_inference` will expose the parameters without realising they need to sanitise them; the fix closes that footgun at the source rather than relying on every caller to get it right.

cc @lewiswigmore
