### PR TITLE
feat(provider): add MiniMax as a first-class LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,28 @@ You can configure `~/.metagpt/config2.yaml` according to the [example](https://g
 
 ```yaml
 llm:
-  api_type: "openai"  # or azure / ollama / groq etc. Check LLMType for more options
+  api_type: "openai"  # or azure / ollama / minimax etc. Check LLMType for more options
   model: "gpt-4-turbo"  # or gpt-3.5-turbo
   base_url: "https://api.openai.com/v1"  # or forward url / other llm url
   api_key: "YOUR_API_KEY"
 ```
+
+<details>
+<summary>Example: Using MiniMax</summary>
+
+MiniMax exposes an OpenAI-compatible Chat Completions API. Two regional endpoints are available; pick the one for your account:
+
+```yaml
+llm:
+  api_type: "minimax"
+  model: "MiniMax-M3"  # or MiniMax-M2.7
+  base_url: "https://api.minimax.io/v1"  # global endpoint
+  # base_url: "https://api.minimaxi.com/v1"  # China endpoint
+  api_key: "YOUR_API_KEY"
+  temperature: 0.5  # MiniMax requires temperature in (0.0, 1.0]
+```
+
+</details>
 
 ### Usage
 

--- a/config/config2.example.yaml
+++ b/config/config2.example.yaml
@@ -119,6 +119,12 @@ models:
 #    # timeout: 600 # Optional. If set to 0, default value is 300.
 #    # Details: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
 #    pricing_plan: "" # Optional. Use for Azure LLM when its model name is not the same as OpenAI's
+#  "MiniMax-M3":  # MiniMax (OpenAI-compatible). Docs: https://platform.minimax.io/docs
+#    api_type: "minimax"
+#    model: "MiniMax-M3"  # or MiniMax-M2.7
+#    base_url: "https://api.minimax.io/v1"  # global endpoint; use https://api.minimaxi.com/v1 for China
+#    api_key: "YOUR_API_KEY"
+#    temperature: 0.5  # MiniMax requires temperature in (0.0, 1.0]
 #  "YOUR_MODEL_NAME_2 or YOUR_API_TYPE_2": # api_type: "openai"  # or azure / ollama / groq etc.
 #    api_type: "openai"  # or azure / ollama / groq etc.
 #    base_url: "YOUR_BASE_URL"
@@ -127,3 +133,9 @@ models:
 #    # timeout: 600 # Optional. If set to 0, default value is 300.
 #    # Details: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
 #    pricing_plan: "" # Optional. Use for Azure LLM when its model name is not the same as OpenAI's
+#  "MiniMax-M3":  # MiniMax (OpenAI-compatible). Docs: https://platform.minimax.io/docs
+#    api_type: "minimax"
+#    model: "MiniMax-M3"  # or MiniMax-M2.7
+#    base_url: "https://api.minimax.io/v1"  # global endpoint; use https://api.minimaxi.com/v1 for China
+#    api_key: "YOUR_API_KEY"
+#    temperature: 0.5  # MiniMax requires temperature in (0.0, 1.0]

--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -44,6 +44,7 @@ class LLMType(Enum):
     BEDROCK = "bedrock"
     ARK = "ark"  # https://www.volcengine.com/docs/82379/1263482#python-sdk
     LLAMA_API = "llama_api"
+    MINIMAX = "minimax"  # https://platform.minimax.io/docs
 
     def __missing__(self, key):
         return self.OPENAI

--- a/metagpt/provider/__init__.py
+++ b/metagpt/provider/__init__.py
@@ -20,6 +20,7 @@ from metagpt.provider.anthropic_api import AnthropicLLM
 from metagpt.provider.bedrock_api import BedrockLLM
 from metagpt.provider.ark_api import ArkLLM
 from metagpt.provider.openrouter_reasoning import OpenrouterReasoningLLM
+from metagpt.provider.minimax_api import MiniMaxLLM
 
 __all__ = [
     "GeminiLLM",
@@ -36,4 +37,5 @@ __all__ = [
     "BedrockLLM",
     "ArkLLM",
     "OpenrouterReasoningLLM",
+    "MiniMaxLLM",
 ]

--- a/metagpt/provider/minimax_api.py
+++ b/metagpt/provider/minimax_api.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Provider for MiniMax.
+MiniMax exposes an OpenAI-compatible Chat Completions API, so this provider
+subclasses ``OpenAILLM`` and only customizes the request constraints that MiniMax
+requires (temperature must be in (0.0, 1.0]).
+
+Two regional endpoints are supported by setting ``base_url`` accordingly:
+  - global (default): https://api.minimax.io/v1
+  - China:           https://api.minimaxi.com/v1
+
+config2.yaml example:
+```yaml
+llm:
+  api_type: "minimax"
+  model: "MiniMax-M3"  # or MiniMax-M2.7
+  base_url: "https://api.minimax.io/v1"  # global endpoint; use https://api.minimaxi.com/v1 for China
+  api_key: "YOUR_API_KEY"
+  temperature: 0.5  # MiniMax requires temperature in (0.0, 1.0]
+```
+"""
+
+from __future__ import annotations
+
+from metagpt.configs.llm_config import LLMType
+from metagpt.const import USE_CONFIG_TIMEOUT
+from metagpt.provider.llm_provider_registry import register_provider
+from metagpt.provider.openai_api import OpenAILLM
+
+# MiniMax requires the sampling temperature to be strictly greater than 0 and at most 1.
+MINIMAX_MIN_TEMPERATURE = 0.01
+MINIMAX_MAX_TEMPERATURE = 1.0
+
+
+@register_provider(LLMType.MINIMAX)
+class MiniMaxLLM(OpenAILLM):
+    """OpenAI-compatible provider for the MiniMax Chat Completions API.
+
+    MiniMax accepts the standard OpenAI Chat Completions request shape. The only
+    constraint that needs enforcing here is ``temperature``, which must be in the
+    open-closed range (0.0, 1.0]; a non-positive temperature is rejected by the API,
+    so it is bumped up to ``MINIMAX_MIN_TEMPERATURE``.
+    """
+
+    def _cons_kwargs(self, messages: list[dict], timeout=USE_CONFIG_TIMEOUT, **extra_kwargs) -> dict:
+        kwargs = super()._cons_kwargs(messages, timeout=timeout, **extra_kwargs)
+        # MiniMax rejects temperature <= 0; clamp to the valid range (0.0, 1.0].
+        temperature = kwargs.get("temperature")
+        if temperature is None or temperature <= 0:
+            kwargs["temperature"] = MINIMAX_MIN_TEMPERATURE
+        elif temperature > MINIMAX_MAX_TEMPERATURE:
+            kwargs["temperature"] = MINIMAX_MAX_TEMPERATURE
+        return kwargs

--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -117,6 +117,8 @@ TOKEN_COSTS = {
     "llama-4-Maverick-17B-128E-Instruct-FP8": {"prompt": 0.0, "completion": 0.0},
     "llama-3.3-8B-Instruct": {"prompt": 0.0, "completion": 0.0},
     "llama-3.3-70B-Instruct": {"prompt": 0.0, "completion": 0.0},  # end, for Llama API
+    "MiniMax-M3": {"prompt": 0.0006, "completion": 0.0024},  # start, for MiniMax
+    "MiniMax-M2.7": {"prompt": 0.0003, "completion": 0.0012},  # end, for MiniMax
 }
 
 
@@ -350,6 +352,8 @@ TOKEN_MAX = {
     "qwen-7b-chat": 32000,
     "qwen-1.8b-longcontext-chat": 32000,
     "qwen-1.8b-chat": 8000,
+    "MiniMax-M3": 1000000,  # start, for MiniMax
+    "MiniMax-M2.7": 204800,  # end, for MiniMax
 }
 
 # For Amazon Bedrock US region

--- a/tests/metagpt/provider/mock_llm_config.py
+++ b/tests/metagpt/provider/mock_llm_config.py
@@ -72,3 +72,7 @@ mock_llm_config_bedrock = LLMConfig(
 )
 
 mock_llm_config_ark = LLMConfig(api_type="ark", api_key="eyxxx", base_url="xxx", model="ep-xxx")
+
+mock_llm_config_minimax = LLMConfig(
+    api_type="minimax", api_key="xxx", base_url="https://api.minimax.io/v1", model="MiniMax-M3"
+)

--- a/tests/metagpt/provider/test_minimax_api.py
+++ b/tests/metagpt/provider/test_minimax_api.py
@@ -1,0 +1,93 @@
+"""
+Test cases for the MiniMax provider.
+MiniMax exposes an OpenAI-compatible Chat Completions API.
+API docs: https://platform.minimax.io/docs
+"""
+
+from typing import AsyncIterator, List, Union
+
+import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
+from openai.types.chat.chat_completion_chunk import Choice, ChoiceDelta
+
+from metagpt.provider.minimax_api import MINIMAX_MAX_TEMPERATURE, MINIMAX_MIN_TEMPERATURE, MiniMaxLLM
+from tests.metagpt.provider.mock_llm_config import mock_llm_config_minimax
+from tests.metagpt.provider.req_resp_const import (
+    get_openai_chat_completion,
+    llm_general_chat_funcs_test,
+    messages,
+    prompt,
+    resp_cont_tmpl,
+)
+
+name = "AI assistant"
+resp_cont = resp_cont_tmpl.format(name=name)
+USAGE = {"completion_tokens": 1000, "prompt_tokens": 1000, "total_tokens": 2000}
+default_resp = get_openai_chat_completion(name)
+default_resp.model = "MiniMax-M3"
+default_resp.usage = USAGE
+
+
+def create_chat_completion_chunk(
+    content: str, finish_reason: str = None, choices: List[Choice] = None
+) -> ChatCompletionChunk:
+    if choices is None:
+        choices = [
+            Choice(
+                delta=ChoiceDelta(content=content, function_call=None, role="assistant", tool_calls=None),
+                finish_reason=finish_reason,
+                index=0,
+                logprobs=None,
+            )
+        ]
+
+    return ChatCompletionChunk(
+        id="012",
+        choices=choices,
+        created=1716278586,
+        model="MiniMax-M3",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        usage=None if choices else USAGE,
+    )
+
+
+minimax_resp_chunk = create_chat_completion_chunk(content="")
+minimax_resp_chunk_finish = create_chat_completion_chunk(content=resp_cont, finish_reason="stop")
+minimax_resp_chunk_last = create_chat_completion_chunk(content="", choices=[])
+
+
+async def chunk_iterator(chunks: List[ChatCompletionChunk]) -> AsyncIterator[ChatCompletionChunk]:
+    for chunk in chunks:
+        yield chunk
+
+
+async def mock_minimax_acompletions_create(
+    self, stream: bool = False, **kwargs
+) -> Union[ChatCompletionChunk, ChatCompletion]:
+    if stream:
+        chunks = [minimax_resp_chunk, minimax_resp_chunk_finish, minimax_resp_chunk_last]
+        return chunk_iterator(chunks)
+    else:
+        return default_resp
+
+
+@pytest.mark.asyncio
+async def test_minimax_acompletion(mocker):
+    mocker.patch("openai.resources.chat.completions.AsyncCompletions.create", mock_minimax_acompletions_create)
+
+    llm = MiniMaxLLM(mock_llm_config_minimax)
+
+    resp = await llm.acompletion(messages)
+    assert resp.choices[0].finish_reason == "stop"
+    assert resp.choices[0].message.content == resp_cont
+    assert resp.usage == USAGE
+
+    await llm_general_chat_funcs_test(llm, prompt, messages, resp_cont)
+
+
+def test_minimax_temperature_constraint():
+    llm = MiniMaxLLM(mock_llm_config_minimax)
+    kwargs = llm._cons_kwargs(messages)
+    # temperature must be in (0.0, 1.0]
+    assert MINIMAX_MIN_TEMPERATURE <= kwargs["temperature"] <= MINIMAX_MAX_TEMPERATURE


### PR DESCRIPTION
Reason: Add MiniMax as a first-class LLM provider with current model, context, and pricing metadata, plus documented global and China endpoints.

## Changes

- **New provider enum**: add `MINIMAX` to `LLMType` (`metagpt/configs/llm_config.py`).
- **New provider class**: add `MiniMaxLLM` in `metagpt/provider/minimax_api.py`. It subclasses `OpenAILLM` (MiniMax exposes an OpenAI-compatible Chat Completions API) and registers itself for `LLMType.MINIMAX`. It enforces the MiniMax sampling-temperature constraint `(0.0, 1.0]` on every request.
- **Provider export**: export `MiniMaxLLM` from `metagpt/provider/__init__.py`.
- **Pricing metadata**: add `MiniMax-M3` (input $0.6/M, output $2.4/M) and `MiniMax-M2.7` (input $0.3/M, output $1.2/M) to `TOKEN_COSTS` in `metagpt/utils/token_counter.py`.
- **Context windows**: add `MiniMax-M3` (1,000,000) and `MiniMax-M2.7` (204,800) to `TOKEN_MAX` in `metagpt/utils/token_counter.py`.
- **Configuration docs**: document both the global endpoint (`https://api.minimax.io/v1`) and the China endpoint (`https://api.minimaxi.com/v1`) in `README.md` and `config/config2.example.yaml`.
- **Test**: add `tests/metagpt/provider/test_minimax_api.py` covering chat completion, streaming, and the temperature constraint.

The regional endpoint is selected by setting `base_url` in the user's `config2.yaml`; the provider respects whatever `base_url` is configured, so both regions work without code changes.

## Checks

- `ruff check` on changed files: all checks passed.
- `ruff format --check` on the new provider file: passed.
- `pytest tests/metagpt/provider/test_minimax_api.py` (with mocked OpenAI completions): 2 passed.
