### PR TITLE
docs: add Persian (Farsi) README and install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 [ <b>En</b> |
 <a href="docs/README_CN.md">中</a> |
 <a href="docs/README_FR.md">Fr</a> |
-<a href="docs/README_JA.md">日</a> ]
+<a href="docs/README_JA.md">日</a> |
+<a href="docs/README_FA.md">فا</a> ]
 <b>Assign different roles to GPTs to form a collaborative entity for complex tasks.</b>
 </p>
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -8,7 +8,8 @@
 [ <a href="../README.md">En</a> |
 <b>中</b> |
 <a href="README_FR.md">Fr</a> |
-<a href="README_JA.md">日</a> ]
+<a href="README_JA.md">日</a> |
+<a href="README_FA.md">فا</a> ]
 <b>使 GPTs 组成软件公司，协作处理更复杂的任务</b>
 </p>
 

--- a/docs/README_FA.md
+++ b/docs/README_FA.md
@@ -1,0 +1,124 @@
+# MetaGPT: فریم‌ورک چندعامله
+
+<p align="center">
+<a href=""><img src="resources/MetaGPT-new-log.png" alt="لوگوی MetaGPT: GPT را در قالب یک شرکت نرم‌افزاری همکاری‌دهنده به کار بیندازید." width="150px"></a>
+</p>
+
+<p align="center">
+[ <a href="../README.md">En</a> |
+<a href="README_CN.md">中</a> |
+<a href="README_FR.md">Fr</a> |
+<a href="README_JA.md">日</a> |
+<b>فا</b> ]
+<b>نقش‌های مختلف به GPTها بدهید تا برای کارهای پیچیده یک تیم همکاری بسازند.</b>
+</p>
+
+<p align="center">
+<a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
+<a href="https://discord.gg/DYn29wFk9z"><img src="https://img.shields.io/badge/Join-Discord-gGnrXvVz7a?logo=discord" alt="Discord Follow"></a>
+<a href="https://twitter.com/MetaGPT_"><img src="https://img.shields.io/twitter/follow/MetaGPT?style=social" alt="Twitter Follow"></a>
+</p>
+
+## MetaGPT چیست؟
+
+MetaGPT یک **نیازمندی یک‌خطی** می‌گیرد و خروجی‌هایی مثل **داستان کاربر، تحلیل رقبا، PRD، ساختار داده، API و فایل‌های پروژه** تولید می‌کند.
+
+درون سیستم، نقش‌هایی مثل **مدیر محصول، معمار، مدیر پروژه و مهندس** با SOPهای (رویه‌های عملیاتی استاندارد) هماهنگ کار می‌کنند.
+
+`Code = SOP(Team)` فلسفهٔ اصلی است: SOP را عملیاتی می‌کند و روی تیمی از LLMها اعمال می‌کند.
+
+![شرکت نرم‌افزاری متشکل از نقش‌های LLM](resources/software_company_cd.jpeg)
+
+<p align="center">نمای کلی شرکت نرم‌افزاری چندعامله (در حال تکمیل تدریجی)</p>
+
+## نصب
+
+> Python **۳.۹ تا ۳.۱۱** لازم است. بررسی: `python --version`  
+> با conda: `conda create -n metagpt python=3.9 && conda activate metagpt`
+
+```bash
+pip install --upgrade metagpt
+metagpt --init-config   # ~/.metagpt/config2.yaml را می‌سازد
+metagpt --language fa "یک بازی 2048 بساز"   # خروجی در ./workspace
+```
+
+یا با متغیر محیطی:
+
+```bash
+set METAGPT_LANG=fa
+metagpt "یک بازی 2048 بساز"
+```
+
+### پیکربندی فارسی
+
+فایل `~/.metagpt/config2.yaml`:
+
+```yaml
+language: "Persian"   # یا fa / Farsi / فارسی
+
+llm:
+  api_type: "openai"
+  model: "gpt-4-turbo"
+  base_url: "https://api.openai.com/v1"
+  api_key: "YOUR_API_KEY"
+```
+
+### استفاده به‌عنوان کتابخانه
+
+```python
+from metagpt.software_company import generate_repo
+
+repo_path = generate_repo("یک بازی 2048 بساز", language="Persian")
+print(repo_path)
+```
+
+### Data Interpreter
+
+```python
+import asyncio
+from metagpt.roles.di.data_interpreter import DataInterpreter
+
+async def main():
+    di = DataInterpreter()
+    await di.run("تحلیل داده مجموعه Iris در sklearn، همراه با نمودار")
+
+asyncio.run(main())
+```
+
+راهنمای نصب CLI: [cli_install_fa.md](install/cli_install_fa.md)
+
+## پشتیبانی فارسی
+
+MetaGPT از فارسی در این بخش‌ها پشتیبانی می‌کند:
+
+| بخش | وضعیت |
+|-----|--------|
+| README و راهنمای نصب | فارسی |
+| CLI (`--language fa` / `METAGPT_LANG=fa`) | فارسی |
+| تشخیص زبان در RoleZero | فارسی + fallback از config |
+| تحلیل نیازمندی | مثال فارسی |
+| تعامل انسانی (human interaction) | فارسی |
+| خروجی عامل‌ها | با نیازمندی فارسی یا `language: Persian` |
+
+## آموزش و مستندات
+
+- [مستندات انگلیسی](https://docs.deepwisdom.ai/main/en/)
+- [شروع سریع](https://docs.deepwisdom.ai/main/en/guide/get_started/quickstart.html)
+- [آموزش عامل](https://docs.deepwisdom.ai/main/en/guide/tutorials/agent_101.html)
+
+## پشتیبانی
+
+- [Discord](https://discord.gg/ZRHeExS6xv)
+- [Issues در GitHub](https://github.com/FoundationAgents/MetaGPT/issues)
+
+## ارجاع
+
+```bibtex
+@inproceedings{hong2024metagpt,
+      title={Meta{GPT}: Meta Programming for A Multi-Agent Collaborative Framework},
+      author={Sirui Hong and Mingchen Zhuge and Jonathan Chen and others},
+      booktitle={The Twelfth International Conference on Learning Representations},
+      year={2024},
+      url={https://openreview.net/forum?id=VtmBAGCN7o}
+}
+```

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -9,7 +9,8 @@
 [ <a href="../README.md">En</a> |
 <a href="README_CN.md">中</a> |
 <b>Fr</b> |
-<a href="README_JA.md">日</a> ]
+<a href="README_JA.md">日</a> |
+<a href="README_FA.md">فا</a> ]
 <b>Assigner différents rôles aux GPTs pour former une entité collaborative capable de gérer des tâches complexes.</b>
 </p> 
 

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -8,7 +8,8 @@
 [ <a href="../README.md">En</a> |
 <a href="README_CN.md">中</a> |
 <a href="README_FR.md">Fr</a> |
-<b>日</b> ]
+<b>日</b> |
+<a href="README_FA.md">فا</a> ]
 <b>GPT にさまざまな役割を割り当てることで、複雑なタスクのための共同ソフトウェアエンティティを形成します。</b>
 </p>
 

--- a/docs/install/cli_install_fa.md
+++ b/docs/install/cli_install_fa.md
@@ -1,0 +1,64 @@
+# نصب MetaGPT از خط فرمان (فارسی)
+
+## پیش‌نیازها
+
+- Python 3.9، 3.10 یا 3.11
+- [Node.js](https://nodejs.org/) و [pnpm](https://pnpm.io/)
+- کلید API برای مدل زبانی (OpenAI، Azure، Ollama و غیره)
+
+## نصب
+
+```bash
+pip install --upgrade metagpt
+```
+
+یا از سورس:
+
+```bash
+git clone https://github.com/FoundationAgents/MetaGPT.git
+cd MetaGPT
+pip install --upgrade -e .
+```
+
+## پیکربندی
+
+```bash
+metagpt --init-config
+```
+
+فایل `~/.metagpt/config2.yaml` را ویرایش کنید:
+
+```yaml
+language: "Persian"
+
+llm:
+  api_type: "openai"
+  model: "gpt-4-turbo"
+  base_url: "https://api.openai.com/v1"
+  api_key: "YOUR_API_KEY"
+```
+
+## اجرا به فارسی
+
+```bash
+# روش ۱: فلگ زبان
+metagpt --language fa "یک بازی مار با پایتون بساز"
+
+# روش ۲: متغیر محیطی (رابط CLI هم فارسی می‌شود)
+set METAGPT_LANG=fa
+metagpt "یک اپلیکیشن todo بساز"
+```
+
+## خروجی
+
+پروژه در پوشه `./workspace` ساخته می‌شود.
+
+## عیب‌یابی
+
+| مشکل | راه‌حل |
+|------|--------|
+| `Missing argument 'IDEA'` | ایده را داخل کوتیشن بنویسید |
+| خروجی انگلیسی | `language: Persian` در config یا `--language fa` |
+| خطای API | `base_url` و `api_key` را بررسی کنید |
+
+مستندات کامل: [README_FA.md](../README_FA.md)


### PR DESCRIPTION
**Features**

- Add `docs/README_FA.md` (Persian README, following README_CN/FR/JA pattern)
- Add `docs/install/cli_install_fa.md` (Persian CLI install guide)
- Add **فا** language switcher links in En/CN/FR/JA README files

**Feature Docs**

- Persian README: `docs/README_FA.md`
- Persian install guide: `docs/install/cli_install_fa.md`

**Influence**

- Documentation-only PR; no runtime behavior changes
- Part 1 of 2 for Persian localization (see issue #2113)
- Runtime/CLI support will follow in a separate PR

**Result**

- N/A (docs only)

Closes FoundationAgents/MetaGPT#2113 partially — runtime PR to follow.

**Other**

- Split from a larger localization effort at maintainer preference
