### PR TITLE
fix: signal dropped environment messages

### DIFF
--- a/metagpt/environment/base_env.py
+++ b/metagpt/environment/base_env.py
@@ -192,7 +192,7 @@ class Environment(ExtEnv):
             logger.warning(f"Message no recipients: {message.dump()}")
         self.history.add(message)  # For debug
 
-        return True
+        return found
 
     async def run(self, k=1):
         """处理一次所有信息的运行

--- a/tests/metagpt/environment/test_base_env.py
+++ b/tests/metagpt/environment/test_base_env.py
@@ -15,6 +15,8 @@ from metagpt.environment.base_env import (
     mark_as_readable,
     mark_as_writeable,
 )
+from metagpt.roles.role import Role
+from metagpt.schema import Message
 
 
 class ForTestEnv(Environment):
@@ -69,3 +71,27 @@ async def test_ext_env():
 
     assert await env.read_from_api("read_api_no_param") == 15
     assert await env.read_from_api(EnvAPIAbstract(api_name="read_api", kwargs={"a": 5, "b": 5})) == 10
+
+
+def test_publish_message_returns_true_when_recipient_found():
+    env = Environment()
+    role = Role(name="Alice", profile="greeter")
+    env.add_role(role)
+
+    msg = Message(content="please process this", sent_from="Producer", send_to={"Alice"})
+
+    assert env.publish_message(msg) is True
+    assert not role.rc.msg_buffer.empty()
+    assert env.history.storage[-1] == msg
+
+
+def test_publish_message_returns_false_when_recipient_missing():
+    env = Environment()
+    role = Role(name="Alice", profile="greeter")
+    env.add_role(role)
+
+    msg = Message(content="please process this", sent_from="Producer", send_to={"NonexistentRole"})
+
+    assert env.publish_message(msg) is False
+    assert role.rc.msg_buffer.empty()
+    assert env.history.storage[-1] == msg


### PR DESCRIPTION
## Summary

  This PR fixes `Environment.publish_message` so it returns the actual delivery status instead of always returning
  `True`.

  ## Changes

  - Return `found` from `publish_message` to correctly indicate whether a matching recipient was found.
  - Preserve message history recording for both delivered and undelivered messages.
  - Add regression tests for:
    - successful delivery to an existing recipient
    - failed delivery when no recipient matches

  ## Motivation

  Previously, `publish_message` logged a warning when no recipient was found, but still returned `True`. This made
  dropped or undeliverable environment messages indistinguishable from successfully delivered ones.