### PR TITLE
Add Tavily search engine support

### DIFF
--- a/config/config2.example.yaml
+++ b/config/config2.example.yaml
@@ -56,9 +56,12 @@ repair_llm_output: true  # when the output is not a valid json, try to repair it
 proxy: "YOUR_PROXY"  # for tools like requests, playwright, selenium, etc.
 
 search:
-  api_type: "google"
+  api_type: "google"  # serpapi / serper / google / ddg / bing / tavily
   api_key: "YOUR_API_KEY"
   cse_id: "YOUR_CSE_ID"
+  # Example for Tavily (https://app.tavily.com/ for an API key):
+  # api_type: "tavily"
+  # api_key: "tvly-YOUR_API_KEY"
 
 browser:
   engine: "playwright"  # playwright/selenium

--- a/metagpt/configs/search_config.py
+++ b/metagpt/configs/search_config.py
@@ -20,6 +20,7 @@ class SearchEngineType(Enum):
     DUCK_DUCK_GO = "ddg"
     CUSTOM_ENGINE = "custom"
     BING = "bing"
+    TAVILY = "tavily"
 
 
 class SearchConfig(YamlModel):

--- a/metagpt/tools/search_engine.py
+++ b/metagpt/tools/search_engine.py
@@ -71,6 +71,9 @@ class SearchEngine(BaseModel):
         elif self.engine == SearchEngineType.BING:
             module = "metagpt.tools.search_engine_bing"
             run_func = importlib.import_module(module).BingAPIWrapper(**kwargs).run
+        elif self.engine == SearchEngineType.TAVILY:
+            module = "metagpt.tools.search_engine_tavily"
+            run_func = importlib.import_module(module).TavilyAPIWrapper(**kwargs).run
         else:
             raise NotImplementedError
         self.run_func = run_func

--- a/metagpt/tools/search_engine_tavily.py
+++ b/metagpt/tools/search_engine_tavily.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+@Time    : 2026/7/8
+@File    : search_engine_tavily.py
+@Desc    : Tavily (https://tavily.com) search engine wrapper. Tavily is a web
+           search API purpose-built for LLM agents, returning LLM-optimized
+           content. Mirrors the aiohttp-based SerpAPI/Serper wrappers so it
+           works under the existing `search_engine_mocker` test harness and
+           adds no new runtime dependency (aiohttp is already required).
+           API reference: https://docs.tavily.com/documentation/api-reference/endpoint/search
+"""
+import json
+from typing import Any, Optional
+
+import aiohttp
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+class TavilyAPIWrapper(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    api_key: str
+    url: str = "https://api.tavily.com/search"
+    # Latency/relevance tradeoff: "basic", "advanced", "fast", "ultra-fast".
+    search_depth: str = "basic"
+    # Search category: "general", "news", "finance".
+    topic: str = "general"
+    aiosession: Optional[aiohttp.ClientSession] = None
+    proxy: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_tavily(cls, values: dict) -> dict:
+        if "api_key" not in values:
+            raise ValueError(
+                "To use the Tavily search engine, make sure you provide the `api_key` when constructing an "
+                "object. You can obtain an API key from https://app.tavily.com/."
+            )
+        return values
+
+    async def run(self, query: str, max_results: int = 8, as_string: bool = True, **kwargs: Any) -> str:
+        """Run query through Tavily and parse the result asynchronously."""
+        return self._process_response(await self.results(query, max_results), as_string=as_string)
+
+    async def results(self, query: str, max_results: int = 8) -> dict:
+        """Use aiohttp to run the query through Tavily and return the raw results asynchronously."""
+        payload = self.get_payload(query, max_results)
+        headers = self.get_headers()
+
+        if not self.aiosession:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(self.url, json=payload, headers=headers, proxy=self.proxy) as response:
+                    response.raise_for_status()
+                    res = await response.json()
+        else:
+            async with self.aiosession.post(self.url, json=payload, headers=headers, proxy=self.proxy) as response:
+                response.raise_for_status()
+                res = await response.json()
+
+        return res
+
+    def get_payload(self, query: str, max_results: int) -> dict:
+        return {
+            "query": query,
+            "search_depth": self.search_depth,
+            "topic": self.topic,
+            "max_results": max_results,
+        }
+
+    def get_headers(self) -> dict:
+        return {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+
+    @staticmethod
+    def _process_response(res: dict, as_string: bool = True) -> str:
+        """Process the response from Tavily into MetaGPT's `{link, snippet, title}` shape."""
+        if "results" not in res:
+            raise ValueError(f"Got error from Tavily: {res}")
+
+        results = [
+            {"link": item.get("url"), "snippet": item.get("content"), "title": item.get("title")}
+            for item in res["results"]
+        ]
+        return json.dumps(results, ensure_ascii=False) if as_string else results
+
+
+if __name__ == "__main__":
+    import fire
+
+    fire.Fire(TavilyAPIWrapper().run)

--- a/tests/data/search_rsp_cache.json
+++ b/tests/data/search_rsp_cache.json
@@ -991,5 +991,53 @@
                 }
             ]
         }
