### PR TITLE
fix(bedrock): make llama2 BOS a string, not a 1-tuple

### DIFF
--- a/metagpt/provider/bedrock/utils.py
+++ b/metagpt/provider/bedrock/utils.py
@@ -103,7 +103,7 @@ SUPPORT_STREAM_MODELS = {
 
 
 def messages_to_prompt_llama2(messages: list[dict]) -> str:
-    BOS = ("<s>",)
+    BOS = "<s>"
     B_INST, E_INST = "[INST]", "[/INST]"
     B_SYS, E_SYS = "<<SYS>>\n", "\n<</SYS>>\n\n"
 


### PR DESCRIPTION
## Problem

`messages_to_prompt_llama2` (`metagpt/provider/bedrock/utils.py`) defines its beginning-of-sequence token as a **one-element tuple**, not a string:

```python
def messages_to_prompt_llama2(messages: list[dict]) -> str:
    BOS = ("<s>",)          # trailing comma -> tuple, not str
    ...
    prompt = f"{BOS}"       # renders the tuple repr
```

Because `BOS` is a tuple, `prompt = f"{BOS}"` interpolates its `repr`, so every Llama-2 / Mistral prompt begins with the literal text `('<s>',)` instead of the `<s>` BOS token.

The sibling `messages_to_prompt_llama3` in the same file does the same thing correctly with a plain string, which confirms the intent:

```python
def messages_to_prompt_llama3(messages: list[dict]) -> str:
    BOS = "<|begin_of_text|>"   # string
    prompt = f"{BOS}"
```

The malformed prompt flows through `BaseBedrockProvider.get_request_body` for the Mistral and Meta (Llama-2) providers in `bedrock_provider.py`, so every such Amazon Bedrock request was sent a prompt starting with `('<s>',)`.

## Reproduction

```python
BOS = ("<s>",)
prompt = f"{BOS}" + "[INST] hi [/INST]"
```

| | prompt starts with |
|---|---|
| before (`BOS = ("<s>",)`) | `('<s>',)[INST] hi [/INST]` — `startswith("<s>")` → `False` ❌ |
| after (`BOS = "<s>"`) | `<s>[INST] hi [/INST]` — `startswith("<s>")` → `True` ✅ |

## Fix

Drop the trailing comma so `BOS` is the string it is used as:

```python
BOS = "<s>"
```

One character. `python -m py_compile` passes.
