### PR TITLE
fix: extract multi-digit state indices in extract_state_value_from_output

### DIFF
--- a/metagpt/utils/repair_llm_raw_output.py
+++ b/metagpt/utils/repair_llm_raw_output.py
@@ -349,10 +349,9 @@ def extract_state_value_from_output(content: str) -> str:
     """
     content = content.strip()  # deal the output cases like " 0", "0\n" and so on.
     pattern = (
-        r"(?<!-)[0-9]"  # TODO find the number using a more proper method not just extract from content using pattern
+        r"-?\d+"  # extract the first (possibly multi-digit or negative) integer from the output
     )
     matches = re.findall(pattern, content, re.DOTALL)
-    matches = list(set(matches))
     state = matches[0] if len(matches) > 0 else "-1"
     return state
 

--- a/tests/metagpt/utils/test_repair_llm_raw_output.py
+++ b/tests/metagpt/utils/test_repair_llm_raw_output.py
@@ -386,3 +386,15 @@ def test_extract_content_from_output():
     assert output.startswith('{\n"Implementation approach"') and output.endswith(
         '"Anything UNCLEAR": "The requirement is clear to me."\n}'
     )
+
+
+def test_extract_state_value_from_output():
+    from metagpt.utils.repair_llm_raw_output import extract_state_value_from_output
+
+    # single-digit states and the "-1" no-op state are returned as-is
+    assert extract_state_value_from_output("0") == "0"
+    assert extract_state_value_from_output(" 3\n") == "3"
+    assert extract_state_value_from_output("-1") == "-1"
+    # multi-digit state indices (>= 10) must be kept whole, not split into digits
+    assert extract_state_value_from_output("10") == "10"
+    assert extract_state_value_from_output("The next state is 12.") == "12"


### PR DESCRIPTION
## Problem

`extract_state_value_from_output` is used by `Role._think` to read the next state index from an LLM's reply ([role.py](https://github.com/FoundationAgents/MetaGPT/blob/main/metagpt/roles/role.py)):

```python
pattern = r"(?<!-)[0-9]"
matches = re.findall(pattern, content, re.DOTALL)
matches = list(set(matches))
state = matches[0] if len(matches) > 0 else "-1"
```

Two issues:

1. The pattern matches a **single digit**, so a state index `>= 10` is split into separate digits. For `content == "10"` the result is `"1"` or `"0"` — never `"10"`.
2. `list(set(matches))` makes the choice **order-dependent on set hashing**, which varies with `PYTHONHASHSEED` across processes, so the returned digit is nondeterministic.

Because the caller only validates `int(next_state) in range(-1, len(self.states))`, a wrong-but-in-range digit passes silently, so any role with 10+ states can transition to the wrong state (or loop) without error.

## Fix

Match the first optionally-negative, multi-digit integer and drop the `set()` dedup:

```python
pattern = r"-?\d+"
matches = re.findall(pattern, content, re.DOTALL)
state = matches[0] if len(matches) > 0 else "-1"
```

Single-digit outputs and the `"-1"` no-op state are unchanged; multi-digit indices are now returned whole and deterministically.

## Test

Adds `test_extract_state_value_from_output` covering `"0"`, `" 3\n"`, `"-1"`, `"10"`, and `"The next state is 12."`. Without the fix the `"10"` and `"12"` cases fail (return a single digit).