### PR TITLE
feat: add Persian (Farsi) runtime and CLI localization

### DIFF
--- a/config/config2.example.yaml
+++ b/config/config2.example.yaml
@@ -1,3 +1,7 @@
+# UI and agent response language: English | Persian | Chinese | French | Japanese
+# Aliases for Persian: fa, fa-IR, Farsi, فارسی
+language: "English"
+
 llm:
   api_type: "openai"  # or azure / ollama / groq etc.
   base_url: "YOUR_BASE_URL"

--- a/metagpt/actions/analyze_requirements.py
+++ b/metagpt/actions/analyze_requirements.py
@@ -42,6 +42,14 @@ Outputs:
 [User Restrictions] : You must ignore create PRD and TRD.
 [Language Restrictions] : The response, message and instruction must be in English.
 [Programming Language] : HTML (*.html), CSS (*.css), and JavaScript (*.js)
+
+Example 4
+Requirements:
+یک بازی 2048 با پایتون بساز. PRD ننویس.
+Outputs:
+[User Restrictions] : PRD ننویس.
+[Language Restrictions] : The response, message and instruction must be in Persian.
+[Programming Language] : Python
 """
 
 INSTRUCTIONS = """

--- a/metagpt/locale/__init__.py
+++ b/metagpt/locale/__init__.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Lightweight localization for MetaGPT CLI and user-facing messages."""
+
+import os
+from typing import Optional
+
+from metagpt.locale.messages import MESSAGES, normalize_language
+
+_current_language = normalize_language(os.environ.get("METAGPT_LANG", "English"))
+
+
+def set_language(lang: Optional[str]) -> str:
+    """Set active UI language and return the canonical name."""
+    global _current_language
+    _current_language = normalize_language(lang)
+    return _current_language
+
+
+def get_language() -> str:
+    return _current_language
+
+
+def init_locale(lang: Optional[str] = None) -> str:
+    """Initialize locale from explicit arg, env var, or config.language."""
+    if lang:
+        return set_language(lang)
+    env_lang = os.environ.get("METAGPT_LANG")
+    if env_lang:
+        return set_language(env_lang)
+    try:
+        from metagpt.config2 import config
+
+        if config.language and config.language != "English":
+            return set_language(config.language)
+    except Exception:
+        pass
+    return _current_language
+
+
+def t(key: str, **kwargs) -> str:
+    """Translate a message key for the active language."""
+    lang = normalize_language(_current_language)
+    catalog = MESSAGES.get(lang, MESSAGES["English"])
+    text = catalog.get(key, MESSAGES["English"].get(key, key))
+    return text.format(**kwargs) if kwargs else text
+
+
+__all__ = ["init_locale", "set_language", "get_language", "normalize_language", "t"]

--- a/metagpt/locale/messages.py
+++ b/metagpt/locale/messages.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Localized UI strings for MetaGPT CLI and human interaction."""
+
+from typing import Optional
+
+PERSIAN_ALIASES = frozenset(
+    {
+        "fa",
+        "fa_ir",
+        "fa-ir",
+        "persian",
+        "farsi",
+        "فارسی",
+        "پارسی",
+    }
+)
+
+ENGLISH_ALIASES = frozenset({"en", "en_us", "en-us", "english"})
+
+MESSAGES = {
+    "English": {
+        "missing_idea": "Missing argument 'IDEA'. Run 'metagpt --help' for more information.",
+        "config_backed_up": "Existing configuration file backed up at {path}",
+        "config_initialized": "Configuration file initialized at {path}",
+        "multilines_input_hint": "Enter your content, use Ctrl-D or Ctrl-Z (windows) to save it.",
+        "input_type_error": "Input content can't meet required_type: {req_type}, please Re-Enter.",
+        "input_num_prompt": "Enter the num of the interaction key: ",
+        "interact_header": (
+            "\n{interact_type} interaction\n"
+            "Interaction data: {fields}\n"
+            "Enter the num to interact with corresponding field or `q`/`quit`/`exit` to stop interaction.\n"
+            "Enter the field content until it meet field required type.\n"
+        ),
+        "interact_stop": "Stop human interaction",
+        "interact_field": "You choose to interact with field: {field}, and do a `{interact_type}` operation.",
+        "review_prompt": "Enter your review comment: ",
+        "revise_prompt": "Enter your revise content: ",
+        "cli_startup_help": "Start a new project.",
+        "cli_idea_help": "Your innovative idea, such as 'Create a 2048 game.'",
+        "cli_investment_help": "Dollar amount to invest in the AI company.",
+        "cli_n_round_help": "Number of rounds for the simulation.",
+        "cli_code_review_help": "Whether to use code review.",
+        "cli_run_tests_help": "Whether to enable QA for adding & running tests.",
+        "cli_implement_help": "Enable or disable code implementation.",
+        "cli_project_name_help": "Unique project name, such as 'game_2048'.",
+        "cli_inc_help": "Incremental mode. Use it to coop with existing repo.",
+        "cli_project_path_help": "Directory path of the old version project for incremental requirements.",
+        "cli_reqa_file_help": "Source file name for rewriting the quality assurance code.",
+        "cli_max_auto_summarize_help": (
+            "Maximum auto-invocations of 'SummarizeCode' (-1 = unlimited). For debugging."
+        ),
+        "cli_recover_path_help": "Recover the project from existing serialized storage.",
+        "cli_init_config_help": "Initialize the configuration file for MetaGPT.",
+        "cli_language_help": "UI language: English or Persian (fa). Also set via METAGPT_LANG or config language.",
+        "cli_startup_desc": "Run a startup. Be a boss.",
+    },
+    "Persian": {
+        "missing_idea": "آرگومان «IDEA» وارد نشده است. برای راهنما دستور «metagpt --help» را اجرا کنید.",
+        "config_backed_up": "فایل پیکربندی قبلی در {path} پشتیبان‌گیری شد.",
+        "config_initialized": "فایل پیکربندی در {path} ایجاد شد.",
+        "multilines_input_hint": "متن خود را وارد کنید. برای ذخیره از Ctrl-D یا Ctrl-Z (ویندوز) استفاده کنید.",
+        "input_type_error": "ورودی با نوع موردنیاز ({req_type}) سازگار نیست. دوباره وارد کنید.",
+        "input_num_prompt": "شماره فیلد تعاملی را وارد کنید: ",
+        "interact_header": (
+            "\nتعامل {interact_type}\n"
+            "داده‌های تعامل: {fields}\n"
+            "شماره فیلد را وارد کنید یا با `q`/`quit`/`exit` تعامل را متوقف کنید.\n"
+            "محتوای فیلد را تا رسیدن به نوع صحیح وارد کنید.\n"
+        ),
+        "interact_stop": "تعامل با کاربر متوقف شد",
+        "interact_field": "فیلد «{field}» انتخاب شد. عملیات «{interact_type}» انجام می‌شود.",
+        "review_prompt": "نظر بازبینی خود را وارد کنید: ",
+        "revise_prompt": "متن اصلاح‌شده را وارد کنید: ",
+        "cli_startup_help": "شروع یک پروژه جدید.",
+        "cli_idea_help": "ایدهٔ نوآورانهٔ شما، مثلاً «یک بازی 2048 بساز».",
+        "cli_investment_help": "مبلغ سرمایه‌گذاری (دلار) در شرکت هوش مصنوعی.",
+        "cli_n_round_help": "تعداد دورهای شبیه‌سازی.",
+        "cli_code_review_help": "فعال‌سازی بازبینی کد.",
+        "cli_run_tests_help": "فعال‌سازی QA برای افزودن و اجرای تست‌ها.",
+        "cli_implement_help": "فعال یا غیرفعال کردن پیاده‌سازی کد.",
+        "cli_project_name_help": "نام یکتا برای پروژه، مثلاً game_2048.",
+        "cli_inc_help": "حالت افزایشی؛ برای همکاری با مخزن موجود.",
+        "cli_project_path_help": "مسیر پروژهٔ قبلی برای نیازمندی‌های افزایشی.",
+        "cli_reqa_file_help": "نام فایل منبع برای بازنویسی کد تضمین کیفیت.",
+        "cli_max_auto_summarize_help": "حداکثر اجرای خودکار SummarizeCode (‎-1 = نامحدود). برای دیباگ.",
+        "cli_recover_path_help": "بازیابی پروژه از حافظهٔ سریال‌شده.",
+        "cli_init_config_help": "ایجاد فایل پیکربندی MetaGPT.",
+        "cli_language_help": "زبان رابط: English یا Persian (fa). از METAGPT_LANG یا language در config هم پشتیبانی می‌شود.",
+        "cli_startup_desc": "اجرای استارتاپ. رئیس باشید.",
+    },
+}
+
+
+def normalize_language(lang: Optional[str]) -> str:
+    """Map locale aliases to canonical language names."""
+    if not lang:
+        return "English"
+    key = lang.strip().lower().replace(" ", "_")
+    if key in PERSIAN_ALIASES or lang.strip() in PERSIAN_ALIASES:
+        return "Persian"
+    if key in ENGLISH_ALIASES:
+        return "English"
+    if lang.strip() in ("Persian", "English", "Chinese", "French", "Japanese"):
+        return lang.strip()
+    return lang.strip() or "English"

