### PR TITLE
docs: fix a11y tree comment typo

### DIFF
--- a/metagpt/utils/a11y_tree.py
+++ b/metagpt/utils/a11y_tree.py
@@ -165,7 +165,7 @@ async def get_element_center(node_info):
 
 
 def extract_step(response: str, action_splitter: str = "```") -> str:
-    # find the first occurence of action
+    # find the first occurrence of action
     pattern = rf"{action_splitter}((.|\n)*?){action_splitter}"
     match = re.search(pattern, response)
     if match:


### PR DESCRIPTION
## What

Fixes a comment typo in `metagpt/utils/a11y_tree.py`:

- `occurence` → `occurrence`

## Why

This is a reader-facing comment in the accessibility tree utility. The change is comment-only and has no runtime impact.

## Verification

- Ran `git diff --check`.
