### PR TITLE
docs: fix --code_review flag typo in usage tutorials (--code_review -> --code-review)

### DIFF
--- a/docs/tutorial/usage.md
+++ b/docs/tutorial/usage.md
@@ -18,7 +18,7 @@ metagpt "Write a cli snake game"
 # Do not hire an engineer to implement the project
 metagpt "Write a cli snake game" --no-implement
 # Hire an engineer and perform code reviews
-metagpt "Write a cli snake game" --code_review
+metagpt "Write a cli snake game" --code-review
 ```
 
 After running the script, you can find your new project in the `workspace/` directory.

--- a/docs/tutorial/usage_cn.md
+++ b/docs/tutorial/usage_cn.md
@@ -15,7 +15,7 @@ cp config/config2.yaml ~/.metagpt/config2.yaml
 ```shell
 metagpt "写一个命令行贪吃蛇"
 # 开启code review模式会花费更多的金钱, 但是会提升代码质量和成功率
-metagpt "写一个命令行贪吃蛇" --code_review
+metagpt "写一个命令行贪吃蛇" --code-review
 ```
 
 运行脚本后，您可以在 `workspace/` 目录中找到您的新项目。


### PR DESCRIPTION
The startup CLI example in the usage tutorials passes `--code_review` (underscore):

```
metagpt "Write a cli snake game" --code_review
```

But the option is registered as `--code-review`. It comes from the `code_review` parameter in `metagpt/software_company.py` (`code_review: bool = typer.Option(default=True, ...)`), and Typer maps `code_review` to the option string `--code-review`. Click does exact long-option matching, so `--code_review` fails with `Error: No such option: --code_review`.

The auto-generated `--help` output shown further down in the *same* docs already lists the correct `--code-review` / `--no-code-review`, and the neighboring `--no-implement` example uses a hyphen too — only this line is wrong.

Fixes both `docs/tutorial/usage.md` and `docs/tutorial/usage_cn.md`. Docs-only, no functional change.