--- a/metagpt/prompts/di/role_zero.py
+++ b/metagpt/prompts/di/role_zero.py
@@ -262,6 +262,10 @@ DETECT_LANGUAGE_PROMPT = """
 The requirement is:
 {requirement}
 
+Default language (when the requirement is ambiguous): {default_language}
+
 Which Natural Language must you respond in?
-Output only the language type.
+Recognize Persian, Farsi, and فارسی as "Persian".
+Recognize Chinese and 中文 as "Chinese".
+Output only the language name in English (e.g. English, Chinese, Persian, French).
 """

--- a/metagpt/roles/di/role_zero.py
+++ b/metagpt/roles/di/role_zero.py
@@ -207,8 +207,14 @@ class RoleZero(Role):
 
         if not self.planner.plan.goal:
             self.planner.plan.goal = self.get_memories()[-1].content
-            detect_language_prompt = DETECT_LANGUAGE_PROMPT.format(requirement=self.planner.plan.goal)
+            default_language = self.config.language or "English"
+            detect_language_prompt = DETECT_LANGUAGE_PROMPT.format(
+                requirement=self.planner.plan.goal,
+                default_language=default_language,
+            )
             self.respond_language = await self.llm.aask(detect_language_prompt)
+            if default_language == "Persian" and self.respond_language.strip().lower() in ("english", ""):
+                self.respond_language = "Persian"
         ### 1. Experience ###
         example = self._retrieve_experience()
 

