### PR TITLE
docs: fix typo in Stanford town memory comments

### DIFF
--- a/metagpt/ext/stanford_town/memory/scratch.py
+++ b/metagpt/ext/stanford_town/memory/scratch.py
@@ -123,7 +123,7 @@ class Scratch(BaseModel):
         OUTPUT
           an integer value for the current index of f_daily_schedule.
         """
-        # We first calculate teh number of minutes elapsed today.
+        # We first calculate the number of minutes elapsed today.
         today_min_elapsed = 0
         today_min_elapsed += self.curr_time.hour * 60
         today_min_elapsed += self.curr_time.minute
@@ -158,7 +158,7 @@ class Scratch(BaseModel):
         OUTPUT
           an integer value for the current index of f_daily_schedule.
         """
-        # We first calculate teh number of minutes elapsed today.
+        # We first calculate the number of minutes elapsed today.
         today_min_elapsed = 0
         today_min_elapsed += self.curr_time.hour * 60
         today_min_elapsed += self.curr_time.minute


### PR DESCRIPTION
## What

Fixes two comment typos in `metagpt/ext/stanford_town/memory/scratch.py`:

- `teh number of minutes elapsed today` → `the number of minutes elapsed today`

## Why

These comments are part of the Stanford town memory code and are visible to readers navigating the implementation. The change is comment-only and has no runtime impact.

## Verification

- Ran `git diff --check`.
