### PR TITLE
[codex] Fix FAQ base_url example formatting

### DIFF
--- a/docs/FAQ-EN.md
+++ b/docs/FAQ-EN.md
@@ -51,9 +51,9 @@ MetaGPT Community - The position of Chief Evangelist rotates on a monthly basis.
     1.  Merging a PR will get you into the contributor's team. The main ongoing tasks are all listed on the ROADMAP.
 7.  PRD stuck / unable to access/ connection interrupted
     1.  The official openai base_url address is `https://api.openai.com/v1`
-    2.  If the official openai base_url address is inaccessible in your environment (this can be verified with curl), it's recommended to configure using base_url to other "reverse-proxy" provider such as openai-forward. For instance, `openai base_url: "``https://api.openai-forward.com/v1``"`
+    2.  If the official openai base_url address is inaccessible in your environment (this can be verified with curl), it's recommended to configure using base_url to other "reverse-proxy" provider such as openai-forward. For instance, `openai base_url: "https://api.openai-forward.com/v1"`
     3.  If the official openai base_url address is inaccessible in your environment (again, verifiable via curl), another option is to configure the llm.proxy in the `config2.yaml`. This way, you can access the official openai base_url via a local proxy. If you don't need to access via a proxy, please do not enable this configuration; if accessing through a proxy is required, modify it to the correct proxy address.
-    4.  Note: OpenAI's default API design ends with a v1. An example of the correct configuration is: `base_url: "https://api.openai.com/v1"
+    4.  Note: OpenAI's default API design ends with a v1. An example of the correct configuration is: `base_url: "https://api.openai.com/v1"`
 8.  Get reply: "Absolutely! How can I assist you today?"
     1.  Did you use Chi or a similar service? These services are prone to errors, and it seems that the error rate is higher when consuming 3.5k-4k tokens in GPT-4
 9.  What does Max token mean?


### PR DESCRIPTION
**Features**

- Fix malformed inline code formatting for `base_url` examples in `docs/FAQ-EN.md`.

**Feature Docs**

Not applicable; this is a docs-only Markdown formatting fix.

**Influence**

- Improves readability of existing FAQ configuration examples.
- No runtime, API, or behavior changes.

**Result**

- `git diff --check`
- `python3` sanity check confirmed balanced backticks on the affected FAQ lines.

**Other**

Duplicate check: searched open PRs/issues for the exact FAQ/base_url wording and broader `base_url`/FAQ Markdown terms; no duplicate ownership conflict was found.

AI assistance disclosure: this PR was prepared with AI assistance from OpenAI Codex and manually checked before submission.