--- a/metagpt/software_company.py
+++ b/metagpt/software_company.py
@@ -2,11 +2,15 @@
 # -*- coding: utf-8 -*-
 
 import asyncio
+import os
 from pathlib import Path
 
 import typer
 
 from metagpt.const import CONFIG_ROOT
+from metagpt.locale import init_locale, set_language, t
+
+init_locale()
 
 app = typer.Typer(add_completion=False, pretty_exceptions_show_locals=False)
 
@@ -24,6 +28,7 @@ def generate_repo(
     reqa_file="",
     max_auto_summarize_code=0,
     recover_path=None,
+    language=None,
 ):
     """Run the startup logic. Can be called from CLI or other Python scripts."""
     from metagpt.config2 import config
@@ -37,8 +42,14 @@ def generate_repo(
     )
     from metagpt.team import Team
 
+    if language:
+        config.language = set_language(language)
+    else:
+        init_locale(config.language)
+
     config.update_via_cli(project_path, project_name, inc, reqa_file, max_auto_summarize_code)
     ctx = Context(config=config)
+    ctx.kwargs.set("language", config.language)
 
     if not recover_path:
         company = Team(context=ctx)
@@ -74,38 +85,36 @@ def generate_repo(
     return ctx.kwargs.get("project_path")
 
 
-@app.command("", help="Start a new project.")
+@app.command("", help=t("cli_startup_help"))
 def startup(
-    idea: str = typer.Argument(None, help="Your innovative idea, such as 'Create a 2048 game.'"),
-    investment: float = typer.Option(default=3.0, help="Dollar amount to invest in the AI company."),
-    n_round: int = typer.Option(default=5, help="Number of rounds for the simulation."),
-    code_review: bool = typer.Option(default=True, help="Whether to use code review."),
-    run_tests: bool = typer.Option(default=False, help="Whether to enable QA for adding & running tests."),
-    implement: bool = typer.Option(default=True, help="Enable or disable code implementation."),
-    project_name: str = typer.Option(default="", help="Unique project name, such as 'game_2048'."),
-    inc: bool = typer.Option(default=False, help="Incremental mode. Use it to coop with existing repo."),
-    project_path: str = typer.Option(
-        default="",
-        help="Specify the directory path of the old version project to fulfill the incremental requirements.",
+    idea: str = typer.Argument(None, help=t("cli_idea_help")),
+    investment: float = typer.Option(default=3.0, help=t("cli_investment_help")),
+    n_round: int = typer.Option(default=5, help=t("cli_n_round_help")),
+    code_review: bool = typer.Option(default=True, help=t("cli_code_review_help")),
+    run_tests: bool = typer.Option(default=False, help=t("cli_run_tests_help")),
+    implement: bool = typer.Option(default=True, help=t("cli_implement_help")),
+    project_name: str = typer.Option(default="", help=t("cli_project_name_help")),
+    inc: bool = typer.Option(default=False, help=t("cli_inc_help")),
+    project_path: str = typer.Option(default="", help=t("cli_project_path_help")),
+    reqa_file: str = typer.Option(default="", help=t("cli_reqa_file_help")),
+    max_auto_summarize_code: int = typer.Option(default=0, help=t("cli_max_auto_summarize_help")),
+    recover_path: str = typer.Option(default=None, help=t("cli_recover_path_help")),
+    init_config: bool = typer.Option(default=False, help=t("cli_init_config_help")),
+    language: str = typer.Option(
+        default=os.environ.get("METAGPT_LANG", ""),
+        help=t("cli_language_help"),
     ),
-    reqa_file: str = typer.Option(
-        default="", help="Specify the source file name for rewriting the quality assurance code."
-    ),
-    max_auto_summarize_code: int = typer.Option(
-        default=0,
-        help="The maximum number of times the 'SummarizeCode' action is automatically invoked, with -1 indicating "
-        "unlimited. This parameter is used for debugging the workflow.",
-    ),
-    recover_path: str = typer.Option(default=None, help="recover the project from existing serialized storage"),
-    init_config: bool = typer.Option(default=False, help="Initialize the configuration file for MetaGPT."),
 ):
     """Run a startup. Be a boss."""
+    if language:
+        set_language(language)
+
     if init_config:
         copy_config_to()
         return
 
     if idea is None:
-        typer.echo("Missing argument 'IDEA'. Run 'metagpt --help' for more information.")
+        typer.echo(t("missing_idea"))
         raise typer.Exit()
 
     return generate_repo(
@@ -121,12 +130,15 @@ def startup(
         reqa_file,
         max_auto_summarize_code,
         recover_path,
+        language=language or None,
     )
 
 
 DEFAULT_CONFIG = """# Full Example: https://github.com/geekan/MetaGPT/blob/main/config/config2.example.yaml
 # Reflected Code: https://github.com/geekan/MetaGPT/blob/main/metagpt/config2.py
 # Config Docs: https://docs.deepwisdom.ai/main/en/guide/get_started/configuration.html
+language: "English"  # English | Persian | Chinese | French | Japanese
+
 llm:
   api_type: "openai"  # or azure / ollama / groq etc.
   model: "gpt-4-turbo"  # or gpt-3.5-turbo
@@ -146,11 +158,11 @@ def copy_config_to():
     if target_path.exists():
         backup_path = target_path.with_suffix(".bak")
         target_path.rename(backup_path)
-        print(f"Existing configuration file backed up at {backup_path}")
+        print(t("config_backed_up", path=backup_path))
 
     # 复制文件
     target_path.write_text(DEFAULT_CONFIG, encoding="utf-8")
-    print(f"Configuration file initialized at {target_path}")
+    print(t("config_initialized", path=target_path))
 
 
 if __name__ == "__main__":

--- a/metagpt/utils/human_interaction.py
+++ b/metagpt/utils/human_interaction.py
@@ -7,6 +7,7 @@ from typing import Any, Tuple, Type
 
 from pydantic import BaseModel
 
+from metagpt.locale import init_locale, t
 from metagpt.logs import logger
 from metagpt.utils.common import import_class
 
@@ -14,8 +15,11 @@ from metagpt.utils.common import import_class
 class HumanInteraction(object):
     stop_list = ("q", "quit", "exit")
 
+    def __init__(self):
+        init_locale()
+
     def multilines_input(self, prompt: str = "Enter: ") -> str:
-        logger.warning("Enter your content, use Ctrl-D or Ctrl-Z ( windows ) to save it.")
+        logger.warning(t("multilines_input_hint"))
         logger.info(f"{prompt}\n")
         lines = []
         while True:
@@ -54,12 +58,12 @@ class HumanInteraction(object):
             if check_ret:
                 break
             else:
-                logger.error(f"Input content can't meet required_type: {req_type}, please Re-Enter.")
+                logger.error(t("input_type_error", req_type=req_type))
         return structure_content
 
     def input_num_until_valid(self, num_max: int) -> int:
         while True:
-            input_num = input("Enter the num of the interaction key: ")
+            input_num = input(t("input_num_prompt"))
             input_num = input_num.strip()
             if input_num in self.stop_list:
                 return input_num
@@ -78,27 +82,30 @@ class HumanInteraction(object):
         instruct_content_dict = instruct_content.model_dump()
         num_fields_map = dict(zip(range(0, len(instruct_content_dict)), instruct_content_dict.keys()))
         logger.info(
-            f"\n{interact_type.upper()} interaction\n"
-            f"Interaction data: {num_fields_map}\n"
-            f"Enter the num to interact with corresponding field or `q`/`quit`/`exit` to stop interaction.\n"
-            f"Enter the field content until it meet field required type.\n"
+            t(
+                "interact_header",
+                interact_type=interact_type.upper(),
+                fields=num_fields_map,
+            )
         )
 
         interact_contents = {}
         while True:
             input_num = self.input_num_until_valid(len(instruct_content_dict))
             if input_num in self.stop_list:
-                logger.warning("Stop human interaction")
+                logger.warning(t("interact_stop"))
                 break
 
             field = num_fields_map.get(input_num)
-            logger.info(f"You choose to interact with field: {field}, and do a `{interact_type}` operation.")
+            logger.info(
+                t("interact_field", field=field, interact_type=interact_type)
+            )
 
             if interact_type == "review":
-                prompt = "Enter your review comment: "
+                prompt = t("review_prompt")
                 req_type = str
             else:
-                prompt = "Enter your revise content: "
+                prompt = t("revise_prompt")
                 req_type = mapping.get(field)[0]  # revise need input content match the required_type
 
             field_content = self.input_until_valid(prompt=prompt, req_type=req_type)

--- a/tests/metagpt/test_locale.py
+++ b/tests/metagpt/test_locale.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from metagpt.locale import init_locale, set_language, t
+from metagpt.locale.messages import normalize_language
+
+
+def test_normalize_language_persian_aliases():
+    for alias in ("fa", "fa-IR", "Persian", "Farsi", "فارسی"):
+        assert normalize_language(alias) == "Persian"
+
+
+def test_normalize_language_english():
+    assert normalize_language("English") == "English"
+    assert normalize_language("en") == "English"
+
+
+def test_persian_cli_messages():
+    set_language("fa")
+    assert "IDEA" in t("missing_idea")
+    assert "پیکربندی" in t("config_initialized", path="/tmp/x")
+
+
+def test_init_locale_from_env(monkeypatch):
+    monkeypatch.setenv("METAGPT_LANG", "fa")
+    assert init_locale() == "Persian"


### PR DESCRIPTION
**Features**

- Add lightweight `metagpt/locale/` module for CLI and human-interaction strings
- Add `--language fa` CLI flag and `METAGPT_LANG` env var support
- Document `language` field in `config/config2.example.yaml`
- Improve RoleZero language detection for Persian/Farsi/فارسی with config fallback
- Add Persian example in requirement analysis prompts
- Add unit tests for locale normalization (`tests/metagpt/test_locale.py`)

**Feature Docs**

- See companion docs PR for Persian README and install guide

**Influence**

- Default language remains English; Persian is opt-in via config/CLI/env
- No gettext/Babel — consistent with existing MetaGPT i18n approach
- Part 2 of 2 for Persian localization (see issue #2113)

**Result**

- `tests/metagpt/test_locale.py` covers Persian alias normalization and message lookup

Refs FoundationAgents/MetaGPT#2113

**Other**

- Complements docs PR (README_FA + install guide)
- Can be reviewed/merged independently after docs PR