-    ]
+    ],
+    "aiohttp-post-https://api.tavily.com/search-{\"headers\": {\"Authorization\": \"Bearer mock-tavily-key\", \"Content-Type\": \"application/json\"}, \"json\": {\"max_results\": 8, \"query\": \"metagpt\", \"search_depth\": \"basic\", \"topic\": \"general\"}}": {
+        "query": "metagpt",
+        "results": [
+            {
+                "title": "MetaGPT: The Multi-Agent Framework",
+                "url": "https://github.com/FoundationAgents/MetaGPT",
+                "content": "MetaGPT takes a one-line requirement as input and outputs user stories, competitive analysis, requirements, data structures, APIs and documents.",
+                "score": 0.95
+            },
+            {
+                "title": "MetaGPT: Meta Programming for A Multi-Agent Collaborative Framework",
+                "url": "https://arxiv.org/abs/2308.00352",
+                "content": "We introduce MetaGPT, a meta-programming framework incorporating efficient human workflows into LLM-based multi-agent collaborations.",
+                "score": 0.92
+            },
+            {
+                "title": "MetaGPT Documentation",
+                "url": "https://docs.deepwisdom.ai/main/en/",
+                "content": "MetaGPT assigns different roles to GPTs to form a collaborative software entity for complex tasks.",
+                "score": 0.88
+            }
+        ],
+        "response_time": "0.42"
+    },
+    "aiohttp-post-https://api.tavily.com/search-{\"headers\": {\"Authorization\": \"Bearer mock-tavily-key\", \"Content-Type\": \"application/json\"}, \"json\": {\"max_results\": 6, \"query\": \"metagpt\", \"search_depth\": \"basic\", \"topic\": \"general\"}}": {
+        "query": "metagpt",
+        "results": [
+            {
+                "title": "MetaGPT: The Multi-Agent Framework",
+                "url": "https://github.com/FoundationAgents/MetaGPT",
+                "content": "MetaGPT takes a one-line requirement as input and outputs user stories, competitive analysis, requirements, data structures, APIs and documents.",
+                "score": 0.95
+            },
+            {
+                "title": "MetaGPT: Meta Programming for A Multi-Agent Collaborative Framework",
+                "url": "https://arxiv.org/abs/2308.00352",
+                "content": "We introduce MetaGPT, a meta-programming framework incorporating efficient human workflows into LLM-based multi-agent collaborations.",
+                "score": 0.92
+            },
+            {
+                "title": "MetaGPT Documentation",
+                "url": "https://docs.deepwisdom.ai/main/en/",
+                "content": "MetaGPT assigns different roles to GPTs to form a collaborative software entity for complex tasks.",
+                "score": 0.88
+            }
+        ],
+        "response_time": "0.42"
+    }
 }

--- a/tests/metagpt/tools/test_search_engine.py
+++ b/tests/metagpt/tools/test_search_engine.py
@@ -37,6 +37,8 @@ class MockSearchEnine:
         (SearchEngineType.SERPER_GOOGLE, None, 6, False),
         (SearchEngineType.DUCK_DUCK_GO, None, 8, True),
         (SearchEngineType.DUCK_DUCK_GO, None, 6, False),
+        (SearchEngineType.TAVILY, None, 8, True),
+        (SearchEngineType.TAVILY, None, 6, False),
         (SearchEngineType.BING, None, 6, False),
         (SearchEngineType.CUSTOM_ENGINE, MockSearchEnine().run, 8, False),
         (SearchEngineType.CUSTOM_ENGINE, MockSearchEnine().run, 6, False),
@@ -59,6 +61,8 @@ async def test_search_engine(
         search_engine_config["cse_id"] = "mock-google-cse"
     elif search_engine_type is SearchEngineType.SERPER_GOOGLE:
         search_engine_config["api_key"] = "mock-serper-key"
+    elif search_engine_type is SearchEngineType.TAVILY:
+        search_engine_config["api_key"] = "mock-tavily-key"
 
     async def test(search_engine):
         rsp = await search_engine.run("metagpt", max_results, as_string)


### PR DESCRIPTION
Closes #1534 — Tavily support was requested there and a maintainer was receptive; here's the implementation.

**Features**

- Add [Tavily](https://tavily.com) as a `SearchEngineType` option, alongside the existing serpapi / serper / google / ddg / bing providers. Tavily is a web-search API built for LLM agents.
- New `metagpt/tools/search_engine_tavily.py` (`TavilyAPIWrapper`) calling Tavily's `POST /search` endpoint. It mirrors the existing aiohttp-based `SerperWrapper` / `SerpAPIWrapper`, so **no new runtime dependency is added** (`aiohttp` is already required) and results are normalized to MetaGPT's standard `{link, snippet, title}` shape.
- Wired into `SearchEngine._process_extra`, the `SearchEngineType` enum, and `config/config2.example.yaml`.

Usage:

```yaml
search:
  api_type: "tavily"
  api_key: "tvly-YOUR_API_KEY"   # from https://app.tavily.com/
```

**Feature Docs**

Not a large update — a single additional search provider. `config/config2.example.yaml` is updated with a Tavily example. API reference: https://docs.tavily.com/documentation/api-reference/endpoint/search

**Influence**

Additive only. No behavior change for existing engines (the default remains `SERPER_GOOGLE`). Roles that consume `SearchEngine` (e.g. `Researcher`, `SearchEnhancedQA`) can use Tavily by changing config alone.

**Result**

Extended `tests/metagpt/tools/test_search_engine.py` with two Tavily cases (`as_string` True/False), following the serper/ddg precedent, plus recorded response fixtures in `tests/data/search_rsp_cache.json` so they run fully offline — no network and no API key required — matching how the existing serper/ddg/bing providers are tested. `black`, `isort`, and `ruff` pass on the changed files.

**Other**

Search-only for now. Tavily's `include_answer` / `include_raw_content` and the `/extract`, `/crawl`, `/map` endpoints are natural follow-ups, left out of scope to keep this consistent with the single-purpose search-provider pattern.
