### PR TITLE
fix: confine Editor paths to workspace (prevent path traversal via model-controlled absolute paths)

### DIFF
--- a/metagpt/tools/libs/editor.py
+++ b/metagpt/tools/libs/editor.py
@@ -1094,12 +1094,25 @@ class Editor(BaseModel):
         return "\n".join(res_list)
 
     def _try_fix_path(self, path: Union[Path, str]) -> Path:
-        """Tries to fix the path if it is not absolute."""
+        """Tries to fix the path if it is not absolute, and confines it to the workspace."""
         if not isinstance(path, Path):
             path = Path(path)
         if not path.is_absolute():
             path = self.working_dir / path
-        return path
+        # Confine resolved path to the workspace to prevent path traversal.
+        # Without this, a model (or a prompt-injected agent) can read/write
+        # arbitrary files via absolute paths like /etc/passwd or /root/.bashrc.
+        resolved = path.resolve()
+        workspace_resolved = self.working_dir.resolve()
+        try:
+            resolved.relative_to(workspace_resolved)
+        except ValueError:
+            raise ValueError(
+                f"Path '{path}' resolves to '{resolved}', which is outside the "
+                f"workspace '{workspace_resolved}'. Editor access is confined to "
+                f"the workspace for security."
+            )
+        return resolved
 
     @staticmethod
     async def similarity_search(query: str, path: Union[str, Path]) -> List[str]:


### PR DESCRIPTION
## Summary

The `Editor._try_fix_path` method accepted absolute paths without checking if they were inside the workspace. A model (or a prompt-injected agent) could read/write **arbitrary files on the host** via paths like `/etc/passwd`, `/root/.bashrc`, or `/root/.ssh/authorized_keys`.

## The vulnerability

**File:** `metagpt/tools/libs/editor.py`, method `_try_fix_path`

```python
def _try_fix_path(self, path):
    if not path.is_absolute():
        path = self.working_dir / path
    return path  # absolute paths pass through with no confinement
```

The Editor tool is available to all agents that inherit from `RoleZero` (Architect, Engineer, etc.). These agents consume inter-agent messages (PRDs, design docs) whose content originates from model output. A prompt-injected requirement or PRD can instruct the agent to:

- `Editor.read("/root/.ssh/id_rsa")` — exfiltrate private keys
- `Editor.write("/root/.bashrc", "...")` — persistent backdoor
- `Editor.write("/etc/cron.d/evil", "...")` — scheduled execution

## PoC

Deterministic PoC reproduces the vulnerable `_try_fix_path` logic verbatim:

```
[1] Relative 'src/main.py':
    Resolved to: /workspace/src/main.py
    In workspace: True

[2] Absolute paths outside workspace:
    /etc/passwd                              -> /etc/passwd          ESCAPED
    /root/.bashrc                            -> /root/.bashrc         ESCAPED
    /root/.ssh/authorized_keys               -> /root/.ssh/authorized_keys  ESCAPED
    /etc/cron.d/evil                         -> /etc/cron.d/evil     ESCAPED

[3] Traversal '../../../etc/passwd':
    Resolved to: /etc/passwd
    ESCAPED

[4] Write test: Editor.write('/root/.bashrc', 'PWNED')
    Would succeed — path is outside workspace but _try_fix_path allows it
```

Exit 0 = vulnerability confirmed.

## Fix

Add `Path.resolve()` + `relative_to(workspace)` check that raises `ValueError` for any path resolving outside the workspace.

### Verified

```
src/main.py          -> /workspace/src/main.py     OK (relative, inside)
file.py              -> /workspace/file.py         OK (relative, inside)
/etc/passwd          -> blocked by ValueError       OK (absolute, outside)
/root/.bashrc        -> blocked by ValueError       OK (absolute, outside)
../../../etc/passwd  -> blocked by ValueError       OK (traversal)
```

No regression: all workspace-relative and workspace-absolute paths pass. Only paths resolving outside the workspace are blocked.

## Checklist

- [x] Code compiles
- [x] PoC exit 0 — vulnerability confirmed
- [x] Fix verified — all attack paths blocked, no regression
- [x] `ruff check` passes (line-length 120)
- [x] Self-reviewed
