### PR TITLE
docs: fix special tokens comment typo

### DIFF
--- a/metagpt/utils/special_tokens.py
+++ b/metagpt/utils/special_tokens.py
@@ -1,4 +1,4 @@
 # token to separate different code messages in a WriteCode Message content
 MSG_SEP = "#*000*#"
-# token to seperate file name and the actual code text in a code message
+# token to separate file name and the actual code text in a code message
 FILENAME_CODE_SEP = "#*001*#"


### PR DESCRIPTION
## What

Fixes a typo in `metagpt/utils/special_tokens.py`:

- `seperate file name` → `separate file name`

## Why

This is a reader-facing comment for the special token constants. The change is comment-only and has no runtime impact.

## Verification

- Ran `git diff --check`.
