### PR TITLE
feat(provider): add Eden AI as an OpenAI-compatible provider

### DIFF
--- a/config/examples/edenai.yaml
+++ b/config/examples/edenai.yaml
@@ -1,0 +1,5 @@
+llm:
+  api_type: edenai
+  base_url: "https://api.edenai.run/v3"
+  api_key: "YOUR_API_KEY"
+  model: anthropic/claude-sonnet-4-5

--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -44,6 +44,7 @@ class LLMType(Enum):
     BEDROCK = "bedrock"
     ARK = "ark"  # https://www.volcengine.com/docs/82379/1263482#python-sdk
     LLAMA_API = "llama_api"
+    EDENAI = "edenai"  # Eden AI: EU-hosted, OpenAI-compatible gateway to 100+ models
 
     def __missing__(self, key):
         return self.OPENAI

--- a/metagpt/provider/openai_api.py
+++ b/metagpt/provider/openai_api.py
@@ -53,6 +53,7 @@ from metagpt.utils.token_counter import (
         LLMType.SILICONFLOW,
         LLMType.OPENROUTER,
         LLMType.LLAMA_API,
+        LLMType.EDENAI,
     ]
 )
 class OpenAILLM(BaseLLM):


### PR DESCRIPTION
## Description

Adds **Eden AI** (https://www.edenai.co) as an OpenAI-compatible provider. Eden AI is an EU-hosted gateway that exposes 100+ models from many providers (OpenAI, Anthropic, Google, Mistral, DeepSeek, …) through a single endpoint and API key. Models use the `provider/model` naming scheme.

Registered the same way as the other OpenAI-compatible providers (Moonshot, Mistral, DeepSeek, OpenRouter, SiliconFlow, …), which all reuse `OpenAILLM`:

- `metagpt/configs/llm_config.py` — new `LLMType.EDENAI`
- `metagpt/provider/openai_api.py` — `LLMType.EDENAI` added to `OpenAILLM`'s `@register_provider([...])` list (base URL taken from config)
- `config/examples/edenai.yaml` — example config

## Example config

```yaml
llm:
  api_type: edenai
  base_url: "https://api.edenai.run/v3"
  api_key: "YOUR_API_KEY"
  model: anthropic/claude-sonnet-4-5
```

## Testing

- `LLMType.EDENAI` imports cleanly; `OpenAILLM`'s `@register_provider` list includes `LLMType.EDENAI`, so `edenai` routes to the shared OpenAI-compatible client (same mechanism as the sibling providers).
- Example YAML validated.
- Verified live against the Eden AI API (`/v3/chat/completions` → 200).
- API key comes from config (`api_key`); never hardcoded.
