### PR TITLE
docs: document Minecraft code execution boundary

### DIFF
--- a/metagpt/environment/minecraft/README.md
+++ b/metagpt/environment/minecraft/README.md
@@ -1,0 +1,14 @@
+# Minecraft Environment
+
+## Code execution boundary
+
+The Mineflayer runner executes the generated `programs` and `code` with `eval()`
+inside the Mineflayer Node.js process. This code has the same filesystem,
+network, environment-variable, and process privileges as that process; it is
+not executed in a separate sandbox.
+
+Run the Minecraft environment only in an isolated, disposable environment,
+and do not expose its execution endpoint to untrusted callers. Review or
+constrain generated code before execution when the model input or skill source
+is not fully trusted. See the execution path in
+[`mineflayer/index.js`](mineflayer/index.js).


### PR DESCRIPTION
**Features**

- Add a Minecraft environment README that documents where generated `programs` and `code` execute.
- Clarify that the Mineflayer runner does not provide a separate sandbox and recommend an isolated, disposable environment for untrusted model input or skills.
- Link the note to the existing `eval()` execution path in `mineflayer/index.js`.

**Feature Docs**

Documentation-only clarification of the existing Minecraft/Voyager execution boundary.

**Influence**

This makes the security assumptions visible to users before they run model-generated JavaScript with the Mineflayer process's filesystem, network, environment, and process privileges. Runtime behavior is unchanged.

**Result**

- `git diff --check` passes.
- The relative link to `mineflayer/index.js` resolves in the repository.
- The README is UTF-8 without a BOM and ends with a newline.
- Repository pre-commit hooks target Python files; no runtime tests are required for this documentation-only change.

**Other**

Closes #2091.