### PR TITLE
docs: fix typo in special tokens comment

### DIFF
--- a/metagpt/utils/special_tokens.py
+++ b/metagpt/utils/special_tokens.py
@@ -1,4 +1,4 @@
 # token to separate different code messages in a WriteCode Message content
 MSG_SEP = "#*000*#"
-# token to seperate file name and the actual code text in a code message
+# token to separate file name and the actual code text in a code message
 FILENAME_CODE_SEP = "#*001*#"


### PR DESCRIPTION
Fixes a typo in a special tokens comment. No behavior change.