### PR TITLE
docs: fix duplicated word in prompt text

### DIFF
--- a/metagpt/memory/longterm_memory.py
+++ b/metagpt/memory/longterm_memory.py
@@ -49,7 +49,7 @@ class LongTermMemory(Memory):
 
     async def find_news(self, observed: list[Message], k=0) -> list[Message]:
         """
-        find news (previously unseen messages) from the the most recent k memories, from all memories when k=0
+        find news (previously unseen messages) from the most recent k memories, from all memories when k=0
             1. find the short-term memory(stm) news
             2. furthermore, filter out similar messages based on ltm(long-term memory), get the final news
         """

--- a/metagpt/prompts/di/team_leader.py
+++ b/metagpt/prompts/di/team_leader.py
@@ -32,7 +32,7 @@ Note:
 9. Do not use the 'end' command when the current task remains unfinished; instead, use the 'finish_current_task' command to indicate completion before switching to the next task.
 10. Do not use escape characters in json data, particularly within file paths.
 11. Analyze the capabilities of team members and assign tasks to them based on user Requirements. If the requirements ask to ignore certain tasks, follow the requirements.
-12. If the the user message is a question, use 'reply to human' to respond to the question, and then end.
+12. If the user message is a question, use 'reply to human' to respond to the question, and then end.
 13. Instructions and reply must be in the same language.
 14. Default technology stack is Vite, React, MUI, Tailwind CSS. Web app is the default option when developing software. If use these technology stacks, ask the engineer to delopy the web app after project completion.
 15. You are the only one who decides the programming language for the software, so the instruction must contain the programming language.

--- a/metagpt/prompts/di/write_analysis_code.py
+++ b/metagpt/prompts/di/write_analysis_code.py
@@ -96,7 +96,7 @@ Check latest data info to guide subsequent tasks.
 
 # Task
 Check code in finished tasks, print key variables to guide your following actions.
-Specifically, if it is a data analysis or machine learning task, print the the latest column information using the following code, with DataFrame variable from 'Finished Tasks' in place of df:
+Specifically, if it is a data analysis or machine learning task, print the latest column information using the following code, with DataFrame variable from 'Finished Tasks' in place of df:
 ```python
 from metagpt.tools.libs.data_preprocess import get_column_info
 


### PR DESCRIPTION
Fixes a duplicated word in prompt/comment text. Documentation/text-only change.