### PR TITLE
Security: Fix command injection via mermaid.path config (#2037)

### DIFF
--- a/metagpt/utils/common.py
+++ b/metagpt/utils/common.py
@@ -22,8 +22,8 @@ import inspect
 import json
 import mimetypes
 import os
-import platform
 import re
+import shutil
 import sys
 import time
 import traceback
@@ -56,12 +56,9 @@ def check_cmd_exists(command) -> int:
     :param command: 待检查的命令
     :return: 如果命令存在，返回0，如果不存在，返回非0
     """
-    if platform.system().lower() == "windows":
-        check_command = "where " + command
-    else:
-        check_command = "command -v " + command + ' >/dev/null 2>&1 || { echo >&2 "no mermaid"; exit 1; }'
-    result = os.system(check_command)
-    return result
+    if not command:
+        return 1
+    return 0 if shutil.which(command) else 1
 
 
 def require_python_version(req_version: Tuple) -> bool:

--- a/metagpt/utils/mermaid.py
+++ b/metagpt/utils/mermaid.py
@@ -80,8 +80,8 @@ async def mermaid_to_file(
                 ]
             else:
                 commands = [config.mermaid.path, "-i", str(tmp), "-o", output_file, "-w", str(width), "-H", str(height)]
-            process = await asyncio.create_subprocess_shell(
-                " ".join(commands), stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+            process = await asyncio.create_subprocess_exec(
+                *commands, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
             )
 
             stdout, stderr = await process.communicate()

--- a/tests/metagpt/utils/test_common.py
+++ b/tests/metagpt/utils/test_common.py
@@ -121,6 +121,25 @@ class TestGetProjectRoot:
             else:
                 assert result != 0
 
+    def test_check_cmd_exists_rejects_shell_injection(self, tmp_path):
+        """Regression test for issue #2037: command-injection via shell metacharacters.
+
+        check_cmd_exists must not invoke a shell on the input. Payloads containing
+        shell metacharacters must (a) return non-zero and (b) not execute the
+        smuggled command.
+        """
+        marker = tmp_path / "INJECTED"
+        payloads = [
+            "",
+            f"ls; touch {marker}",
+            f"ls && touch {marker}",
+            f"ls $(touch {marker})",
+            f"ls | tee {marker}",
+        ]
+        for payload in payloads:
+            assert check_cmd_exists(payload) != 0, f"payload should be rejected: {payload!r}"
+            assert not marker.exists(), f"shell injection executed for payload: {payload!r}"
+
     @pytest.mark.parametrize(("filename", "want"), [("1.md", "File list"), ("2.md", "Language"), ("3.md", "# TODOs")])
     @pytest.mark.asyncio
     async def test_parse_data_exception(self, filename, want):

--- a/tests/metagpt/utils/test_mermaid.py
+++ b/tests/metagpt/utils/test_mermaid.py
@@ -6,6 +6,10 @@
 @File    : test_mermaid.py
 """
 
+import os
+import sys
+from types import SimpleNamespace
+
 import pytest
 
 from metagpt.const import DEFAULT_WORKSPACE_ROOT
@@ -36,6 +40,40 @@ async def test_mermaid(engine, suffixes, context, mermaid_mocker):
         for ext in exts:
             assert save_to.with_suffix(ext).exists()
             save_to.with_suffix(ext).unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="shell script fake mmdc is POSIX-only")
+async def test_mermaid_to_file_rejects_path_injection(tmp_path):
+    """Regression test for issue #2037: command-injection via config.mermaid.path.
+
+    Drives mermaid_to_file with a malicious path containing shell metacharacters
+    and asserts the smuggled command does NOT execute. Uses a fake mmdc binary
+    so the test does not depend on the real Mermaid CLI being installed.
+    """
+    fake_mmdc = tmp_path / "mmdc"
+    fake_mmdc.write_text("#!/usr/bin/env bash\nexit 0\n")
+    os.chmod(fake_mmdc, 0o755)
+
+    marker = tmp_path / "INJECTED"
+    malicious_path = f"{fake_mmdc}; touch {marker} #"
+
+    config = SimpleNamespace(
+        mermaid=SimpleNamespace(path=malicious_path, puppeteer_config="", engine="nodejs")
+    )
+
+    rc = await mermaid_to_file(
+        engine="nodejs",
+        mermaid_code="graph TD; A-->B;",
+        output_file_without_suffix=str(tmp_path / "out"),
+        config=config,
+        suffixes=["svg"],
+    )
+
+    # Either check_cmd_exists rejects the path (-1) or subprocess_exec raises
+    # FileNotFoundError. In both cases the marker file must not exist.
+    assert not marker.exists(), "shell injection executed — path was passed through a shell"
+    assert rc != 0, "malicious path should not produce a successful rendering"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Features**

Closes #2037. Fixes two unsafe shell-execution sites that allowed arbitrary command injection via the user-controllable `mermaid.path` configuration value.

- `metagpt/utils/common.py::check_cmd_exists` — replace `os.system()` + shell string concat with `shutil.which()`. Same return-code contract (0 if found, non-zero if not), no shell involved, cross-platform.
- `metagpt/utils/mermaid.py::mermaid_to_file` — replace `asyncio.create_subprocess_shell(" ".join(commands))` with `asyncio.create_subprocess_exec(*commands)`. argv passed directly, no shell parsing.

This incidentally also closes the same class of injection via `config.mermaid.puppeteer_config`, which was previously joined into the same shell string.

**Influence**

No behavior change for legitimate paths (`"mmdc"`, `/usr/local/bin/mmdc`, etc.). The default install / happy path is completely unaffected. Only inputs containing shell metacharacters are now rejected instead of silently executed by the shell.

Threat surface this protects against:
- Multi-tenant deployments where users supply configs
- Shared templates / examples that ship a `config2.yaml`
- Supply-chain attacks via dependency-provided configs
- CI pipelines that load untrusted fixture configs

**Result**

Added two regression tests:
- `tests/metagpt/utils/test_common.py::test_check_cmd_exists_rejects_shell_injection` — covers 5 metacharacter payloads (empty string, `;`, `&&`, `\$()`, `|`); asserts non-zero return AND that the smuggled command never executes.
- `tests/metagpt/utils/test_mermaid.py::test_mermaid_to_file_rejects_path_injection` — drives `mermaid_to_file` end-to-end with the exact payload format from issue #2037 using a fake mmdc binary in `tmp_path`; asserts no payload execution.

Verification performed locally:
- The issue's exact PoC payload (`\"mmdc; /bin/bash -c '...' #'\"`) does not execute against the patched code; the same payload against the pre-patch code triggers the embedded command.
- Happy path (legitimate `mmdc`) still runs and produces an SVG.
- All other existing tests in `test_common.py` / `test_mermaid.py` behave identically to `main` (the 3 pre-existing failures in `test_parse_data_exception[2]`, `test_parse_recipient[2]`, `test_require_python_version[2]` reproduce on unmodified `main` and are unrelated to this change).
- Ruff clean.

**Other**

Mirrors the approach used in already-open security-fix PRs (#1983, #2026, #2035). Only new import is `shutil` (Python stdlib) — no `requirements.txt` change needed.